### PR TITLE
plan, docs: WS spike resolved — gabbo subprotocol is mandatory

### DIFF
--- a/admin/PLAN.md
+++ b/admin/PLAN.md
@@ -368,68 +368,100 @@ equivalent of `python3 build.py` from a laptop.
 
 ## Live updates — WebSocket (0.3)
 
-### Pre-spike — do this before 0.2 starts
+### Pre-spike — VERIFIED 2026-05-10
 
-The plan assumes `ws://<speaker>:8080/` accepts browser-origin
-connections. **This is not yet verified.** From any LAN browser dev
-console:
+Spike done against firmware `trunk r46330 v4 epdbuild hepdswbld04`.
+**WebSocket works, but only when the client negotiates the `gabbo`
+subprotocol on the handshake.** Without it, the connection succeeds
+and the speaker emits its `<SoundTouchSdkInfo>` hello frame, but no
+state-change events flow afterwards — which is what the original
+`docs/api-reference.md` got wrong with its "subscribe once, receive
+forever" claim. (`docs/api-reference.md` has been corrected.)
 
-```js
-new WebSocket('ws://<speaker>:8080/').addEventListener(
-  'message', e => console.log(e.data));
+```bash
+# Reproduce:
+wscat -s gabbo -c ws://<speaker-ip>:8080/
 ```
 
-If frames arrive while you fiddle with the speaker, ship 0.3 as
-designed. If the connection closes immediately, try
-`wscat -c ws://<speaker>:8080/ -H 'Origin: http://<speaker>:8080'`
-to see whether an Origin tweak unblocks it.
-
-### Kill criterion
-
-If browser→WS doesn't work and no Origin header tweak fixes it:
-**drop WS-dependent features from 0.3 entirely.** Don't build a
-separate WS-proxy daemon — busybox httpd doesn't proxy WS, and a new
-Python/Lua daemon is more moving parts than the value justifies for a
-remote that's already 90% useful with REST polling.
-
-Dropped features in this case: "pressed on speaker" toasts, the live
-VU dot, the connection-state pill's "live" mode.
-
-REST polling becomes primary instead of fallback: poll
-`/cgi-bin/api/v1/speaker/now_playing` every 2s while the now-playing
-tab is visible, plus on-demand on user actions.
-
-### If the spike succeeds
-
-The SPA opens a connection on load:
-
 ```js
-// app/ws.js
-const ws = new WebSocket(`ws://${location.hostname}:8080/`);
-ws.addEventListener('message', e => handleSpeakerEvent(e.data));
+// In the SPA:
+const ws = new WebSocket(`ws://${location.hostname}:8080/`, 'gabbo');
 ```
 
-Events handled:
+The `gabbo` magic string is the same one already required as the
+`<key sender="Gabbo">` value (Bose's internal SDK uses it in both
+contexts). Confirmed in two open-source clients:
+[CharlesBlonde/libsoundtouch](https://github.com/CharlesBlonde/libsoundtouch/blob/master/libsoundtouch/device.py)
+and
+[thlucas1/bosesoundtouchapi](https://github.com/thlucas1/bosesoundtouchapi/blob/main/bosesoundtouchapi/ws/soundtouchwebsocket.py).
 
-| Event                          | State update                  |
-| ------------------------------ | ----------------------------- |
-| `<volumeUpdated>`              | `state.speaker.volume`        |
-| `<bassUpdated>`                | `state.speaker.bass` (0.4)    |
-| `<balanceUpdated>`             | `state.speaker.balance` (0.4) |
-| `<nowPlayingUpdated>`          | `state.speaker.nowPlaying`    |
-| `<sourcesUpdated>`             | `state.speaker.sources`       |
-| `<presetsUpdated>`             | `state.speaker.presets` + toast "Presets changed" |
-| `<keyEvent>`                   | toast "Preset N pressed on speaker" |
-| `<connectionStateUpdated>`     | `state.ws` plus header pill   |
-| `<zoneUpdated>` (0.4)          | `state.speaker.zone`          |
-| `<recentsUpdated>` (0.4)       | `state.speaker.recents`       |
+### Event envelope
+
+Events arrive wrapped in `<updates deviceID="…">…</updates>`. The
+inner element is the actual event. `app/ws.js`'s parser must unwrap
+before dispatching:
+
+```js
+function handleSpeakerEvent(xmlText) {
+  const doc  = new DOMParser().parseFromString(xmlText, 'application/xml');
+  const root = doc.documentElement;
+  if (root.tagName === 'updates') {
+    for (const inner of root.children) dispatchEvent(inner);
+  } else {
+    dispatchEvent(root);   // <userActivityUpdate/>, <SoundTouchSdkInfo/> are unwrapped
+  }
+}
+```
+
+### Events handled
+
+| Event (inside `<updates>` unless noted) | State update                                                       |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| `<volumeUpdated>`                       | `state.speaker.volume`                                             |
+| `<bassUpdated>` (0.4)                   | `state.speaker.bass`                                               |
+| `<balanceUpdated>` (0.4)                | `state.speaker.balance`                                            |
+| `<nowPlayingUpdated>`                   | `state.speaker.nowPlaying` (incl. STANDBY transitions)             |
+| `<nowSelectionUpdated>`                 | "Preset N selected" toast + reconcile `state.speaker.presets`       |
+| `<sourcesUpdated>`                      | `state.speaker.sources`                                            |
+| `<presetsUpdated>`                      | `state.speaker.presets` + toast "Presets changed"                  |
+| `<keyEvent>`                            | toast "Preset N pressed on speaker" — see note below               |
+| `<connectionStateUpdated>`              | `state.ws` plus header pill                                        |
+| `<zoneUpdated>` (0.4)                   | `state.speaker.zone`                                               |
+| `<recentsUpdated>` (0.4)                | `state.speaker.recents`                                            |
+| `<userActivityUpdate />` (unwrapped)    | Optional: feed a "user is active" timer for screen-wake heuristics |
+| `<SoundTouchSdkInfo>` (unwrapped)       | Set `state.ws.connected = true` — readiness signal (stronger than TCP-open) |
+
+`<userActivityUpdate />` and `<SoundTouchSdkInfo>` arrive **outside**
+the `<updates>` envelope. Treat them as top-level cases in the parser.
+
+**Note on `<keyEvent>`:** the spike observed `<nowSelectionUpdated>`
+on physical preset-button presses but no `<keyEvent>`. `<keyEvent>`
+may fire only for some keys, or only on hardware-button press without
+release. Investigate during 0.3 build; if it doesn't fire reliably,
+source the "pressed on speaker" toast from `<nowSelectionUpdated>`
+(preset) + `<volumeUpdated>` (volume) — those *do* fire reliably.
+
+### Reconnect + fallback
 
 Reconnect with exponential backoff capped at 30s. If WS drops, the
-SPA falls back to REST polling at 2s while a tab is visible.
+SPA falls back to REST polling at 2s while a tab is visible. Re-fetch
+full state on reconnect (the speaker doesn't replay missed events).
 
-A minimal `admin/ws-test.html` (~20 lines) ships with 0.2's deploy as
-a diagnostic page — open in any browser to check WS health on a given
-speaker, or to debug after a firmware-update incident.
+A minimal `admin/ws-test.html` (~20 lines, must use the `gabbo`
+subprotocol) ships with 0.2's deploy as a diagnostic page — open in
+any browser to check WS health on a given speaker, or to debug after
+a firmware-update incident.
+
+### Kill criterion (kept as a contingency)
+
+If a future firmware update breaks the gabbo subprotocol or any
+similar protocol-level regression makes events stop flowing, apply
+the kill criterion: **drop WS-dependent features.** Don't build a
+WS-proxy daemon. REST polling becomes primary; "pressed on speaker"
+toasts and the live VU dot are cut. The plan was originally drafted
+with this contingency for the case where the spike failed; the spike
+passed, but the criterion remains useful documentation if the
+firmware ever changes.
 
 ## View specs
 
@@ -709,20 +741,25 @@ A `mock-speaker.py` for offline iteration is **out of scope** for
 | Release | Includes | Days |
 | ------- | -------- | ---- |
 | **0.2** | Hash router, state.js, dom.js, api client, tunein forwarder CGI, presets CGI, speaker GET-only proxy, fixtures + CI tests, browse/search/station views, thin polled now-playing header, deploy.sh, verify.sh extension, ws-test.html | ~3 |
-| **0.3** | WebSocket + reconnect (or, if pre-spike fails, REST-polling-primary path), full now-playing view (transport, volume, source, preset row), speaker proxy POST endpoints, "pressed on speaker" toasts (if WS works), connection pill, dark mode, factory reset | ~2.5 |
+| **0.3** | WebSocket (gabbo subprotocol) + reconnect, full now-playing view (transport, volume, source, preset row), speaker proxy POST endpoints, "pressed on speaker" toasts, connection pill, live VU dot, dark mode, factory reset | ~2.5 |
 | **0.4** | Settings view (7 sub-sections), refresh-all CGI, album-art tint, mobile-remote container queries, accessibility pass | ~3 (wide error bars) |
 | **Total** | | **~8.5** |
 
 ## Open questions to resolve during build
 
-1. **WebSocket Origin acceptance — pre-spike before 0.2 starts.**
-   See *Live updates* § *Pre-spike*. Kill criterion documented.
-2. **busybox httpd CGI behaviour:** verify shell scripts in
+1. **busybox httpd CGI behaviour:** verify shell scripts in
    `cgi-bin/` execute without explicit `httpd.conf` config. If they
    need shaping, ship an `httpd.conf` alongside.
-3. **Speaker WS reliability** (if the spike succeeded): how often
-   does it drop? How does it behave during STANDBY? Tune reconnect
-   backoff accordingly.
+2. **Speaker WS reliability:** how often does the connection drop?
+   How does it behave during STANDBY (the `<nowPlayingUpdated
+   source="STANDBY">` event was observed in the spike — does the WS
+   stay open when the speaker sleeps)? Tune reconnect backoff
+   accordingly.
+3. **`<keyEvent>` payload variance:** the spike showed
+   `<nowSelectionUpdated>` on physical preset-button presses but no
+   `<keyEvent>`. Characterise which keys do/don't emit `<keyEvent>`,
+   and decide whether to source the "pressed on speaker" toast from
+   `<nowSelectionUpdated>` + `<volumeUpdated>` instead.
 4. **`<presetsUpdated>` payload shape:** not documented; capture one
    to confirm.
 5. **Speaker `/storePreset` side effects:** the audit found

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -191,28 +191,60 @@ LAN IP.
 
 ## WebSocket events (port 8080)
 
-Connect to `ws://<speaker-ip>:8080/` (no path). The speaker streams XML
-events in real time:
+Connect to `ws://<speaker-ip>:8080/` with the **`gabbo` subprotocol**:
+
+```bash
+wscat -s gabbo -c ws://<speaker-ip>:8080/
+```
+
+```js
+new WebSocket("ws://<speaker-ip>:8080/", "gabbo")
+```
+
+**The subprotocol is mandatory.** A connection without it succeeds
+and returns the `<SoundTouchSdkInfo>` hello frame, but the speaker
+never pushes state-change events afterwards. With `gabbo`, events
+flow on any state change — no application-level subscribe message
+required.
+
+Events arrive wrapped in `<updates deviceID="…">…</updates>`. The
+inner element is the actual event:
 
 - `<volumeUpdated>` — volume changed
