### PR TITLE
ci: shellcheck + resolver/build.py compile gate; finalise v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run shellcheck on every shell script
+        uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: --severity=warning
+        with:
+          scandir: ./scripts
+
+  resolver-build:
+    name: resolver/build.py
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile-check resolver/build.py
+        run: python -m py_compile resolver/build.py
+
+      - name: Verify the no-stations.json error path
+        # `build.py` should exit non-zero with a helpful message when run
+        # without a stations.json. This protects the contract documented
+        # in resolver/README.md and docs/installation.md.
+        run: |
+          set +e
+          cd resolver
+          python build.py >out.txt 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "BUG: build.py succeeded without stations.json"
+            cat out.txt
+            exit 1
+          fi
+          grep -q "stations.json doesn't exist" out.txt || {
+            echo "BUG: missing-stations.json error message changed"
+            cat out.txt
+            exit 1
+          }
+          echo "OK — build.py errors as documented when stations.json is missing"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ IDEAS.md
 *.bak-*
 .claude/
 
+# Claude Design handoff bundle for the admin UI — kept locally next to
+# admin/PLAN.md as a styling reference, never committed.
+admin/design-mockup/
+
 # --- Editor / OS junk ------------------------------------------------
 
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.1.0] - 2026-05-09
+
 ### Added
 - Initial public release.
 - On-speaker static-file resolver (`resolver/`), including:
@@ -16,8 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `shepherd-resolver.xml` — daemon config so busybox `httpd` auto-starts
     at boot.
 - Documentation (`docs/`) covering compatibility, opening up the speaker,
-  installation, preset customisation, troubleshooting, architecture, and
-  the speaker's local API.
-- Helper scripts (`scripts/`) for USB-stick prep, deployment, and
-  post-install verification.
+  installation, preset customisation, troubleshooting, architecture,
+  the speaker's local API, and TuneIn's OPML API as used by `build.py`.
+- Helper scripts (`scripts/`) for USB-stick prep, deployment,
+  post-install verification, stream refresh, preset assignment,
+  uninstall, and SSH wrapper.
 - Design plan for a browser-based admin UI (`admin/PLAN.md`).
+- CI: GitHub Actions workflow running shellcheck on `scripts/` and a
+  Python compile + error-path check on `resolver/build.py`.
+
+[v0.1.0]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.1.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,7 +56,7 @@ $SSH root@"$SPEAKER" 'true' \
 say "Building station files (TuneIn → Bose JSON)"
 ( cd "$ROOT/resolver" && rm -f s* 2>/dev/null; python3 build.py )
 
-STATION_COUNT=$(ls "$ROOT/resolver/" 2>/dev/null | grep -c '^s[0-9]' || true)
+STATION_COUNT=$(find "$ROOT/resolver" -maxdepth 1 -type f -name 's[0-9]*' 2>/dev/null | wc -l | tr -d ' ')
 [ "$STATION_COUNT" -gt 0 ] \
   || fail "build.py produced no station files. See above for errors."
 echo "Built $STATION_COUNT station file(s)."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with two jobs:
  - `shellcheck` — runs against every script in `scripts/` at warning severity
  - `resolver-build.py` — compile-checks `resolver/build.py` and asserts that running it without a `stations.json` errors with the documented message
- Finalises `CHANGELOG.md`: moves the [Unreleased] entries to a dated `[v0.1.0] - 2026-05-09` section and opens a fresh empty `[Unreleased]` block

## Why

This is the v0.1.0 release PR. After merge, tag the merged commit as `v0.1.0` and create a GitHub release pointing at it. The CI gate gives every subsequent PR a green/red signal, and the changelog entry preserves the release notes.

## Test plan

- [x] `python -m py_compile resolver/build.py` passes locally
- [x] `python build.py` without `stations.json` exits non-zero with the documented "stations.json doesn't exist" message
- [ ] CI green on this PR (shellcheck + python jobs)
- [ ] After merge, tag `v0.1.0` and publish a GitHub release tied to the tag

## Notes

The CI workflow grants `permissions: contents: read` only — it has no write access to the repo. shellcheck is pinned at `ludeeus/action-shellcheck@2.0.0`.