-- `<nowPlayingUpdated>` — track changed / source changed
+- `<nowPlayingUpdated>` — track changed / source changed (incl. STANDBY transition)
+- `<nowSelectionUpdated>` — preset selected (reports which slot, which station)
 - `<sourcesUpdated>` — source list changed
-- `<keyEvent>` — physical button pressed
+- `<keyEvent>` — key press/release (may fire only for some keys; not reliably observed for preset buttons)
 - `<bassUpdated>` / `<balanceUpdated>` / etc.
 - `<connectionStateUpdated>` — Wi-Fi state changed
 - `<presetsUpdated>` — preset stored / removed
 - `<zoneUpdated>` — multi-room zone changed
 
-Subscribe once, receive forever. This is how you'd build a controller
-that reacts to physical button presses.
+Two events arrive **outside** the `<updates>` envelope (self-closing,
+top-level):
+
+- `<SoundTouchSdkInfo serverVersion="…" serverBuild="…"/>` — hello
+  frame on connect; useful as a "WS is truly ready" readiness signal.
+- `<userActivityUpdate deviceID="…" />` — heartbeat-style ping
+  whenever the user does something on the speaker.
+
+Confirmed by two open-source SoundTouch clients that Home Assistant
+and others use:
+[CharlesBlonde/libsoundtouch](https://github.com/CharlesBlonde/libsoundtouch)
+and
+[thlucas1/bosesoundtouchapi](https://github.com/thlucas1/bosesoundtouchapi).
+Bose's own Webservices PDF specifies `gabbo` as the WebSocket
+subprotocol name.
 
 ## The `sender` attribute on `/key`
 
 The `sender` attribute on `<key>` requests is validated by the firmware.
-**`Gabbo` is accepted** — it's the name the SoundTouch app uses
-internally (no, we don't know why). Random strings like `api` get
-rejected with HTTP 400. The full whitelist isn't documented; if you
-discover other accepted values, please open an issue.
+**`Gabbo` is accepted** — it's a magic word baked into the firmware,
+also required as the WebSocket subprotocol on port 8080 (see above).
+Bose's internal SoundTouch SDK uses it in both contexts. Random strings
+like `api` get rejected with HTTP 400. The full whitelist of accepted
+`<key sender="…">` values isn't documented; if you discover other
+accepted values, please open an issue.
 
 ## Useful one-liners
 
@@ -232,8 +264,10 @@ curl -X POST -H 'Content-Type: application/xml' \
   -d '<key state="release" sender="Gabbo">PRESET_3</key>' \
   http://$SPEAKER:8090/key
 
-# Stream events (requires websocat or wscat)
-websocat ws://$SPEAKER:8080/
+# Stream events (gabbo subprotocol is required)
+wscat -s gabbo -c ws://$SPEAKER:8080/
+# or with websocat:
+websocat --protocol gabbo ws://$SPEAKER:8080/
 
 # Push a notification banner
 curl -X POST -H 'Content-Type: application/xml' \


### PR DESCRIPTION
## Summary

- **WebSocket pre-spike done** against firmware `trunk r46330 v4`. Result: handshake works, `<SoundTouchSdkInfo>` arrives, but **events only flow when the client negotiates the `gabbo` subprotocol** on the handshake. Without `gabbo`, the original `docs/api-reference.md` "subscribe once, receive forever" claim never produces events — explaining the mystery.
- **Events arrive wrapped** in `<updates deviceID="…">…</updates>`, except `<SoundTouchSdkInfo/>` and `<userActivityUpdate/>` which are top-level. Parser in `app/ws.js` must unwrap.
- The `gabbo` magic string is the same one the firmware already requires as `<key sender="Gabbo">` — Bose's internal SDK uses it in both contexts. Confirmed by [CharlesBlonde/libsoundtouch](https://github.com/CharlesBlonde/libsoundtouch) (used by Home Assistant's SoundTouch component) and [thlucas1/bosesoundtouchapi](https://github.com/thlucas1/bosesoundtouchapi).
- 0.3 ships with WS as designed. The kill criterion stays in PLAN.md as documented contingency for future firmware regressions but is not applied.

## Bonus events surfaced by the spike

- `<nowSelectionUpdated>` — preset slot + station, not in the original plan but reliably fires on physical preset presses.
- `<userActivityUpdate />` — user-side activity heartbeat, useful for screen-wake heuristics.
- `<keyEvent>` did **not** fire on physical preset-button presses in the spike. Raised as open question #3 — the "pressed on speaker" toast may need to be sourced from `<nowSelectionUpdated>` + `<volumeUpdated>` instead. To investigate during 0.3 build.

## Files changed

- `admin/PLAN.md` § *Live updates* — pre-spike marked VERIFIED; events table updated with envelope + new events; `app/ws.js` sketch shows `gabbo` and unwrap; kill criterion kept as contingency. Open question #1 resolved; renumbered. Effort table cleaned.
- `docs/api-reference.md` § *WebSocket events* — rewrites the bogus "subscribe once" section to specify the `gabbo` handshake. Adds envelope detail + the two unwrapped top-level frames. Connects the `<key sender="Gabbo">` magic word to the same subprotocol name. Updated `wscat` one-liner with `-s gabbo`.

## Test plan

- [x] Spike verified against real firmware (`trunk r46330 v4`) — events flow with `wscat -s gabbo`.
- [ ] Verify rendered Markdown reads cleanly on GitHub (tables, the `app/ws.js` parser code block, the link refs to libsoundtouch + bosesoundtouchapi).
- [ ] After merge: proceed to `/to-issues` for 0.2 against the merged plan.