### PR TITLE
0.6 — architecture deepening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`tunein` CGI 404 envelope shape** — as an intended side-effect of
+  the shared CGI library extraction (#111), the `tunein` CGI's 404
+  response now uses the structured error envelope shared by every
+  other CGI under `admin/cgi-bin/api/v1`.
+  - Old shape: `{"error": "..."}`
+  - New shape: `{"ok": false, "error": {"code": "...", "message": "..."}}`
+  - The SPA is unaffected — no in-tree caller hits a 404-producing
+    `tunein` route. External scripted callers that parse the flat
+    `error` field will need to read `error.message` (or branch on
+    `error.code`) instead.
+
 ## [v0.4.0] - 2026-05-10
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,77 @@
+# bose-soundtouch-resurrect
+
+Replaces Bose's shut-down cloud services for the SoundTouch family with a tiny static responder running on the speaker itself. Below is the project-specific vocabulary that recurs in every conversation about this code.
+
+## Language
+
+### Speaker side
+
+**Speaker**:
+A Bose SoundTouch device — the audio appliance whose firmware this project keeps working.
+_Avoid_: device, unit, box.
+
+**Resolver**:
+The on-speaker static-file + CGI responder that replaces the four Bose cloud services. Lives at `/mnt/nv/resolver/`, served by busybox httpd on port 8181.
+_Avoid_: server, mock, emulator (used elsewhere for off-speaker variants).
+
+**Override XML**:
+`/mnt/nv/OverrideSdkPrivateCfg.xml` — the file that redirects the firmware's four cloud URLs to `http://127.0.0.1:8181`. Read by BoseApp at boot.
+_Avoid_: config, redirect.
+
+**Preset**:
+One of the six physical preset buttons on the speaker, each holding a station reference.
+_Avoid_: slot, favorite, channel.
+
+**Station**:
+A TuneIn radio entry referenced by a `sNNNNN` TuneIn ID. The thing a preset points at.
+_Avoid_: channel, source, broadcast.
+
+**Stream URL**:
+The audio URL the speaker fetches directly from the radio CDN. The cloud was never in the audio path; only metadata.
+
+**TuneIn ID**:
+The `sNNNNN` identifier TuneIn uses for a station. The firmware stores these against presets; the resolver maps them to Stream URLs.
+_Avoid_: SID (overloaded inside TuneIn's own taxonomy — use the longer form).
+
+### Admin side
+
+**Admin SPA**:
+The browser-served admin at `http://<speaker>:8181/` — vanilla HTML/CSS + ES modules under `/app/`. The user-facing interface post-cloud-shutdown.
+_Avoid_: dashboard, console, UI.
+
+**CGI**:
+A busybox-shell script under `admin/cgi-bin/api/v1/`, serving one endpoint family (play, presets, refresh-all, speaker, tunein, preview). Pinned to POSIX + busybox idioms.
+
+**TuneIn drill**:
+The act of crawling TuneIn's outline tree — from a root (genre / location / language) through pagination, lcode validation, and outline classification — down to a station. Implemented across `tunein-url`, `tunein-pager`, `tunein-outline`, `tunein-cache`, `tunein-sid`, plus the renderer under `views/browse/`.
+_Avoid_: browse, search (those are distinct concepts in TuneIn's API).
+
+**Crumb stack**:
+The breadcrumb trail in the browse view plus the `parts` value type that backs it. Owns parsing, rendering, hydration, and the trail's relationship to the URL hash.
+_Avoid_: breadcrumb, trail (those refer to the visual element only; the stack is the value).
+
+**Field**:
+The unit of speaker-state synchronisation. A row in the `FIELDS` registry in `admin/app/speaker-state.js`, encoding `path` (REST), `tag` (XML), `parseEl` (decoder), `apply` (writer), and optional `eventTag` (WS event). Both the polling reconcile and the WS dispatch path converge on a field.
+_Avoid_: property, attribute (too generic).
+
+**FIELDS registry**:
+The list of all known speaker fields — single source of truth for what gets synced and how.
+
+## Relationships
+
+- A **Preset** points to a **Station** by its **TuneIn ID**.
+- The **Resolver** maps a **TuneIn ID** to a **Stream URL**; the **Speaker** then streams audio from that URL directly.
+- The **Admin SPA** mutates speaker state through **CGIs** that proxy or augment the speaker's port-8090 REST API.
+- A **TuneIn drill** terminates at a **Station**; a station can be assigned to a **Preset**.
+- The **Crumb stack** represents the user's path through a **TuneIn drill**.
+- Every **Field** is reconciled either by polling (REST) or by WS dispatch (inline payload or hint + refetch).
+
+## Example dialogue
+
+> **Maintainer:** "When the WS pipe goes down, does the **Admin SPA** stop reflecting **Speaker** state?"
+> **Other maintainer:** "No — `reconcile(store)` polls every **Field** in the registry on a fallback timer. The WS path is the fast path; the polling path is the floor."
+
+## Flagged ambiguities
+
+- *Browse* vs *TuneIn drill*: the SPA's "Browse" tab is one entry point into a **TuneIn drill**, but the drill itself spans the cache, pager, and outline classifier — it's not a synonym for the tab.
+- *Preset* usually means "preset button," but in `views/preset.js` can also refer to the preset-row UI element. Use the longer form (preset row / preset slot) when context is ambiguous.

--- a/admin/app/optimistic.js
+++ b/admin/app/optimistic.js
@@ -1,3 +1,4 @@
+// see also: sliders.js — value-with-target drags use that path instead
 // Optimistic action helper. Applies a local state mutation eagerly,
 // fires the POST, and on rejection rolls back the mutation and surfaces
 // an error toast. Modelled after the slider controller in sliders.js:

--- a/admin/app/sliders.js
+++ b/admin/app/sliders.js
@@ -1,3 +1,4 @@
+// see also: optimistic.js — discrete actions use that path instead
 // Slider merge contract. A slider field is a value the speaker owns
 // (actualXxx) and a target the user is dragging toward (targetXxx). The
 // controller mediates between three event streams without yanking the

--- a/admin/app/speaker-state.js
+++ b/admin/app/speaker-state.js
@@ -222,6 +222,20 @@ export async function reconcile(store) {
   store.touch('speaker');
 }
 
+// Refresh one field by name. Same shape as the hint-only fallback in
+// dispatch(): fetch via the row's fetcher (or xmlGet), swallow rejection
+// and null payloads, apply and notify once on success. Returns nothing —
+// callers observe the new value via the store subscription.
+export async function reconcileField(store, fieldName) {
+  const entry = BY_NAME.get(fieldName);
+  if (!entry) return;
+  let value;
+  try { value = await fetchEntry(entry); } catch (_err) { return; }
+  if (value == null) return;
+  applyEntry(entry, store.state, value);
+  store.touch('speaker');
+}
+
 // Locate the first descendant element matching the entry's `tag` inside
 // the envelope child and parse it. Returns null when the envelope is
 // hint-only (no inline payload) so dispatch() can fall back to fetch.

--- a/admin/app/views/browse.js
+++ b/admin/app/views/browse.js
@@ -1,10 +1,11 @@
 // browse — TuneIn taxonomy browser. Owns the drill-view
 // orchestration: root tabs, drill frame (back / trail / header /
-// filter / body), crumb stack parsing + hydration, filter input mount,
-// and lifecycle (disposing previous pagers on every navigation). Row
-// → DOM rendering, "Load more" pagination, the eager-serial crawl
-// coordinator, and the c=pbrowse show-landing body all live in the
-// per-concern submodules under `./browse/`.
+// filter / body), filter input mount, and lifecycle (disposing
+// previous pagers on every navigation). Row → DOM rendering,
+// "Load more" pagination, the eager-serial crawl coordinator, and
+// the c=pbrowse show-landing body all live in the per-concern
+// submodules under `./browse/`. The crumb-stack value type +
+// renderers + hydrators live in `./browse/crumbs.js`.
 //
 // Two modes:
 //   1. Root view (#/browse): three-tab segmented control (Genre /
@@ -18,18 +19,13 @@
 // See admin/PLAN.md § View specs / browse and docs/tunein-api.md.
 
 import { html, mount, defineView } from '../dom.js';
-import { tuneinBrowse, tuneinDescribe } from '../api.js';
-import { icon } from '../icons.js';
-import {
-  lcodeLabel,
-  LCODES_LOADED_EVENT,
-} from '../tunein-url.js';
+import { tuneinBrowse } from '../api.js';
+import { lcodeLabel, LCODES_LOADED_EVENT } from '../tunein-url.js';
 import { cache, TTL_LABEL } from '../tunein-cache.js';
 
 import {
   renderOutline,
   renderEntry,
-  drillHashFor,
   setChildCrumbs,
   setCurrentParts,
   pluralize,
@@ -57,17 +53,45 @@ import {
   _applyDomFilterForTest,
   _getCoordinatorForTest,
 } from './browse/pager-crawl.js';
+import {
+  MAX_CRUMBS,
+  parseCrumbs,
+  stringifyCrumbs,
+  crumbTokenFor,
+  partsFromCrumb,
+  pickDrillParts,
+  filtersOf,
+  crumbLabelFor,
+  backHrefFor,
+  initialHeaderTitle,
+  renderPillBar,
+  renderCrumbTrail,
+  renderFilterBadge,
+  renderFilterBadges,
+  hydrateCrumbLabels,
+  patchTrailCrumb,
+} from './browse/crumbs.js';
 
-// Re-export the entry/render primitives + test hooks so existing
-// callers (test_browse, test_browse_crumbs, test_tunein_pager,
-// main.js) keep their imports stable across the split. The split is
-// internal-only — every public surface of the original browse.js
-// still resolves through this module.
+// Re-export the entry/render primitives + crumb helpers + test hooks
+// so existing callers (test_browse, test_browse_crumbs,
+// test_tunein_pager, main.js) keep their imports stable across the
+// split. The split is internal-only — every public surface of the
+// original browse.js still resolves through this module.
 export {
   renderOutline,
   renderEntry,
   filterRowEntries,
   mountLoadMoreButtons,
+  parseCrumbs,
+  stringifyCrumbs,
+  crumbTokenFor,
+  partsFromCrumb,
+  crumbLabelFor,
+  backHrefFor,
+  renderPillBar,
+  renderCrumbTrail,
+  renderFilterBadge,
+  renderFilterBadges,
   _renderShowLandingForTest,
   _setChildCrumbsForTest,
   _setActivePagersForTest,
@@ -88,17 +112,6 @@ const TABS = [
   { key: 'location', label: 'Location', params: { id: 'r0' }   },
   { key: 'language', label: 'Language', params: { c: 'lang' }  },
 ];
-
-// Maximum depth of the URL crumb stack (`from=...`). Deeper than the
-// deepest observed location-tree depth (5); see issue #74 notes. Any
-// crumbs beyond this are dropped from the head of the stack.
-const MAX_CRUMBS = 8;
-
-// Maximum number of `Describe.ashx?id=<X>` calls in flight at once
-// during cold-load label-fill. Matches MAX_CRUMBS so the worst case
-// (a fully-deep shared URL with no cached labels) saturates in one
-// wave.
-const DESCRIBE_CONCURRENCY = 5;
 
 export default defineView({
   mount(root, _store, ctx) {
@@ -140,146 +153,6 @@ export default defineView({
 function isShowDrillParts(parts) {
   if (!parts || parts.c !== 'pbrowse') return false;
   return typeof parts.id === 'string' && /^p\d+$/.test(parts.id);
-}
-
-// Parse the comma-separated `from=` query parameter into an array of
-// crumb tokens. Empty / missing input returns []. Trims, drops empty
-// segments, caps to MAX_CRUMBS by keeping the tail (the most recent
-// crumbs — the ones closest to the current node).
-export function parseCrumbs(raw) {
-  if (typeof raw !== 'string' || raw === '') return [];
-  const segs = raw.split(',').map((s) => s.trim()).filter(Boolean);
-  return segs.length > MAX_CRUMBS ? segs.slice(segs.length - MAX_CRUMBS) : segs;
-}
-
-// Inverse of parseCrumbs: stringify the crumb array into a `from=`
-// value. Returns '' for an empty array so callers can skip emitting
-// the parameter entirely.
-export function stringifyCrumbs(crumbs) {
-  if (!Array.isArray(crumbs) || crumbs.length === 0) return '';
-  return crumbs.join(',');
-}
-
-// Helpers for the `filters` array shape. Always returns a fresh array
-// of trimmed non-empty strings. Tolerates legacy callers still passing
-// `parts.filter` as a single string (or a pre-joined comma list).
-function filtersOf(parts) {
-  if (!parts) return [];
-  if (Array.isArray(parts.filters)) {
-    return parts.filters.filter((s) => typeof s === 'string' && s !== '');
-  }
-  if (typeof parts.filter === 'string' && parts.filter !== '') {
-    return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
-  }
-  return [];
-}
-
-// Stash a `filters: string[]` (and back-compat `filter: string`) on a
-// parts object. Empty arrays drop both fields so the URL composer emits
-// the bare drill (no `filter=` param).
-function setFilters(parts, list) {
-  const cleaned = (Array.isArray(list) ? list : []).filter((s) => typeof s === 'string' && s !== '');
-  if (cleaned.length > 0) {
-    parts.filters = cleaned;
-    parts.filter  = cleaned.join(',');
-  } else {
-    delete parts.filters;
-    delete parts.filter;
-  }
-  return parts;
-}
-
-// Crumb token for a drill-parts object. The token is the value the
-// user would land on if they clicked Back to this level: prefer `id`,
-// fall back to `c`. When filters accompany the anchor we encode them
-// as `<anchor>:<f1>+<f2>+…` so two drills that share the same anchor
-// but differ in their filters (e.g. the language tree, where every
-// level emits `c=lang` or `c=music` with a different `filter=l<NNN>`)
-// produce distinct, navigable crumbs (#89, #106). pivots / offsets
-// remain refinements that do not become crumbs.
-// Returns null when neither anchor is set (root view).
-export function crumbTokenFor(parts) {
-  if (!parts) return null;
-  let anchor = '';
-  if (typeof parts.id === 'string' && parts.id !== '') anchor = parts.id;
-  else if (typeof parts.c === 'string' && parts.c !== '') anchor = parts.c;
-  if (!anchor) return null;
-  const filters = filtersOf(parts);
-  if (filters.length > 0) {
-    return `${anchor}:${filters.join('+')}`;
-  }
-  return anchor;
-}
-
-// Inverse of crumbTokenFor: turn a crumb token back into the drill
-// parts the user should land on. Heuristic:
-//   - bare tokens matching /^[a-z]\d+$/ are guide_ids (`id=` anchor)
-//   - bare tokens otherwise are category short names (`c=`)
-//   - tokens with a `:f1+f2+…` suffix attach N filters to whichever
-//     anchor form applies (so `lang:l109` → `{c:'lang', filters:['l109']}`,
-//     `r101821:g26+l170` → `{id:'r101821', filters:['g26','l170']}`)
-export function partsFromCrumb(token) {
-  if (typeof token !== 'string' || token === '') return null;
-  const colonIdx = token.indexOf(':');
-  let anchor = token;
-  let filterRaw = '';
-  if (colonIdx >= 0) {
-    anchor = token.slice(0, colonIdx);
-    filterRaw = token.slice(colonIdx + 1);
-  }
-  if (!anchor) return null;
-  const parts = /^[a-z]\d+$/.test(anchor) ? { id: anchor } : { c: anchor };
-  if (filterRaw) {
-    const list = filterRaw.split('+').map((s) => s.trim()).filter(Boolean);
-    setFilters(parts, list);
-  }
-  return parts;
-}
-
-// A drill URL can carry any of {id, c, filter, pivot, offset}. The
-// presence of `id` or `c` is the load-bearing signal; the others
-// modify the drill. The URL's `filter=` may be comma-separated values
-// (multi-filter wire shape, #106); the resulting parts object carries
-// `filters: string[]` plus back-compat `filter: string`. Returns null
-// when neither anchor is set (root view).
-function pickDrillParts(query) {
-  if (!query || (typeof query.id !== 'string' && typeof query.c !== 'string')) {
-    return null;
-  }
-  const out = {};
-  for (const key of ['id', 'c', 'pivot', 'offset']) {
-    if (typeof query[key] === 'string' && query[key] !== '') out[key] = query[key];
-  }
-  if (typeof query.filter === 'string' && query.filter !== '') {
-    const list = query.filter.split(',').map((s) => s.trim()).filter(Boolean);
-    setFilters(out, list);
-  }
-  return out;
-}
-
-// Display label for the drill crumb — a compact form of the parts.
-// `c=music&filter=l216` reads more usefully than just `music`. When
-// the filter is an lcode (`l<NNN>`) and we have a cached language
-// name for it, append the human form so end users get an at-a-glance
-// translation of the otherwise opaque numeric filter (#90). With
-// multi-filter drills (#106) the comma-joined wire value is shown;
-// a single-lcode filter still resolves to its language name.
-// Exported for unit testing — production callers stay inside this file.
-export function crumbLabelFor(parts) {
-  const segs = [];
-  const filters = filtersOf(parts);
-  const filterStr = filters.join(',');
-  if (parts.id) segs.push(parts.id);
-  if (parts.c)  segs.push(`c=${parts.c}`);
-  if (filterStr) segs.push(`filter=${filterStr}`);
-  if (parts.pivot)  segs.push(`pivot=${parts.pivot}`);
-  if (parts.offset) segs.push(`offset=${parts.offset}`);
-  let label = segs.join(' · ');
-  if (filters.length === 1 && /^l\d+$/.test(filters[0])) {
-    const name = lcodeLabel(filters[0]);
-    if (name) label += ` (${name})`;
-  }
-  return label;
 }
 
 // ---- root view (segmented tabs) -------------------------------------
@@ -360,19 +233,6 @@ function selectTab(tab, buttons, body, headerLeft, headerCount) {
 // below that a thin count strap (kept for loadInto's total-count
 // write). Each caller (renderDrill / renderShowLanding) adds the
 // mode-specific bits (filter input for renderDrill).
-
-// Trail label override for the entry-point tab tokens. The first
-// crumb on any rooted drill is the tab — the spec wants its label
-// to read as the tab name (`Genre` / `Location` / `Language`), not
-// the cached API title ("Music" / "By Location" / "By Language").
-// Matched against the bare anchor portion of a crumb token; tokens
-// with an `:lXXX` filter suffix fall through to the cache /
-// catalogue path so e.g. `lang:l109` still resolves to "German".
-const TAB_LABEL_BY_TOKEN = Object.freeze({
-  music: 'Genre',
-  r0:    'Location',
-  lang:  'Language',
-});
 
 function buildDrillFrame(parts, crumbs) {
   const stack = Array.isArray(crumbs) ? crumbs.slice(0, MAX_CRUMBS) : [];
@@ -551,44 +411,6 @@ function renderShowLanding(root, parts, crumbs) {
   });
 }
 
-// Compose the Back-button href. Pops the rightmost crumb and navigates
-// to it; the popped crumb keeps the remaining stack as its own `from=`.
-// An empty stack lands at #/browse (the root tabs view).
-export function backHrefFor(stack) {
-  if (!Array.isArray(stack) || stack.length === 0) return '#/browse';
-  const head = stack.slice(0, -1);
-  const tail = stack[stack.length - 1];
-  const parts = partsFromCrumb(tail);
-  if (!parts) return '#/browse';
-  // Always pass the trimmed crumb stack explicitly so we don't pick up
-  // a stale value of _childCrumbs (set later, after this Back-link is
-  // built — but we want backHref deterministic regardless of order).
-  return drillHashFor(parts, head);
-}
-
-// Initial page-header title before the API response arrives. Prefer
-// the cached label for this node's token; fall back to crumbLabelFor
-// so the user sees *something* during the load.
-//
-// Filter-bearing tokens (`<anchor>:<filter>`) try the bare anchor too:
-// the page IS the anchor node (just filtered), so a cached title for
-// `r101821` should surface as the h1 / current-crumb text for the
-// `r101821:g26` drill too. The filter surface is the badge, not the
-// title.
-function initialHeaderTitle(parts, token) {
-  if (token) {
-    const cached = cache.get(`tunein.label.${token}`);
-    if (typeof cached === 'string' && cached !== '') return cached;
-    const colon = token.indexOf(':');
-    if (colon > 0) {
-      const bare = token.slice(0, colon);
-      const cachedBare = cache.get(`tunein.label.${bare}`);
-      if (typeof cachedBare === 'string' && cachedBare !== '') return cachedBare;
-    }
-  }
-  return crumbLabelFor(parts);
-}
-
 // ---- shared loader --------------------------------------------------
 //
 // `head` is null for the root tabs view (where the section title is the
@@ -637,493 +459,6 @@ function loadInto(body, promise, headerCount, head) {
       body.replaceChildren();
       body.appendChild(errorNode(err));
     });
-}
-
-// ---- pill bar + inline trail (top of every drill body) -------------
-//
-// The pill bar replaces the old standalone Back link + standalone
-// crumb trail with a single horizontal row: a circular chevron-only
-// Back affordance leads, followed by an inline breadcrumb
-// `Browse › <Tab> › <Ancestor> › <Current>`. The current segment is
-// the bolded, non-link tail; earlier segments stay anchors whose
-// hashes match the ones the old trail emitted, so Back/forward
-// history continues to pop the same stack.
-//
-// Composition for the trail:
-//   1. literal `Browse` (entry-point anchor → `#/browse`)
-//   2. one anchor per crumb in the stack — stack[0] gets the
-//      TAB_LABEL_BY_TOKEN override when its bare anchor matches
-//      a tab token (`music` / `r0` / `lang`); other crumbs read
-//      from the cache / lcode catalogue / raw-token fallback
-//      ladder.
-//   3. the current node as a bolded non-link `<span>` with
-//      `aria-current="page"`.
-
-export function renderPillBar(parts, stack) {
-  const bar = document.createElement('div');
-  bar.className = 'browse-bar';
-
-  // Back chevron — circular pill, glyph only. aria-label carries the
-  // destination derived from backHrefFor (so it stays in sync with
-  // the popped target). When the destination is the root tabs view,
-  // we read "Back to Browse"; otherwise the destination crumb's
-  // label is used.
-  const back = document.createElement('a');
-  back.className = 'browse-bar__back';
-  back.href = backHrefFor(stack);
-  back.setAttribute('aria-label', backAriaLabel(stack));
-  // Marker for hydrateCrumbLabels to re-stamp the aria-label once the
-  // destination crumb's title resolves.
-  if (Array.isArray(stack) && stack.length > 0) {
-    back.dataset.backToken = stack[stack.length - 1];
-  }
-  back.appendChild(icon('chevron-left', 16));
-  bar.appendChild(back);
-
-  const trail = renderCrumbTrail(stack, parts);
-  bar.appendChild(trail);
-
-  // Active-filter badges — mounted in-bar, peers to the trail (#104,
-  // #106). One badge per filter in `parts.filters`; each carries the
-  // resolved filter label + a × close affordance that navigates to the
-  // same drill minus that filter only (the other filters + stack + id
-  // are preserved).
-  const badges = renderFilterBadges(parts, stack);
-  for (const badge of badges) bar.appendChild(badge);
-
-  // Sub-handle accessors for the drill frame (hydrateCrumbLabels
-  // mutates the trail anchors + the back aria-label in place).
-  bar._back = back;
-  bar._trail = trail;
-  // Back-compat: `_filter` points at the first badge so single-filter
-  // callers keep working. Multi-filter callers should read `_badges`.
-  bar._filter = badges[0] || null;
-  bar._badges = badges;
-  return bar;
-}
-
-// Build the active-filter badges for the pill bar. Returns an array
-// (possibly empty) of badge nodes — one per filter in `parts.filters`.
-// Each badge mounts as a peer of the trail inside the bar, carrying
-// the resolved filter label and a trailing × close affordance that
-// navigates to the same drill MINUS THIS ONE FILTER (the other
-// filters + stack + primary anchor are preserved). When all filters
-// are dropped, the URL reverts to the bare drill (#106).
-//
-// Label resolution order — same ladder hydrateCrumbLabels uses for
-// trail anchors:
-//   1. lcode catalogue for `lXXX` filters (instant, no fetch).
-//   2. cache lookup `tunein.label.<filter>` (a previous Describe /
-//      Browse landed and stashed the title).
-//   3. raw token while a one-shot Describe / Browse runs in the
-//      background; the badge text upgrades in place when the title
-//      resolves.
-//
-// Exported for unit testing — production callers go through
-// renderPillBar.
-export function renderFilterBadges(parts, stack) {
-  const filters = filtersOf(parts);
-  if (filters.length === 0) return [];
-  const stackArr = Array.isArray(stack) ? stack : [];
-  const out = [];
-  for (const filterToken of filters) {
-    out.push(buildFilterBadge(filterToken, parts, filters, stackArr));
-  }
-  return out;
-}
-
-// Build one badge node for `filterToken`, given the full filter list
-// and current parts / stack so the × close anchor can drop only this
-// filter while preserving the rest.
-function buildFilterBadge(filterToken, parts, filters, stack) {
-  const badge = document.createElement('span');
-  badge.className = 'browse-bar__filter';
-  badge.dataset.filterToken = filterToken;
-
-  const label = document.createElement('span');
-  label.className = 'browse-bar__filter-label';
-  label.textContent = initialFilterLabel(filterToken);
-  badge.appendChild(label);
-
-  // × close affordance — anchor that navigates to the same drill with
-  // this filter dropped (the others are preserved). When the last
-  // filter is removed the URL reverts to the bare drill.
-  const remaining = filters.filter((f) => f !== filterToken);
-  const stripped = Object.assign({}, parts);
-  setFilters(stripped, remaining);
-  const close = document.createElement('a');
-  close.className = 'browse-bar__filter-close';
-  close.setAttribute('href', drillHashFor(stripped, stack));
-  close.setAttribute('aria-label', 'Remove filter');
-  close.appendChild(icon('x', 12));
-  badge.appendChild(close);
-
-  // Stash sub-handles for the hydrator to patch the label in place.
-  badge._label = label;
-  badge._close = close;
-
-  // Kick off async label hydration when the initial label is still the
-  // raw token (no cache hit, no catalogue hit). The hydrator writes the
-  // resolved title back into the cache so subsequent navigations land
-  // pre-resolved.
-  if (label.textContent === filterToken) {
-    hydrateFilterLabel(filterToken, badge);
-  }
-
-  return badge;
-}
-
-// Back-compat shim: legacy callers expect a single badge node (or
-// null) for a single-filter drill. Wraps renderFilterBadges and
-// returns its first element. New code should consume the array form
-// directly via renderFilterBadges.
-export function renderFilterBadge(parts, stack) {
-  const badges = renderFilterBadges(parts, stack);
-  return badges.length > 0 ? badges[0] : null;
-}
-
-// Pick the best already-known label for a filter token without any
-// network work. Mirrors the trail's `initialCrumbLabel` ladder for the
-// filter-only case: lcode catalogue for `lXXX`, then the cache, then
-// the raw token as a last resort.
-function initialFilterLabel(filterToken) {
-  if (/^l\d+$/.test(filterToken)) {
-    const name = lcodeLabel(filterToken);
-    if (name) return name;
-  }
-  const cached = cache.get(`tunein.label.${filterToken}`);
-  if (typeof cached === 'string' && cached !== '') return cached;
-  return filterToken;
-}
-
-// One-shot label fetch for a filter token whose initial render is the
-// raw form. Lcode tokens are catalogue-only; everything else (gNNN /
-// cNNN / etc.) gets a Browse.ashx lookup, with Describe as a fallback
-// for entity prefixes. The badge's label updates in place once the
-// title resolves; failures stay silent (the raw token stays put).
-async function hydrateFilterLabel(filterToken, badge) {
-  // Lcode catalogue is authoritative — never fall through to Describe
-  // for `lXXX`. If it didn't resolve in initialFilterLabel and the
-  // catalogue lands later, the LCODES_LOADED_EVENT listener (mounted
-  // by renderDrill) re-patches the badge.
-  if (/^l\d+$/.test(filterToken)) return;
-  let title = '';
-  try {
-    if (/^[spt]\d+$/.test(filterToken)) {
-      // Entity prefixes — Describe returns title in body[0].
-      const json = await tuneinDescribe({ id: filterToken });
-      const e = json && Array.isArray(json.body) && json.body[0];
-      if (e) {
-        if (typeof e.title === 'string' && e.title !== '') title = e.title;
-        else if (typeof e.name === 'string' && e.name !== '') title = e.name;
-      }
-    } else {
-      // Category / generic — Browse returns head.title.
-      const parts = /^[a-z]\d+$/.test(filterToken)
-        ? { id: filterToken }
-        : { c: filterToken };
-      const json = await tuneinBrowse(parts);
-      const t = json && json.head && json.head.title;
-      if (typeof t === 'string' && t !== '') title = t;
-    }
-  } catch (_err) {
-    return;
-  }
-  if (!title) return;
-  cache.set(`tunein.label.${filterToken}`, title, TTL_LABEL);
-  if (badge && badge._label) badge._label.textContent = title;
-}
-
-// Build the inline trail inside the pill bar. Always leads with the
-// literal `Browse` entry-point anchor; the bolded current segment is
-// appended when `currentParts` is provided (the drill case). Tests
-// can call with `currentParts = null` to render just the lineage —
-// the legacy ancestor-only shape used by the old standalone trail.
-
-export function renderCrumbTrail(stack, currentParts) {
-  const trail = document.createElement('nav');
-  trail.className = 'browse-bar__trail';
-  trail.setAttribute('aria-label', 'Breadcrumb');
-
-  // Defence-in-depth dedupe of consecutive identical tokens (#89). An
-  // old URL pasted from an earlier session could carry
-  // `from=lang,lang,lang` — render it as a single anchor rather than
-  // three identical ones.
-  const dedup = [];
-  if (Array.isArray(stack)) {
-    for (const token of stack) {
-      if (dedup.length === 0 || dedup[dedup.length - 1] !== token) dedup.push(token);
-    }
-  }
-
-  // Tail-dedupe against the current parts (#104). When the user clicks
-  // an end-of-page filter chip, the link appends the current id to
-  // `from=` AND keeps the same primary id (just adds `filter=…`). The
-  // stack's last crumb is then the same node as the current segment;
-  // rendering both produces a duplicated tail like
-  //   Browse › Location › … › Bayreuth › **Bayreuth**
-  // Two shapes count as a match:
-  //   - bare equality (`r101821` === `r101821`)
-  //   - the current token carries a filter while the stack tail does
-  //     not — current `r101821:g26` and stack tail `r101821` refer to
-  //     the same drill node. Drop the duplicate; the filter surface
-  //     is the badge, not a trail anchor.
-  if (currentParts && dedup.length > 0) {
-    const curTok = crumbTokenFor(currentParts);
-    if (curTok) {
-      const tail = dedup[dedup.length - 1];
-      const colon = curTok.indexOf(':');
-      const curAnchor = colon >= 0 ? curTok.slice(0, colon) : curTok;
-      if (tail === curTok || tail === curAnchor) dedup.pop();
-    }
-  }
-
-  // 1. literal Browse anchor — every trail starts here.
-  const browseA = document.createElement('a');
-  browseA.className = 'browse-bar__crumb';
-  browseA.setAttribute('href', '#/browse');
-  browseA.dataset.crumbRole = 'root';
-  browseA.textContent = 'Browse';
-  trail.appendChild(browseA);
-
-  // 2. one anchor per stack entry. stack[0] is the tab; its bare
-  // anchor maps via TAB_LABEL_BY_TOKEN.
-  for (let i = 0; i < dedup.length; i++) {
-    trail.appendChild(makeSeparator());
-    const token = dedup[i];
-    const parts = partsFromCrumb(token);
-    const a = document.createElement('a');
-    a.className = 'browse-bar__crumb';
-    a.dataset.crumbToken = token;
-    if (i === 0) a.dataset.crumbPosition = 'first';
-    if (parts) {
-      a.href = drillHashFor(parts, dedup.slice(0, i));
-    } else {
-      a.className += ' is-disabled';
-    }
-    a.textContent = initialCrumbLabel(token, parts, i === 0);
-    trail.appendChild(a);
-  }
-
-  // 3. current segment — bolded non-link tail. Skipped when no
-  // current parts are supplied (the legacy ancestor-only shape).
-  if (currentParts) {
-    trail.appendChild(makeSeparator());
-    const cur = document.createElement('span');
-    cur.className = 'browse-bar__crumb is-current';
-    cur.setAttribute('aria-current', 'page');
-    // The current segment is the drill's title; it's a separate seam
-    // from the cache labels (which are keyed by crumb token, not by
-    // the current page). Read the same h1-equivalent text we use for
-    // the page title row.
-    const curToken = crumbTokenFor(currentParts);
-    cur.textContent = initialHeaderTitle(currentParts, curToken);
-    if (curToken) cur.dataset.crumbToken = curToken;
-    trail.appendChild(cur);
-  }
-
-  return trail;
-}
-
-function makeSeparator() {
-  const sep = document.createElement('span');
-  sep.className = 'browse-bar__sep';
-  sep.setAttribute('aria-hidden', 'true');
-  sep.textContent = '›'; // ›
-  return sep;
-}
-
-// Pick the best already-known label for a crumb token without doing
-// any network work. Order of preference for ancestors:
-//   - tab-token override (only at stack[0] — the entry-point tab)
-//   - cached label under `tunein.label.<token>` (from a previous
-//     resolve)
-//   - in-memory lcode catalogue (free for `<anchor>:l<NNN>` tokens)
-//   - raw token fallback
-// The async hydrateCrumbLabels path upgrades any token still
-// rendered as raw once its Describe / Browse lookup completes.
-function initialCrumbLabel(token, parts, isFirstInStack) {
-  // The first crumb in the stack is the entry-point tab — render it
-  // with the tab's display label (`Genre` / `Location` / `Language`)
-  // rather than the cached API title ("Music" / "By Location" / "By
-  // Language"). Filter-bearing tokens (`lang:lXXX`) intentionally
-  // fall through to the catalogue path so they read as the language
-  // name, not "Language".
-  if (isFirstInStack) {
-    const bareAnchor = parts && typeof parts.id === 'string'
-      ? parts.id
-      : (parts && typeof parts.c === 'string' ? parts.c : '');
-    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
-    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) {
-      return TAB_LABEL_BY_TOKEN[bareAnchor];
-    }
-  }
-  const cached = cache.get(`tunein.label.${token}`);
-  if (typeof cached === 'string' && cached !== '') return cached;
-  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
-    const name = lcodeLabel(parts.filter);
-    if (name) return name;
-  }
-  return token;
-}
-
-// Compose the Back chevron's aria-label from the popped destination.
-// Empty stack → root tabs view ("Back to Browse"). Otherwise the
-// destination is the last crumb in the stack; prefer the resolved
-// label (cache / catalogue) and fall back to the raw token.
-function backAriaLabel(stack) {
-  if (!Array.isArray(stack) || stack.length === 0) return 'Back to Browse';
-  const destToken = stack[stack.length - 1];
-  if (!destToken) return 'Back to Browse';
-  const destParts = partsFromCrumb(destToken);
-  // The last crumb in the stack is the trail's tail-before-current —
-  // it's an ancestor, not the entry-point tab, so isFirstInStack is
-  // only relevant when stack length is 1.
-  const label = initialCrumbLabel(destToken, destParts, stack.length === 1);
-  return `Back to ${label}`;
-}
-
-// For every crumb in `stack` that lacks a cached label, fetch its
-// label in parallel (cap DESCRIBE_CONCURRENCY) and patch the trail
-// DOM in-place when the title arrives. Concurrency is bounded by
-// waiting for the oldest pending request to settle before issuing
-// the next one.
-//
-// Endpoint choice per token (the API doesn't expose a single "what
-// is this thing called?" call):
-//   - s / p / t prefix → Describe.ashx?id=<X>, title in body[0].
-//     These are real entities; Describe is the entity-detail endpoint.
-//   - everything else (g / c / r / l / m / a / n, plus plain words
-//     like `music` / `talk` / `sports` / `lang`) → Browse.ashx?id=<X>
-//     (or ?c=<X> for the plain-word case), title in head.title.
-//     Describe returns an empty body for these prefixes, so it
-//     can't serve as the label source. The issue text says "Describe",
-//     but the verified-on-Bo behaviour is that Describe head has
-//     {status} only; head.title comes from Browse. Pragmatic split.
-//
-// Tokens whose resolved title is blank stay rendered as raw IDs —
-// the documented final fallback from the issue spec.
-async function hydrateCrumbLabels(stack, trailEl, backEl) {
-  if (!Array.isArray(stack) || stack.length === 0) return;
-  const todo = [];
-  for (const token of stack) {
-    if (!token) continue;
-    if (typeof cache.get(`tunein.label.${token}`) === 'string') continue;
-    todo.push(token);
-  }
-  if (todo.length === 0) return;
-
-  const inFlight = new Set();
-  for (const token of todo) {
-    if (inFlight.size >= DESCRIBE_CONCURRENCY) {
-      // Wait for any one to finish before issuing the next.
-      await Promise.race(inFlight);
-    }
-    const p = resolveLabelAndApply(token, trailEl, backEl, stack).finally(() => inFlight.delete(p));
-    inFlight.add(p);
-  }
-  // Drain the remaining wave so failures surface in dev tools.
-  await Promise.allSettled(Array.from(inFlight));
-}
-
-// Resolve a single crumb token to a human-readable label and patch
-// the trail. Picks the appropriate endpoint per prefix; falls through
-// silently when no label can be discovered.
-async function resolveLabelAndApply(token, trailEl, backEl, stack) {
-  // Filter-bearing tokens (`<anchor>:l<NNN>`) resolve from the in-
-  // memory lcode catalogue without any network round-trip (#89, #90).
-  // We bypass the Describe / Browse fallbacks entirely — the
-  // catalogue is authoritative for language names.
-  const parts = partsFromCrumb(token);
-  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
-    const name = lcodeLabel(parts.filter);
-    if (name) {
-      cache.set(`tunein.label.${token}`, name, TTL_LABEL);
-      patchTrailCrumb(trailEl, token, name);
-      patchBackAria(backEl, stack, token, name);
-    }
-    return;
-  }
-
-  let title = '';
-  try {
-    if (/^[spt]\d+$/.test(token)) {
-      // Entity prefixes — Describe returns the canonical name in
-      // body[0]. Stations use `name`; shows / topics use `title`.
-      const json = await tuneinDescribe({ id: token });
-      const e = json && Array.isArray(json.body) && json.body[0];
-      if (e) {
-        if (typeof e.title === 'string' && e.title !== '') title = e.title;
-        else if (typeof e.name === 'string' && e.name !== '') title = e.name;
-      }
-    } else if (parts) {
-      // Category prefixes + plain words — Browse returns head.title.
-      // partsFromCrumb routes lowercase-letter+digit tokens through
-      // `id=` and letters-only tokens through `c=`.
-      const json = await tuneinBrowse(parts);
-      const t = json && json.head && json.head.title;
-      if (typeof t === 'string' && t !== '') title = t;
-    }
-  } catch (_err) {
-    // Network error / non-200 — give up silently. The trail keeps
-    // the raw-token rendering, which is the issue's documented
-    // last-resort fallback.
-    return;
-  }
-  if (!title) return;
-  cache.set(`tunein.label.${token}`, title, TTL_LABEL);
-  patchTrailCrumb(trailEl, token, title);
-  patchBackAria(backEl, stack, token, title);
-}
-
-// Find the trail anchor for `token` and rewrite its textContent. The
-// first-in-stack tab override stays sticky — we don't overwrite the
-// tab label with whatever the API returns for its node.
-function patchTrailCrumb(trailEl, token, label) {
-  if (!trailEl || typeof trailEl.querySelector !== 'function') return;
-  const a = trailEl.querySelector(`[data-crumb-token="${cssEscape(token)}"]`);
-  if (!a) return;
-  // Skip if the rendered label already reflects the tab-token override
-  // (stack[0] is allowed to read as `Genre` / `Location` / `Language`
-  // — the cache write happens for the cold-load path but doesn't
-  // overwrite the override visually).
-  if (a.dataset && a.dataset.crumbPosition === 'first') {
-    const parts = partsFromCrumb(token);
-    const bareAnchor = parts && typeof parts.id === 'string'
-      ? parts.id
-      : (parts && typeof parts.c === 'string' ? parts.c : '');
-    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
-    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) return;
-  }
-  a.textContent = label;
-}
-
-// Re-stamp the Back chevron's aria-label when the destination crumb's
-// label resolves. Only fires when the resolving token matches the
-// last crumb in the stack (which is the popped destination). Honour
-// the tab-token override for a single-crumb stack so the popped
-// destination reads as "Back to Genre" rather than "Back to Music".
-function patchBackAria(backEl, stack, token, label) {
-  if (!backEl) return;
-  if (!Array.isArray(stack) || stack.length === 0) return;
-  if (stack[stack.length - 1] !== token) return;
-  if (stack.length === 1) {
-    const parts = partsFromCrumb(token);
-    const bareAnchor = parts && typeof parts.id === 'string'
-      ? parts.id
-      : (parts && typeof parts.c === 'string' ? parts.c : '');
-    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
-    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) return;
-  }
-  backEl.setAttribute('aria-label', `Back to ${label}`);
-}
-
-// CSS.escape isn't available in xmldom (test) and the crumb tokens are
-// always [a-z0-9] anyway, but be defensive against any token shape the
-// API might surface in future.
-function cssEscape(s) {
-  return String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) =>
-    '\\' + ch.charCodeAt(0).toString(16) + ' ');
 }
 
 // ---- page-top filter input ----------------------------------------

--- a/admin/app/views/browse/crumbs.js
+++ b/admin/app/views/browse/crumbs.js
@@ -1,0 +1,710 @@
+// crumbs — the URL crumb stack as a self-contained module. Owns the
+// `parts` value type (the canonical drill-state shape passed around the
+// browser), the crumb token parser/emitter pair (parseCrumbs /
+// stringifyCrumbs, crumbTokenFor / partsFromCrumb), the pill-bar
+// renderer with its inline trail + filter badges (renderPillBar,
+// renderCrumbTrail, renderFilterBadges, renderFilterBadge), and the
+// async label hydration that upgrades raw-token renderings to
+// human-readable names once Describe/Browse resolves (hydrateCrumbLabels,
+// hydrateFilterLabel, patchTrailCrumb, patchBackAria,
+// resolveLabelAndApply).
+//
+// The companion `views/browse.js` mounts the view; this module owns
+// everything below the mount boundary that deals with crumb-state
+// arithmetic.
+
+import { tuneinBrowse, tuneinDescribe } from '../../api.js';
+import { icon } from '../../icons.js';
+import { lcodeLabel } from '../../tunein-url.js';
+import { cache, TTL_LABEL } from '../../tunein-cache.js';
+
+import { drillHashFor } from './outline-render.js';
+
+// Maximum depth of the URL crumb stack (`from=...`). Deeper than the
+// deepest observed location-tree depth (5); see issue #74 notes. Any
+// crumbs beyond this are dropped from the head of the stack.
+export const MAX_CRUMBS = 8;
+
+// Maximum number of `Describe.ashx?id=<X>` calls in flight at once
+// during cold-load label-fill. Matches MAX_CRUMBS so the worst case
+// (a fully-deep shared URL with no cached labels) saturates in one
+// wave.
+const DESCRIBE_CONCURRENCY = 5;
+
+// Trail label override for the entry-point tab tokens. The first
+// crumb on any rooted drill is the tab — the spec wants its label
+// to read as the tab name (`Genre` / `Location` / `Language`), not
+// the cached API title ("Music" / "By Location" / "By Language").
+// Matched against the bare anchor portion of a crumb token; tokens
+// with an `:lXXX` filter suffix fall through to the cache /
+// catalogue path so e.g. `lang:l109` still resolves to "German".
+const TAB_LABEL_BY_TOKEN = Object.freeze({
+  music: 'Genre',
+  r0:    'Location',
+  lang:  'Language',
+});
+
+// ---- value type: parts + crumb token --------------------------------
+
+// Parse the comma-separated `from=` query parameter into an array of
+// crumb tokens. Empty / missing input returns []. Trims, drops empty
+// segments, caps to MAX_CRUMBS by keeping the tail (the most recent
+// crumbs — the ones closest to the current node).
+export function parseCrumbs(raw) {
+  if (typeof raw !== 'string' || raw === '') return [];
+  const segs = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return segs.length > MAX_CRUMBS ? segs.slice(segs.length - MAX_CRUMBS) : segs;
+}
+
+// Inverse of parseCrumbs: stringify the crumb array into a `from=`
+// value. Returns '' for an empty array so callers can skip emitting
+// the parameter entirely.
+export function stringifyCrumbs(crumbs) {
+  if (!Array.isArray(crumbs) || crumbs.length === 0) return '';
+  return crumbs.join(',');
+}
+
+// Helpers for the `filters` array shape. Always returns a fresh array
+// of trimmed non-empty strings. Tolerates legacy callers still passing
+// `parts.filter` as a single string (or a pre-joined comma list).
+export function filtersOf(parts) {
+  if (!parts) return [];
+  if (Array.isArray(parts.filters)) {
+    return parts.filters.filter((s) => typeof s === 'string' && s !== '');
+  }
+  if (typeof parts.filter === 'string' && parts.filter !== '') {
+    return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+// Stash a `filters: string[]` (and back-compat `filter: string`) on a
+// parts object. Empty arrays drop both fields so the URL composer emits
+// the bare drill (no `filter=` param).
+export function setFilters(parts, list) {
+  const cleaned = (Array.isArray(list) ? list : []).filter((s) => typeof s === 'string' && s !== '');
+  if (cleaned.length > 0) {
+    parts.filters = cleaned;
+    parts.filter  = cleaned.join(',');
+  } else {
+    delete parts.filters;
+    delete parts.filter;
+  }
+  return parts;
+}
+
+// Crumb token for a drill-parts object. The token is the value the
+// user would land on if they clicked Back to this level: prefer `id`,
+// fall back to `c`. When filters accompany the anchor we encode them
+// as `<anchor>:<f1>+<f2>+…` so two drills that share the same anchor
+// but differ in their filters (e.g. the language tree, where every
+// level emits `c=lang` or `c=music` with a different `filter=l<NNN>`)
+// produce distinct, navigable crumbs (#89, #106). pivots / offsets
+// remain refinements that do not become crumbs.
+// Returns null when neither anchor is set (root view).
+export function crumbTokenFor(parts) {
+  if (!parts) return null;
+  let anchor = '';
+  if (typeof parts.id === 'string' && parts.id !== '') anchor = parts.id;
+  else if (typeof parts.c === 'string' && parts.c !== '') anchor = parts.c;
+  if (!anchor) return null;
+  const filters = filtersOf(parts);
+  if (filters.length > 0) {
+    return `${anchor}:${filters.join('+')}`;
+  }
+  return anchor;
+}
+
+// Inverse of crumbTokenFor: turn a crumb token back into the drill
+// parts the user should land on. Heuristic:
+//   - bare tokens matching /^[a-z]\d+$/ are guide_ids (`id=` anchor)
+//   - bare tokens otherwise are category short names (`c=`)
+//   - tokens with a `:f1+f2+…` suffix attach N filters to whichever
+//     anchor form applies (so `lang:l109` → `{c:'lang', filters:['l109']}`,
+//     `r101821:g26+l170` → `{id:'r101821', filters:['g26','l170']}`)
+export function partsFromCrumb(token) {
+  if (typeof token !== 'string' || token === '') return null;
+  const colonIdx = token.indexOf(':');
+  let anchor = token;
+  let filterRaw = '';
+  if (colonIdx >= 0) {
+    anchor = token.slice(0, colonIdx);
+    filterRaw = token.slice(colonIdx + 1);
+  }
+  if (!anchor) return null;
+  const parts = /^[a-z]\d+$/.test(anchor) ? { id: anchor } : { c: anchor };
+  if (filterRaw) {
+    const list = filterRaw.split('+').map((s) => s.trim()).filter(Boolean);
+    setFilters(parts, list);
+  }
+  return parts;
+}
+
+// A drill URL can carry any of {id, c, filter, pivot, offset}. The
+// presence of `id` or `c` is the load-bearing signal; the others
+// modify the drill. The URL's `filter=` may be comma-separated values
+// (multi-filter wire shape, #106); the resulting parts object carries
+// `filters: string[]` plus back-compat `filter: string`. Returns null
+// when neither anchor is set (root view).
+export function pickDrillParts(query) {
+  if (!query || (typeof query.id !== 'string' && typeof query.c !== 'string')) {
+    return null;
+  }
+  const out = {};
+  for (const key of ['id', 'c', 'pivot', 'offset']) {
+    if (typeof query[key] === 'string' && query[key] !== '') out[key] = query[key];
+  }
+  if (typeof query.filter === 'string' && query.filter !== '') {
+    const list = query.filter.split(',').map((s) => s.trim()).filter(Boolean);
+    setFilters(out, list);
+  }
+  return out;
+}
+
+// Display label for the drill crumb — a compact form of the parts.
+// `c=music&filter=l216` reads more usefully than just `music`. When
+// the filter is an lcode (`l<NNN>`) and we have a cached language
+// name for it, append the human form so end users get an at-a-glance
+// translation of the otherwise opaque numeric filter (#90). With
+// multi-filter drills (#106) the comma-joined wire value is shown;
+// a single-lcode filter still resolves to its language name.
+export function crumbLabelFor(parts) {
+  const segs = [];
+  const filters = filtersOf(parts);
+  const filterStr = filters.join(',');
+  if (parts.id) segs.push(parts.id);
+  if (parts.c)  segs.push(`c=${parts.c}`);
+  if (filterStr) segs.push(`filter=${filterStr}`);
+  if (parts.pivot)  segs.push(`pivot=${parts.pivot}`);
+  if (parts.offset) segs.push(`offset=${parts.offset}`);
+  let label = segs.join(' · ');
+  if (filters.length === 1 && /^l\d+$/.test(filters[0])) {
+    const name = lcodeLabel(filters[0]);
+    if (name) label += ` (${name})`;
+  }
+  return label;
+}
+
+// Compose the Back-button href. Pops the rightmost crumb and navigates
+// to it; the popped crumb keeps the remaining stack as its own `from=`.
+// An empty stack lands at #/browse (the root tabs view).
+export function backHrefFor(stack) {
+  if (!Array.isArray(stack) || stack.length === 0) return '#/browse';
+  const head = stack.slice(0, -1);
+  const tail = stack[stack.length - 1];
+  const parts = partsFromCrumb(tail);
+  if (!parts) return '#/browse';
+  // Always pass the trimmed crumb stack explicitly so we don't pick up
+  // a stale value of _childCrumbs (set later, after this Back-link is
+  // built — but we want backHref deterministic regardless of order).
+  return drillHashFor(parts, head);
+}
+
+// Initial page-header title before the API response arrives. Prefer
+// the cached label for this node's token; fall back to crumbLabelFor
+// so the user sees *something* during the load.
+//
+// Filter-bearing tokens (`<anchor>:<filter>`) try the bare anchor too:
+// the page IS the anchor node (just filtered), so a cached title for
+// `r101821` should surface as the h1 / current-crumb text for the
+// `r101821:g26` drill too. The filter surface is the badge, not the
+// title.
+export function initialHeaderTitle(parts, token) {
+  if (token) {
+    const cached = cache.get(`tunein.label.${token}`);
+    if (typeof cached === 'string' && cached !== '') return cached;
+    const colon = token.indexOf(':');
+    if (colon > 0) {
+      const bare = token.slice(0, colon);
+      const cachedBare = cache.get(`tunein.label.${bare}`);
+      if (typeof cachedBare === 'string' && cachedBare !== '') return cachedBare;
+    }
+  }
+  return crumbLabelFor(parts);
+}
+
+// ---- pill bar + inline trail (top of every drill body) -------------
+//
+// The pill bar replaces the old standalone Back link + standalone
+// crumb trail with a single horizontal row: a circular chevron-only
+// Back affordance leads, followed by an inline breadcrumb
+// `Browse › <Tab> › <Ancestor> › <Current>`. The current segment is
+// the bolded, non-link tail; earlier segments stay anchors whose
+// hashes match the ones the old trail emitted, so Back/forward
+// history continues to pop the same stack.
+//
+// Composition for the trail:
+//   1. literal `Browse` (entry-point anchor → `#/browse`)
+//   2. one anchor per crumb in the stack — stack[0] gets the
+//      TAB_LABEL_BY_TOKEN override when its bare anchor matches
+//      a tab token (`music` / `r0` / `lang`); other crumbs read
+//      from the cache / lcode catalogue / raw-token fallback
+//      ladder.
+//   3. the current node as a bolded non-link `<span>` with
+//      `aria-current="page"`.
+
+export function renderPillBar(parts, stack) {
+  const bar = document.createElement('div');
+  bar.className = 'browse-bar';
+
+  // Back chevron — circular pill, glyph only. aria-label carries the
+  // destination derived from backHrefFor (so it stays in sync with
+  // the popped target). When the destination is the root tabs view,
+  // we read "Back to Browse"; otherwise the destination crumb's
+  // label is used.
+  const back = document.createElement('a');
+  back.className = 'browse-bar__back';
+  back.href = backHrefFor(stack);
+  back.setAttribute('aria-label', backAriaLabel(stack));
+  // Marker for hydrateCrumbLabels to re-stamp the aria-label once the
+  // destination crumb's title resolves.
+  if (Array.isArray(stack) && stack.length > 0) {
+    back.dataset.backToken = stack[stack.length - 1];
+  }
+  back.appendChild(icon('chevron-left', 16));
+  bar.appendChild(back);
+
+  const trail = renderCrumbTrail(stack, parts);
+  bar.appendChild(trail);
+
+  // Active-filter badges — mounted in-bar, peers to the trail (#104,
+  // #106). One badge per filter in `parts.filters`; each carries the
+  // resolved filter label + a × close affordance that navigates to the
+  // same drill minus that filter only (the other filters + stack + id
+  // are preserved).
+  const badges = renderFilterBadges(parts, stack);
+  for (const badge of badges) bar.appendChild(badge);
+
+  // Sub-handle accessors for the drill frame (hydrateCrumbLabels
+  // mutates the trail anchors + the back aria-label in place).
+  bar._back = back;
+  bar._trail = trail;
+  // Back-compat: `_filter` points at the first badge so single-filter
+  // callers keep working. Multi-filter callers should read `_badges`.
+  bar._filter = badges[0] || null;
+  bar._badges = badges;
+  return bar;
+}
+
+// Build the active-filter badges for the pill bar. Returns an array
+// (possibly empty) of badge nodes — one per filter in `parts.filters`.
+// Each badge mounts as a peer of the trail inside the bar, carrying
+// the resolved filter label and a trailing × close affordance that
+// navigates to the same drill MINUS THIS ONE FILTER (the other
+// filters + stack + primary anchor are preserved). When all filters
+// are dropped, the URL reverts to the bare drill (#106).
+//
+// Label resolution order — same ladder hydrateCrumbLabels uses for
+// trail anchors:
+//   1. lcode catalogue for `lXXX` filters (instant, no fetch).
+//   2. cache lookup `tunein.label.<filter>` (a previous Describe /
+//      Browse landed and stashed the title).
+//   3. raw token while a one-shot Describe / Browse runs in the
+//      background; the badge text upgrades in place when the title
+//      resolves.
+export function renderFilterBadges(parts, stack) {
+  const filters = filtersOf(parts);
+  if (filters.length === 0) return [];
+  const stackArr = Array.isArray(stack) ? stack : [];
+  const out = [];
+  for (const filterToken of filters) {
+    out.push(buildFilterBadge(filterToken, parts, filters, stackArr));
+  }
+  return out;
+}
+
+// Build one badge node for `filterToken`, given the full filter list
+// and current parts / stack so the × close anchor can drop only this
+// filter while preserving the rest.
+function buildFilterBadge(filterToken, parts, filters, stack) {
+  const badge = document.createElement('span');
+  badge.className = 'browse-bar__filter';
+  badge.dataset.filterToken = filterToken;
+
+  const label = document.createElement('span');
+  label.className = 'browse-bar__filter-label';
+  label.textContent = initialFilterLabel(filterToken);
+  badge.appendChild(label);
+
+  // × close affordance — anchor that navigates to the same drill with
+  // this filter dropped (the others are preserved). When the last
+  // filter is removed the URL reverts to the bare drill.
+  const remaining = filters.filter((f) => f !== filterToken);
+  const stripped = Object.assign({}, parts);
+  setFilters(stripped, remaining);
+  const close = document.createElement('a');
+  close.className = 'browse-bar__filter-close';
+  close.setAttribute('href', drillHashFor(stripped, stack));
+  close.setAttribute('aria-label', 'Remove filter');
+  close.appendChild(icon('x', 12));
+  badge.appendChild(close);
+
+  // Stash sub-handles for the hydrator to patch the label in place.
+  badge._label = label;
+  badge._close = close;
+
+  // Kick off async label hydration when the initial label is still the
+  // raw token (no cache hit, no catalogue hit). The hydrator writes the
+  // resolved title back into the cache so subsequent navigations land
+  // pre-resolved.
+  if (label.textContent === filterToken) {
+    hydrateFilterLabel(filterToken, badge);
+  }
+
+  return badge;
+}
+
+// Back-compat shim: legacy callers expect a single badge node (or
+// null) for a single-filter drill. Wraps renderFilterBadges and
+// returns its first element. New code should consume the array form
+// directly via renderFilterBadges.
+export function renderFilterBadge(parts, stack) {
+  const badges = renderFilterBadges(parts, stack);
+  return badges.length > 0 ? badges[0] : null;
+}
+
+// Pick the best already-known label for a filter token without any
+// network work. Mirrors the trail's `initialCrumbLabel` ladder for the
+// filter-only case: lcode catalogue for `lXXX`, then the cache, then
+// the raw token as a last resort.
+function initialFilterLabel(filterToken) {
+  if (/^l\d+$/.test(filterToken)) {
+    const name = lcodeLabel(filterToken);
+    if (name) return name;
+  }
+  const cached = cache.get(`tunein.label.${filterToken}`);
+  if (typeof cached === 'string' && cached !== '') return cached;
+  return filterToken;
+}
+
+// One-shot label fetch for a filter token whose initial render is the
+// raw form. Lcode tokens are catalogue-only; everything else (gNNN /
+// cNNN / etc.) gets a Browse.ashx lookup, with Describe as a fallback
+// for entity prefixes. The badge's label updates in place once the
+// title resolves; failures stay silent (the raw token stays put).
+export async function hydrateFilterLabel(filterToken, badge) {
+  // Lcode catalogue is authoritative — never fall through to Describe
+  // for `lXXX`. If it didn't resolve in initialFilterLabel and the
+  // catalogue lands later, the LCODES_LOADED_EVENT listener (mounted
+  // by renderDrill) re-patches the badge.
+  if (/^l\d+$/.test(filterToken)) return;
+  let title = '';
+  try {
+    if (/^[spt]\d+$/.test(filterToken)) {
+      // Entity prefixes — Describe returns title in body[0].
+      const json = await tuneinDescribe({ id: filterToken });
+      const e = json && Array.isArray(json.body) && json.body[0];
+      if (e) {
+        if (typeof e.title === 'string' && e.title !== '') title = e.title;
+        else if (typeof e.name === 'string' && e.name !== '') title = e.name;
+      }
+    } else {
+      // Category / generic — Browse returns head.title.
+      const parts = /^[a-z]\d+$/.test(filterToken)
+        ? { id: filterToken }
+        : { c: filterToken };
+      const json = await tuneinBrowse(parts);
+      const t = json && json.head && json.head.title;
+      if (typeof t === 'string' && t !== '') title = t;
+    }
+  } catch (_err) {
+    return;
+  }
+  if (!title) return;
+  cache.set(`tunein.label.${filterToken}`, title, TTL_LABEL);
+  if (badge && badge._label) badge._label.textContent = title;
+}
+
+// Build the inline trail inside the pill bar. Always leads with the
+// literal `Browse` entry-point anchor; the bolded current segment is
+// appended when `currentParts` is provided (the drill case). Tests
+// can call with `currentParts = null` to render just the lineage —
+// the legacy ancestor-only shape used by the old standalone trail.
+
+export function renderCrumbTrail(stack, currentParts) {
+  const trail = document.createElement('nav');
+  trail.className = 'browse-bar__trail';
+  trail.setAttribute('aria-label', 'Breadcrumb');
+
+  // Defence-in-depth dedupe of consecutive identical tokens (#89). An
+  // old URL pasted from an earlier session could carry
+  // `from=lang,lang,lang` — render it as a single anchor rather than
+  // three identical ones.
+  const dedup = [];
+  if (Array.isArray(stack)) {
+    for (const token of stack) {
+      if (dedup.length === 0 || dedup[dedup.length - 1] !== token) dedup.push(token);
+    }
+  }
+
+  // Tail-dedupe against the current parts (#104). When the user clicks
+  // an end-of-page filter chip, the link appends the current id to
+  // `from=` AND keeps the same primary id (just adds `filter=…`). The
+  // stack's last crumb is then the same node as the current segment;
+  // rendering both produces a duplicated tail like
+  //   Browse › Location › … › Bayreuth › **Bayreuth**
+  // Two shapes count as a match:
+  //   - bare equality (`r101821` === `r101821`)
+  //   - the current token carries a filter while the stack tail does
+  //     not — current `r101821:g26` and stack tail `r101821` refer to
+  //     the same drill node. Drop the duplicate; the filter surface
+  //     is the badge, not a trail anchor.
+  if (currentParts && dedup.length > 0) {
+    const curTok = crumbTokenFor(currentParts);
+    if (curTok) {
+      const tail = dedup[dedup.length - 1];
+      const colon = curTok.indexOf(':');
+      const curAnchor = colon >= 0 ? curTok.slice(0, colon) : curTok;
+      if (tail === curTok || tail === curAnchor) dedup.pop();
+    }
+  }
+
+  // 1. literal Browse anchor — every trail starts here.
+  const browseA = document.createElement('a');
+  browseA.className = 'browse-bar__crumb';
+  browseA.setAttribute('href', '#/browse');
+  browseA.dataset.crumbRole = 'root';
+  browseA.textContent = 'Browse';
+  trail.appendChild(browseA);
+
+  // 2. one anchor per stack entry. stack[0] is the tab; its bare
+  // anchor maps via TAB_LABEL_BY_TOKEN.
+  for (let i = 0; i < dedup.length; i++) {
+    trail.appendChild(makeSeparator());
+    const token = dedup[i];
+    const parts = partsFromCrumb(token);
+    const a = document.createElement('a');
+    a.className = 'browse-bar__crumb';
+    a.dataset.crumbToken = token;
+    if (i === 0) a.dataset.crumbPosition = 'first';
+    if (parts) {
+      a.href = drillHashFor(parts, dedup.slice(0, i));
+    } else {
+      a.className += ' is-disabled';
+    }
+    a.textContent = initialCrumbLabel(token, parts, i === 0);
+    trail.appendChild(a);
+  }
+
+  // 3. current segment — bolded non-link tail. Skipped when no
+  // current parts are supplied (the legacy ancestor-only shape).
+  if (currentParts) {
+    trail.appendChild(makeSeparator());
+    const cur = document.createElement('span');
+    cur.className = 'browse-bar__crumb is-current';
+    cur.setAttribute('aria-current', 'page');
+    // The current segment is the drill's title; it's a separate seam
+    // from the cache labels (which are keyed by crumb token, not by
+    // the current page). Read the same h1-equivalent text we use for
+    // the page title row.
+    const curToken = crumbTokenFor(currentParts);
+    cur.textContent = initialHeaderTitle(currentParts, curToken);
+    if (curToken) cur.dataset.crumbToken = curToken;
+    trail.appendChild(cur);
+  }
+
+  return trail;
+}
+
+export function makeSeparator() {
+  const sep = document.createElement('span');
+  sep.className = 'browse-bar__sep';
+  sep.setAttribute('aria-hidden', 'true');
+  sep.textContent = '›'; // ›
+  return sep;
+}
+
+// Pick the best already-known label for a crumb token without doing
+// any network work. Order of preference for ancestors:
+//   - tab-token override (only at stack[0] — the entry-point tab)
+//   - cached label under `tunein.label.<token>` (from a previous
+//     resolve)
+//   - in-memory lcode catalogue (free for `<anchor>:l<NNN>` tokens)
+//   - raw token fallback
+// The async hydrateCrumbLabels path upgrades any token still
+// rendered as raw once its Describe / Browse lookup completes.
+export function initialCrumbLabel(token, parts, isFirstInStack) {
+  // The first crumb in the stack is the entry-point tab — render it
+  // with the tab's display label (`Genre` / `Location` / `Language`)
+  // rather than the cached API title ("Music" / "By Location" / "By
+  // Language"). Filter-bearing tokens (`lang:lXXX`) intentionally
+  // fall through to the catalogue path so they read as the language
+  // name, not "Language".
+  if (isFirstInStack) {
+    const bareAnchor = parts && typeof parts.id === 'string'
+      ? parts.id
+      : (parts && typeof parts.c === 'string' ? parts.c : '');
+    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
+    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) {
+      return TAB_LABEL_BY_TOKEN[bareAnchor];
+    }
+  }
+  const cached = cache.get(`tunein.label.${token}`);
+  if (typeof cached === 'string' && cached !== '') return cached;
+  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
+    const name = lcodeLabel(parts.filter);
+    if (name) return name;
+  }
+  return token;
+}
+
+// Compose the Back chevron's aria-label from the popped destination.
+// Empty stack → root tabs view ("Back to Browse"). Otherwise the
+// destination is the last crumb in the stack; prefer the resolved
+// label (cache / catalogue) and fall back to the raw token.
+export function backAriaLabel(stack) {
+  if (!Array.isArray(stack) || stack.length === 0) return 'Back to Browse';
+  const destToken = stack[stack.length - 1];
+  if (!destToken) return 'Back to Browse';
+  const destParts = partsFromCrumb(destToken);
+  // The last crumb in the stack is the trail's tail-before-current —
+  // it's an ancestor, not the entry-point tab, so isFirstInStack is
+  // only relevant when stack length is 1.
+  const label = initialCrumbLabel(destToken, destParts, stack.length === 1);
+  return `Back to ${label}`;
+}
+
+// ---- hydration: resolve raw tokens to human-readable labels --------
+
+// For every crumb in `stack` that lacks a cached label, fetch its
+// label in parallel (cap DESCRIBE_CONCURRENCY) and patch the trail
+// DOM in-place when the title arrives. Concurrency is bounded by
+// waiting for the oldest pending request to settle before issuing
+// the next one.
+//
+// Endpoint choice per token (the API doesn't expose a single "what
+// is this thing called?" call):
+//   - s / p / t prefix → Describe.ashx?id=<X>, title in body[0].
+//     These are real entities; Describe is the entity-detail endpoint.
+//   - everything else (g / c / r / l / m / a / n, plus plain words
+//     like `music` / `talk` / `sports` / `lang`) → Browse.ashx?id=<X>
+//     (or ?c=<X> for the plain-word case), title in head.title.
+//     Describe returns an empty body for these prefixes, so it
+//     can't serve as the label source. The issue text says "Describe",
+//     but the verified-on-Bo behaviour is that Describe head has
+//     {status} only; head.title comes from Browse. Pragmatic split.
+//
+// Tokens whose resolved title is blank stay rendered as raw IDs —
+// the documented final fallback from the issue spec.
+export async function hydrateCrumbLabels(stack, trailEl, backEl) {
+  if (!Array.isArray(stack) || stack.length === 0) return;
+  const todo = [];
+  for (const token of stack) {
+    if (!token) continue;
+    if (typeof cache.get(`tunein.label.${token}`) === 'string') continue;
+    todo.push(token);
+  }
+  if (todo.length === 0) return;
+
+  const inFlight = new Set();
+  for (const token of todo) {
+    if (inFlight.size >= DESCRIBE_CONCURRENCY) {
+      // Wait for any one to finish before issuing the next.
+      await Promise.race(inFlight);
+    }
+    const p = resolveLabelAndApply(token, trailEl, backEl, stack).finally(() => inFlight.delete(p));
+    inFlight.add(p);
+  }
+  // Drain the remaining wave so failures surface in dev tools.
+  await Promise.allSettled(Array.from(inFlight));
+}
+
+// Resolve a single crumb token to a human-readable label and patch
+// the trail. Picks the appropriate endpoint per prefix; falls through
+// silently when no label can be discovered.
+export async function resolveLabelAndApply(token, trailEl, backEl, stack) {
+  // Filter-bearing tokens (`<anchor>:l<NNN>`) resolve from the in-
+  // memory lcode catalogue without any network round-trip (#89, #90).
+  // We bypass the Describe / Browse fallbacks entirely — the
+  // catalogue is authoritative for language names.
+  const parts = partsFromCrumb(token);
+  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
+    const name = lcodeLabel(parts.filter);
+    if (name) {
+      cache.set(`tunein.label.${token}`, name, TTL_LABEL);
+      patchTrailCrumb(trailEl, token, name);
+      patchBackAria(backEl, stack, token, name);
+    }
+    return;
+  }
+
+  let title = '';
+  try {
+    if (/^[spt]\d+$/.test(token)) {
+      // Entity prefixes — Describe returns the canonical name in
+      // body[0]. Stations use `name`; shows / topics use `title`.
+      const json = await tuneinDescribe({ id: token });
+      const e = json && Array.isArray(json.body) && json.body[0];
+      if (e) {
+        if (typeof e.title === 'string' && e.title !== '') title = e.title;
+        else if (typeof e.name === 'string' && e.name !== '') title = e.name;
+      }
+    } else if (parts) {
+      // Category prefixes + plain words — Browse returns head.title.
+      // partsFromCrumb routes lowercase-letter+digit tokens through
+      // `id=` and letters-only tokens through `c=`.
+      const json = await tuneinBrowse(parts);
+      const t = json && json.head && json.head.title;
+      if (typeof t === 'string' && t !== '') title = t;
+    }
+  } catch (_err) {
+    // Network error / non-200 — give up silently. The trail keeps
+    // the raw-token rendering, which is the issue's documented
+    // last-resort fallback.
+    return;
+  }
+  if (!title) return;
+  cache.set(`tunein.label.${token}`, title, TTL_LABEL);
+  patchTrailCrumb(trailEl, token, title);
+  patchBackAria(backEl, stack, token, title);
+}
+
+// Find the trail anchor for `token` and rewrite its textContent. The
+// first-in-stack tab override stays sticky — we don't overwrite the
+// tab label with whatever the API returns for its node.
+export function patchTrailCrumb(trailEl, token, label) {
+  if (!trailEl || typeof trailEl.querySelector !== 'function') return;
+  const a = trailEl.querySelector(`[data-crumb-token="${cssEscape(token)}"]`);
+  if (!a) return;
+  // Skip if the rendered label already reflects the tab-token override
+  // (stack[0] is allowed to read as `Genre` / `Location` / `Language`
+  // — the cache write happens for the cold-load path but doesn't
+  // overwrite the override visually).
+  if (a.dataset && a.dataset.crumbPosition === 'first') {
+    const parts = partsFromCrumb(token);
+    const bareAnchor = parts && typeof parts.id === 'string'
+      ? parts.id
+      : (parts && typeof parts.c === 'string' ? parts.c : '');
+    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
+    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) return;
+  }
+  a.textContent = label;
+}
+
+// Re-stamp the Back chevron's aria-label when the destination crumb's
+// label resolves. Only fires when the resolving token matches the
+// last crumb in the stack (which is the popped destination). Honour
+// the tab-token override for a single-crumb stack so the popped
+// destination reads as "Back to Genre" rather than "Back to Music".
+export function patchBackAria(backEl, stack, token, label) {
+  if (!backEl) return;
+  if (!Array.isArray(stack) || stack.length === 0) return;
+  if (stack[stack.length - 1] !== token) return;
+  if (stack.length === 1) {
+    const parts = partsFromCrumb(token);
+    const bareAnchor = parts && typeof parts.id === 'string'
+      ? parts.id
+      : (parts && typeof parts.c === 'string' ? parts.c : '');
+    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
+    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) return;
+  }
+  backEl.setAttribute('aria-label', `Back to ${label}`);
+}
+
+// CSS.escape isn't available in xmldom (test) and the crumb tokens are
+// always [a-z0-9] anyway, but be defensive against any token shape the
+// API might surface in future.
+function cssEscape(s) {
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) =>
+    '\\' + ch.charCodeAt(0).toString(16) + ' ');
+}

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -493,15 +493,44 @@ function crumbTokenForParts(parts) {
 //   - the entry has no usable drill parts (no anchor → no crumb token)
 //   - the entry has no usable label text
 //
+// Terminal-entity rule (#117): for `station` / `topic` rows — audio
+// leaves whose `URL` is a `Tune.ashx?id=<sid>` form — strip filter
+// context from the cache token. The TuneIn service echoes the
+// parent cursor's scoping filter (e.g. `&filter=s` for "stations
+// only") back into every emitted row URL, including the leaf Tune
+// URLs where the filter has no functional meaning. Caching "Folk
+// Alley" under both `s10001` (page-0 visit) and `s10001:s`
+// (cursor-emitted page-1 visit) double-keys the same logical entity.
+// The entity name is identified by `guide_id`, not by how the user
+// arrived — so terminal entities cache under the bare anchor.
+//
+// Drill rows (categories / regions / shows) keep the combined token:
+// `r101821:g26` ("Bayreuth · Country") is a distinct page from
+// `r101821` ("Bayreuth"), with its own human label, so the filter
+// IS load-bearing state for those.
+//
 // Never fires a fetch — every value comes from data already in hand.
 export function primeLabelForEntry(entry) {
   if (!entry || typeof entry !== 'object') return;
   const text = typeof entry.text === 'string' ? entry.text.trim() : '';
   if (!text) return;
   const parts = drillPartsFor(entry);
-  const token = crumbTokenForParts(parts);
+  const kind = classifyOutline(entry);
+  const token = (kind === 'station' || kind === 'topic')
+    ? bareAnchorToken(parts)
+    : crumbTokenForParts(parts);
   if (!token) return;
   cache.set(`tunein.label.${token}`, text, TTL_LABEL);
+}
+
+// Anchor-only token (no filter suffix) — for caching terminal-entity
+// labels whose identity is fully determined by their guide_id. See
+// the #117 note on primeLabelForEntry.
+function bareAnchorToken(parts) {
+  if (!parts) return null;
+  if (typeof parts.id === 'string' && parts.id !== '') return parts.id;
+  if (typeof parts.c  === 'string' && parts.c  !== '') return parts.c;
+  return null;
 }
 
 // primeLabelForChip — same idea as primeLabelForEntry, but tailored to

--- a/admin/app/views/now-playing-data.js
+++ b/admin/app/views/now-playing-data.js
@@ -1,0 +1,131 @@
+// now-playing-data — topic-cache coordination for the now-playing view.
+//
+// Sibling of views/now-playing.js (deliberately flat, not under a
+// views/now-playing/ subfolder). Owns the data-flow concern the view
+// previously inlined: walking Browse(c=topics) JSON, priming the topic
+// caches, and resolving a topic id back to a human-readable label.
+//
+// The view imports these helpers; play-button.js writes the parent-show
+// cache via the same key helpers in transport-state.js so the two
+// agents stay in sync without sharing code.
+//
+// Everything here is a pure function over (json | topicId | np). No DOM
+// touches, no store reads — callers thread the now-playing snapshot
+// through `labelForTopic` so the data module is unit-testable without
+// mounting the view.
+
+import { tuneinBrowse } from '../api.js';
+import { cache, TTL_DRILL_HEAD } from '../tunein-cache.js';
+import { classifyOutline } from '../tunein-outline.js';
+import {
+  topicsKey,
+  topicNameKey,
+  extractGuideIdFromLocation,
+} from '../transport-state.js';
+
+// Pull the ordered list of topic guide_ids out of a Browse(c=topics)
+// JSON body. The body shape is either a flat list of topic outlines
+// or a single section container with `children` — handle both so the
+// caller doesn't have to inspect the response. Filters to t-prefix
+// rows (the only ones the firmware can resolve as a topic stream).
+export function extractTopicIds(json) {
+  const out = [];
+  const visit = (entry) => {
+    if (!entry || typeof entry !== 'object') return;
+    if (Array.isArray(entry.children)) {
+      for (const c of entry.children) visit(c);
+      return;
+    }
+    // Filter on classification (drops cursors, pivots, tombstones)
+    // AND on the t-prefix so a sibling station row in the same body
+    // doesn't poison the topics list.
+    const kind = classifyOutline(entry);
+    const gid = typeof entry.guide_id === 'string' ? entry.guide_id : '';
+    if (kind === 'topic' && /^t\d+$/.test(gid)) out.push(gid);
+  };
+  const body = json && Array.isArray(json.body) ? json.body : [];
+  for (const e of body) visit(e);
+  return out;
+}
+
+// #102: stash episode titles under tunein.topicname.<t<N>>. Same
+// traversal shape as extractTopicIds, isolated here so the search-
+// arrival path (lazyFetchTopicsList) gets the same priming the
+// browse-view drill already does.
+export function cacheTopicNames(json) {
+  const visit = (entry) => {
+    if (!entry || typeof entry !== 'object') return;
+    if (Array.isArray(entry.children)) {
+      for (const c of entry.children) visit(c);
+      return;
+    }
+    const gid = typeof entry.guide_id === 'string' ? entry.guide_id : '';
+    if (!/^t\d+$/.test(gid)) return;
+    const text = typeof entry.text === 'string' ? entry.text.trim() : '';
+    if (text) cache.set(topicNameKey(gid), text, TTL_DRILL_HEAD);
+  };
+  const body = json && Array.isArray(json.body) ? json.body : [];
+  for (const e of body) visit(e);
+}
+
+// #102: Resolve the episode title for a /play call's `name` field.
+// Source priority:
+//   1. `tunein.topicname.<t<N>>` — primed by the browse view + the
+//      lazy fetcher below; this is the canonical resolved title.
+//   2. The firmware's own <itemName> if it's already on this topic
+//      AND that name isn't itself the raw guide_id (defending
+//      against a stale state written by an earlier sid-fallback).
+// Falls back to the topic id as a last resort: #99 makes `name`
+// structurally required on playGuideId, so we always return a
+// string. The fallback is the known c9d8396 degrade (itemName
+// surfaces the sid); the topic-name primer in the browse drill +
+// the lazy fetcher below populate the cache so the fallback fires
+// only on a never-drilled, never-fetched topic — vanishingly rare
+// in practice.
+//
+// `np` is the now-playing snapshot the caller already has in hand —
+// passed in rather than read from the store so this helper is pure
+// and trivially unit-testable.
+export function labelForTopic(topicId, np) {
+  const cached = cache.get(topicNameKey(topicId));
+  if (typeof cached === 'string' && cached) return cached;
+  const location = np?.item?.location ?? null;
+  const itemName = np?.item?.name ?? null;
+  if (location
+      && extractGuideIdFromLocation(location) === topicId
+      && itemName
+      && itemName !== topicId) {
+    return itemName;
+  }
+  return topicId;
+}
+
+// Fan-out: lazy-fetch the topics list for `parentId` when it isn't
+// already cached. Used by the Prev/Next path when the user arrived
+// at a topic via search (no drill context). Idempotent — the cache
+// entry survives until TTL_DRILL_HEAD expires.
+export async function lazyFetchTopicsList(parentId) {
+  const key = topicsKey(parentId);
+  const cached = cache.get(key);
+  if (Array.isArray(cached)) return cached;
+  try {
+    const body = await tuneinBrowse({ c: 'topics', id: parentId });
+    const ids = extractTopicIds(body);
+    // #102: lift episode titles from the same body into the
+    // tunein.topicname.<t<N>> cache so the next Prev/Next can ship
+    // `name` to /play. The browse view's primer already does this
+    // on drill; this branch covers the search-arrival path.
+    cacheTopicNames(body);
+    if (ids.length >= 2) {
+      cache.set(key, ids, TTL_DRILL_HEAD);
+      return ids;
+    }
+    // Cache the empty / 1-entry result too so we don't refetch on
+    // every click, but flag the buttons as disabled by writing a
+    // sentinel (the classifier rejects length < 2 anyway).
+    cache.set(key, ids, TTL_DRILL_HEAD);
+    return ids;
+  } catch (_err) {
+    return [];
+  }
+}

--- a/admin/app/views/now-playing.js
+++ b/admin/app/views/now-playing.js
@@ -11,7 +11,7 @@
 
 import { html, mount, defineView } from '../dom.js';
 import { store } from '../state.js';
-import { speakerNowPlaying, presetsList, playGuideId, tuneinBrowse } from '../api.js';
+import { speakerNowPlaying, presetsList, playGuideId } from '../api.js';
 import { setArt } from '../art.js';
 import { hashHue } from '../tint.js';
 import * as actions from '../actions/index.js';
@@ -25,61 +25,15 @@ import {
   extractGuideIdFromLocation,
   parentKey,
   topicsKey,
-  topicNameKey,
 } from '../transport-state.js';
-import { cache, TTL_DRILL_HEAD } from '../tunein-cache.js';
-import { classifyOutline } from '../tunein-outline.js';
+import { cache } from '../tunein-cache.js';
 import { showToast } from '../toast.js';
 import { pickTrackLine, pickMetaLine, humaniseSourceKey } from '../np-derive.js';
+import { labelForTopic, lazyFetchTopicsList } from './now-playing-data.js';
 
 const POLL_MS = 2000;
 const PRESET_SLOTS = 6;
 const LONG_PRESS_MS = 600;
-
-// Pull the ordered list of topic guide_ids out of a Browse(c=topics)
-// JSON body. The body shape is either a flat list of topic outlines
-// or a single section container with `children` — handle both so the
-// caller doesn't have to inspect the response. Filters to t-prefix
-// rows (the only ones the firmware can resolve as a topic stream).
-function extractTopicIds(json) {
-  const out = [];
-  const visit = (entry) => {
-    if (!entry || typeof entry !== 'object') return;
-    if (Array.isArray(entry.children)) {
-      for (const c of entry.children) visit(c);
-      return;
-    }
-    // Filter on classification (drops cursors, pivots, tombstones)
-    // AND on the t-prefix so a sibling station row in the same body
-    // doesn't poison the topics list.
-    const kind = classifyOutline(entry);
-    const gid = typeof entry.guide_id === 'string' ? entry.guide_id : '';
-    if (kind === 'topic' && /^t\d+$/.test(gid)) out.push(gid);
-  };
-  const body = json && Array.isArray(json.body) ? json.body : [];
-  for (const e of body) visit(e);
-  return out;
-}
-
-// #102: stash episode titles under tunein.topicname.<t<N>>. Same
-// traversal shape as extractTopicIds, isolated here so the search-
-// arrival path (lazyFetchTopicsList) gets the same priming the
-// browse-view drill already does.
-function cacheTopicNames(json) {
-  const visit = (entry) => {
-    if (!entry || typeof entry !== 'object') return;
-    if (Array.isArray(entry.children)) {
-      for (const c of entry.children) visit(c);
-      return;
-    }
-    const gid = typeof entry.guide_id === 'string' ? entry.guide_id : '';
-    if (!/^t\d+$/.test(gid)) return;
-    const text = typeof entry.text === 'string' ? entry.text.trim() : '';
-    if (text) cache.set(topicNameKey(gid), text, TTL_DRILL_HEAD);
-  };
-  const body = json && Array.isArray(json.body) ? json.body : [];
-  for (const e of body) visit(e);
-}
 
 // Thin shim so the existing renderName callsites stay one-arg. The
 // canonical helper lives in np-title.js and is shared with the shell
@@ -512,67 +466,6 @@ export default defineView({
       }
     }
 
-    // resolve a topic id to a human label out of the cached topics
-    // list. The list itself stores ids only by default, but we also
-    // #102: Resolve the episode title for a /play call's `name` field.
-    // Source priority:
-    //   1. `tunein.topicname.<t<N>>` — primed by the browse view + the
-    //      lazy fetcher below; this is the canonical resolved title.
-    //   2. The firmware's own <itemName> if it's already on this topic
-    //      AND that name isn't itself the raw guide_id (defending
-    //      against a stale state written by an earlier sid-fallback).
-    // Falls back to the topic id as a last resort: #99 makes `name`
-    // structurally required on playGuideId, so we always return a
-    // string. The fallback is the known c9d8396 degrade (itemName
-    // surfaces the sid); the topic-name primer in the browse drill +
-    // the lazy fetcher below populate the cache so the fallback fires
-    // only on a never-drilled, never-fetched topic — vanishingly rare
-    // in practice.
-    function labelForTopic(topicId) {
-      const cached = cache.get(topicNameKey(topicId));
-      if (typeof cached === 'string' && cached) return cached;
-      const np = store.state.speaker.nowPlaying;
-      const location = np?.item?.location ?? null;
-      const itemName = np?.item?.name ?? null;
-      if (location
-          && extractGuideIdFromLocation(location) === topicId
-          && itemName
-          && itemName !== topicId) {
-        return itemName;
-      }
-      return topicId;
-    }
-
-    // Fan-out: lazy-fetch the topics list for `parentId` when it isn't
-    // already cached. Used by the Prev/Next path when the user arrived
-    // at a topic via search (no drill context). Idempotent — the cache
-    // entry survives until TTL_DRILL_HEAD expires.
-    async function lazyFetchTopicsList(parentId) {
-      const key = topicsKey(parentId);
-      const cached = cache.get(key);
-      if (Array.isArray(cached)) return cached;
-      try {
-        const body = await tuneinBrowse({ c: 'topics', id: parentId });
-        const ids = extractTopicIds(body);
-        // #102: lift episode titles from the same body into the
-        // tunein.topicname.<t<N>> cache so the next Prev/Next can ship
-        // `name` to /play. The browse view's primer already does this
-        // on drill; this branch covers the search-arrival path.
-        cacheTopicNames(body);
-        if (ids.length >= 2) {
-          cache.set(key, ids, TTL_DRILL_HEAD);
-          return ids;
-        }
-        // Cache the empty / 1-entry result too so we don't refetch on
-        // every click, but flag the buttons as disabled by writing a
-        // sentinel (the classifier rejects length < 2 anyway).
-        cache.set(key, ids, TTL_DRILL_HEAD);
-        return ids;
-      } catch (_err) {
-        return [];
-      }
-    }
-
     function onPrev() { onSkip('prev'); }
     function onNext() { onSkip('next'); }
 
@@ -615,7 +508,7 @@ export default defineView({
 
       skipInFlight = true;
       try {
-        const result = await playGuideId(targetId, labelForTopic(targetId));
+        const result = await playGuideId(targetId, labelForTopic(targetId, np));
         if (!result || !result.ok) {
           showToast('Could not skip episode');
         }

--- a/admin/cgi-bin/api/v1/refresh-all
+++ b/admin/cgi-bin/api/v1/refresh-all
@@ -30,31 +30,15 @@
 
 set -u
 
+# shellcheck source=../../lib/cgi-common.sh
+. "$(dirname "$0")/../../lib/cgi-common.sh"
+
 SPEAKER_BASE='http://localhost:8090'
 RESOLVER_DIR='/mnt/nv/resolver/bmx/tunein/v1/playback/station'
 TUNEIN_BASE='http://opml.radiotime.com'
 TUNEIN_MAGIC='formats=mp3,aac&lang=de-de&render=json'
 UA='Bose_Lisa/27.0.6'
 TMPDIR_FALLBACK="${TMPDIR:-/tmp}"
-
-emit_error() {
-    printf 'Status: %s\r\n' "$1"
-    printf 'Content-Type: application/json; charset=utf-8\r\n'
-    printf 'Cache-Control: no-store\r\n'
-    printf 'Access-Control-Allow-Origin: *\r\n'
-    printf '\r\n'
-    printf '{"ok":false,"error":{"code":"%s","message":"%s"}}\n' "$2" "$3"
-}
-
-emit_ok_headers() {
-    printf 'Status: 200 OK\r\n'
-    printf 'Content-Type: application/json; charset=utf-8\r\n'
-    printf 'Cache-Control: no-store\r\n'
-    printf 'Access-Control-Allow-Origin: *\r\n'
-    printf 'Access-Control-Allow-Methods: POST, OPTIONS\r\n'
-    printf 'Access-Control-Allow-Headers: Content-Type\r\n'
-    printf '\r\n'
-}
 
 if [ "${REQUEST_METHOD:-GET}" = 'OPTIONS' ]; then
     printf 'Status: 204 No Content\r\n'

--- a/admin/cgi-bin/api/v1/speaker
+++ b/admin/cgi-bin/api/v1/speaker
@@ -17,44 +17,14 @@
 
 set -u
 
-emit_error() {
-    status="$1"
-    code="$2"
-    msg="$3"
-    printf 'Status: %s\r\n' "$status"
-    printf 'Content-Type: application/json; charset=utf-8\r\n'
-    printf 'Cache-Control: no-store\r\n'
-    printf 'Access-Control-Allow-Origin: *\r\n'
-    printf '\r\n'
-    printf '{"ok":false,"error":{"code":"%s","message":"%s"}}\n' "$code" "$msg"
-}
+# shellcheck source=../../lib/cgi-common.sh
+. "$(dirname "$0")/../../lib/cgi-common.sh"
 
 # CSRF guard: same-origin or no cross-origin header (curl) → pass.
-# Cross-origin mutating request → 403.
-#
-# busybox httpd v1.19.4 does not forward the Origin header as HTTP_ORIGIN,
-# so we check HTTP_REFERER (which busybox DOES forward). A Referer that
-# starts with a different origin than HTTP_HOST is treated as cross-origin.
-# Absent Referer (curl, same-origin navigations) passes freely.
+# Cross-origin mutating request → 403. Idempotent verbs aren't guarded;
+# the browser's default CORS rules already block cross-origin reads.
 case "${REQUEST_METHOD:-GET}" in
-    POST|PUT|DELETE)
-        case "${HTTP_ORIGIN:-}" in
-            "http://${HTTP_HOST:-}"|"https://${HTTP_HOST:-}"|"")
-                ;;
-            *)
-                emit_error 403 CSRF_BLOCKED \
-                    "cross-origin mutating request rejected"
-                exit 0
-                ;;
-        esac
-        REFERER_HOST=$(printf '%s' "${HTTP_REFERER:-}" | \
-            sed 's|^https\{0,1\}://||; s|/.*||')
-        if [ -n "$REFERER_HOST" ] && [ "$REFERER_HOST" != "${HTTP_HOST:-}" ]; then
-            emit_error 403 CSRF_BLOCKED \
-                "cross-origin mutating request rejected"
-            exit 0
-        fi
-        ;;
+    POST|PUT|DELETE) csrf_guard || exit 0 ;;
 esac
 
 # PATH_INFO is everything after the script name. e.g. for

--- a/admin/cgi-bin/api/v1/tunein
+++ b/admin/cgi-bin/api/v1/tunein
@@ -34,6 +34,9 @@ RENDER='render=json'
 # and TuneIn's OPML endpoint serves the same body over either scheme.
 BASE='http://opml.radiotime.com'
 
+# shellcheck source=../../lib/cgi-common.sh
+. "$(dirname "$0")/../../lib/cgi-common.sh"
+
 # CORS preflight: respond and exit before doing any work.
 if [ "${REQUEST_METHOD:-GET}" = 'OPTIONS' ]; then
   printf 'Status: 204 No Content\r\n'
@@ -43,16 +46,6 @@ if [ "${REQUEST_METHOD:-GET}" = 'OPTIONS' ]; then
   printf '\r\n'
   exit 0
 fi
-
-emit_error() {
-  printf 'Status: %s\r\n' "$1"
-  printf 'Content-Type: application/json; charset=utf-8\r\n'
-  printf 'Cache-Control: no-store\r\n'
-  printf 'Access-Control-Allow-Origin: *\r\n'
-  printf '\r\n'
-  printf '{"error":"%s"}\n' "$2"
-  exit 0
-}
 
 # Resolve PATH_INFO to a TuneIn endpoint + extra query string.
 # QUERY_STRING is forwarded for /search and /browse (the only routes
@@ -74,7 +67,8 @@ case "$PI" in
     SID=${PI#/probe/}
     URL="$BASE/Tune.ashx?$MAGIC_TUNE&$RENDER&id=$SID" ;;
   *)
-    emit_error '404 Not Found' 'unknown tunein route' ;;
+    emit_error '404 Not Found' UNKNOWN_ROUTE 'unknown tunein route'
+    exit 0 ;;
 esac
 
 # Headers first, then body. busybox wget writes the body to stdout

--- a/admin/cgi-bin/lib/cgi-common.sh
+++ b/admin/cgi-bin/lib/cgi-common.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=sh
+#
+# cgi-common.sh — helpers shared by every CGI under admin/cgi-bin/api/v1.
+# Sourced via `. "$(dirname "$0")/../../lib/cgi-common.sh"`.
+#
+# This file is sourced, not executed. It must:
+#   - Be busybox-shell safe (no bash-isms, no `local`).
+#   - Tolerate `set -u` in the caller — every referenced env var defaults
+#     via `${VAR:-}` and every helper documents its inputs.
+#   - Not run any code at source time apart from defining functions.
+#
+# Error envelope: `{ ok:false, error: { code:"SHOUTY", message:"..." } }`.
+# Every CGI uses this shape so the SPA's cgiErrorMessage() helper
+# handles them uniformly.
+#
+# CSRF: busybox httpd v1.19.4 does not always forward Origin as
+# HTTP_ORIGIN on this firmware, so the guard ALSO checks HTTP_REFERER
+# (which busybox does forward). Centralised here so the six CGIs can't
+# drift apart.
+
+# --- error envelope ------------------------------------------------
+#
+# emit_error <status-line> <SHOUTY_CODE> <message>
+emit_error() {
+    cc_status="$1"
+    cc_code="$2"
+    cc_msg="$3"
+    printf 'Status: %s\r\n' "$cc_status"
+    printf 'Content-Type: application/json; charset=utf-8\r\n'
+    printf 'Cache-Control: no-store\r\n'
+    printf 'Access-Control-Allow-Origin: *\r\n'
+    printf '\r\n'
+    cc_msg_j=$(json_escape "$cc_msg")
+    printf '{"ok":false,"error":{"code":"%s","message":"%s"}}\n' \
+        "$cc_code" "$cc_msg_j"
+}
+
+# emit_ok_headers [<allow-methods>]   — success preamble; caller writes
+# the body. Default allow-methods is "POST, OPTIONS"; pass an alternative
+# string for CGIs that expose more verbs (e.g. presets allows GET).
+emit_ok_headers() {
+    printf 'Status: 200 OK\r\n'
+    printf 'Content-Type: application/json; charset=utf-8\r\n'
+    printf 'Cache-Control: no-store\r\n'
+    printf 'Access-Control-Allow-Origin: *\r\n'
+    printf 'Access-Control-Allow-Methods: %s\r\n' "${1:-POST, OPTIONS}"
+    printf 'Access-Control-Allow-Headers: Content-Type\r\n'
+    printf '\r\n'
+}
+
+# --- CSRF guard ----------------------------------------------------
+#
+# A request whose Origin OR Referer points at a different host than
+# HTTP_HOST is rejected with 403 CSRF_BLOCKED. Empty Origin/Referer
+# (curl, same-origin GET-style) passes freely.
+#
+# Returns 0 if the caller should continue, 1 if a 403 has already been
+# emitted (caller exits). Honour: the caller is responsible for the
+# `exit 0` — this helper does not call exit so it's safe under `set -u`.
+#
+# Method gating stays in callers because not every CGI mutates. The
+# canonical site-call for a mutating endpoint is:
+#   case "${REQUEST_METHOD:-GET}" in
+#       POST|PUT|DELETE) csrf_guard || exit 0 ;;
+#   esac
+csrf_guard() {
+    case "${HTTP_ORIGIN:-}" in
+        "http://${HTTP_HOST:-}"|"https://${HTTP_HOST:-}"|"")
+            ;;
+        *)
+            emit_error 403 CSRF_BLOCKED \
+                "cross-origin mutating request rejected"
+            return 1
+            ;;
+    esac
+    cc_ref_host=$(printf '%s' "${HTTP_REFERER:-}" | \
+        sed 's|^https\{0,1\}://||; s|/.*||')
+    if [ -n "$cc_ref_host" ] && [ "$cc_ref_host" != "${HTTP_HOST:-}" ]; then
+        emit_error 403 CSRF_BLOCKED \
+            "cross-origin mutating request rejected"
+        return 1
+    fi
+    return 0
+}
+
+# --- escape helpers ------------------------------------------------
+
+# JSON-escape a string for embedding as a JSON value. Handles the two
+# JSON-mandatory escapes plus the common control chars. Doesn't escape
+# Unicode — inputs are short and ASCII in practice.
+json_escape() {
+    printf '%s' "$1" \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+        | tr '\n' ' ' \
+        | tr '\r' ' ' \
+        | tr '\t' ' '
+}
+
+# XML-escape a string for embedding in an attribute or element value.
+xml_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\\&apos;/g"
+}
+
+# --- request-body slurp -------------------------------------------
+#
+# slurp_body <dest>
+# Read up to CONTENT_LENGTH bytes from stdin into <dest>. Truncates the
+# file if CONTENT_LENGTH is missing or zero. Callers own the file
+# (path + trap-driven cleanup).
+slurp_body() {
+    cc_cl="${CONTENT_LENGTH:-0}"
+    if [ "$cc_cl" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$cc_cl" of="$1" 2>/dev/null
+    else
+        : >"$1"
+    fi
+}

--- a/admin/cgi-bin/lib/playback.sh
+++ b/admin/cgi-bin/lib/playback.sh
@@ -1,28 +1,33 @@
 # shellcheck shell=sh
 #
-# playback.sh — shared helpers for the playback-family CGIs
-# (/play, /preview, /presets). Sourced via `. "$(dirname "$0")/../../lib/playback.sh"`.
+# playback.sh — playback-family helpers (/play, /preview, /presets).
+# Sourced via `. "$(dirname "$0")/../../lib/playback.sh"`.
+#
+# Cross-CGI primitives (emit_error, csrf_guard, slurp_body, json_escape,
+# xml_escape, emit_ok_headers) live in cgi-common.sh, which this file
+# sources. The helpers here are playback-specific: the /select POST,
+# the <ContentItem> XML builder, the JSON body-field parsers, and the
+# small `emit_ok_empty` / CORS-preflight conveniences used by the three
+# playback CGIs.
 #
 # This file is sourced, not executed. It must:
 #   - Be busybox-shell safe (no bash-isms, no `local`).
-#   - Tolerate `set -u` in the caller — every referenced env var defaults
-#     via `${VAR:-}` and every helper documents its inputs.
+#   - Tolerate `set -u` in the caller.
 #   - Not run any code at source time apart from defining functions and
-#     a small set of read-only constants. Callers compose handlers.
-#
-# Error envelope: `{ ok:false, error: { code:"SHOUTY", message:"..." } }`.
-# All three playback CGIs use this shape so the SPA's cgiErrorMessage()
-# helper handles them uniformly. The /play CGI's pre-0.4.2 flat envelope
-# (`{ok:false, error:"off-air"}`) is gone — see admin/app/error-messages.js
-# for the client-side mapping that absorbs both shapes during transition.
-#
-# CSRF: busybox httpd v1.19.4 does not always forward Origin as
-# HTTP_ORIGIN on this firmware, so we ALSO check HTTP_REFERER (which
-# busybox does forward). Same shape as cgi-bin/api/v1/speaker — kept in
-# one place here so the three playback CGIs can't drift apart again.
+#     a small set of read-only constants.
+
+# Pull in the cross-CGI primitives unless the caller has already done so
+# (e.g. a unit test that sourced cgi-common.sh first from a different
+# location). Probing for one of its definitions keeps the source path
+# resolution simple: `$(dirname "$0")` is the calling CGI's directory,
+# so `../../lib/` reaches cgi-bin/lib/ both for /play and /preview etc.
+# shellcheck source=cgi-common.sh
+if ! command -v emit_error >/dev/null 2>&1; then
+    . "$(dirname "$0")/../../lib/cgi-common.sh"
+fi
 
 # Resolver path for per-station Bose JSON. Same constant in all three
-# CGIs pre-extract; centralising it here avoids the three-copy drift.
+# playback CGIs pre-extract; centralised here to avoid drift.
 # shellcheck disable=SC2034  # consumed by sourcing CGIs
 PLAYBACK_RESOLVER_DIR='/mnt/nv/resolver/bmx/tunein/v1/playback/station'
 
@@ -33,41 +38,9 @@ PLAYBACK_SPEAKER_BASE='http://localhost:8090'
 # Fallback for $TMPDIR when busybox httpd doesn't set one.
 PLAYBACK_TMPDIR="${TMPDIR:-/tmp}"
 
-# --- envelope emitters ---------------------------------------------
+# --- success-envelope conveniences --------------------------------
 #
-# emit_error <status-line> <SHOUTY_CODE> <message>
-# emit_error_ok <SHOUTY_CODE> <message>   (200 OK with ok:false — used
-#                                           for the placeholder-filter
-#                                           outcomes that aren't really
-#                                           transport errors)
-#
-# emit_ok_headers   — print the success preamble; caller writes the body.
-# emit_ok_empty     — `{ok:true}` shorthand (preview / presets POST).
-
-emit_error() {
-    pb_status="$1"
-    pb_code="$2"
-    pb_msg="$3"
-    printf 'Status: %s\r\n' "$pb_status"
-    printf 'Content-Type: application/json; charset=utf-8\r\n'
-    printf 'Cache-Control: no-store\r\n'
-    printf 'Access-Control-Allow-Origin: *\r\n'
-    printf '\r\n'
-    pb_msg_j=$(json_escape "$pb_msg")
-    printf '{"ok":false,"error":{"code":"%s","message":"%s"}}\n' \
-        "$pb_code" "$pb_msg_j"
-}
-
-emit_ok_headers() {
-    printf 'Status: 200 OK\r\n'
-    printf 'Content-Type: application/json; charset=utf-8\r\n'
-    printf 'Cache-Control: no-store\r\n'
-    printf 'Access-Control-Allow-Origin: *\r\n'
-    printf 'Access-Control-Allow-Methods: %s\r\n' "${1:-POST, OPTIONS}"
-    printf 'Access-Control-Allow-Headers: Content-Type\r\n'
-    printf '\r\n'
-}
-
+# emit_ok_empty — `{ok:true}` shorthand (preview / presets POST).
 emit_ok_empty() {
     emit_ok_headers "${1:-POST, OPTIONS}"
     printf '{"ok":true}\n'
@@ -75,7 +48,7 @@ emit_ok_empty() {
 
 # --- CORS preflight ------------------------------------------------
 #
-# Sources call this BEFORE doing any work and exit if it returns 0.
+# Callers invoke this BEFORE any work and exit if it returns 0.
 # Returns 0 (i.e. "handled, please exit") iff REQUEST_METHOD == OPTIONS.
 # The allowed-methods string is per-CGI (presets includes GET, the
 # others don't), so callers pass it explicitly.
@@ -89,59 +62,6 @@ handle_cors_preflight() {
     printf 'Access-Control-Allow-Headers: Content-Type\r\n'
     printf '\r\n'
     return 0
-}
-
-# --- CSRF guard ----------------------------------------------------
-#
-# Same shape as cgi-bin/api/v1/speaker: a request whose Origin OR
-# Referer points at a different host than HTTP_HOST is rejected with
-# 403 CSRF_BLOCKED. Empty Origin/Referer (curl, same-origin GET-style)
-# passes freely.
-#
-# Returns 0 if the caller should continue, 1 if a 403 has already been
-# emitted (caller exits). Honour: the caller is responsible for the
-# `exit 0` — this helper does not call exit so it's safe under `set -u`.
-csrf_guard() {
-    case "${HTTP_ORIGIN:-}" in
-        "http://${HTTP_HOST:-}"|"https://${HTTP_HOST:-}"|"")
-            ;;
-        *)
-            emit_error 403 CSRF_BLOCKED \
-                "cross-origin mutating request rejected"
-            return 1
-            ;;
-    esac
-    pb_ref_host=$(printf '%s' "${HTTP_REFERER:-}" | \
-        sed 's|^https\{0,1\}://||; s|/.*||')
-    if [ -n "$pb_ref_host" ] && [ "$pb_ref_host" != "${HTTP_HOST:-}" ]; then
-        emit_error 403 CSRF_BLOCKED \
-            "cross-origin mutating request rejected"
-        return 1
-    fi
-    return 0
-}
-
-# --- escape helpers ------------------------------------------------
-
-# JSON-escape a string for embedding as a JSON value. Handles the two
-# JSON-mandatory escapes plus the common control chars. Doesn't escape
-# Unicode — inputs are short and ASCII in practice.
-json_escape() {
-    printf '%s' "$1" \
-        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
-        | tr '\n' ' ' \
-        | tr '\r' ' ' \
-        | tr '\t' ' '
-}
-
-# XML-escape a string for embedding in an attribute or element value.
-xml_escape() {
-    printf '%s' "$1" | sed \
-        -e 's/&/\&amp;/g' \
-        -e 's/</\&lt;/g' \
-        -e 's/>/\&gt;/g' \
-        -e 's/"/\&quot;/g' \
-        -e "s/'/\\&apos;/g"
 }
 
 # --- JSON field parsers --------------------------------------------
@@ -193,21 +113,6 @@ json_object_field() {
             out = out "\n"
         }
     '
-}
-
-# --- request-body slurp -------------------------------------------
-#
-# slurp_body <dest>
-# Read up to CONTENT_LENGTH bytes from stdin into <dest>. Truncates the
-# file if CONTENT_LENGTH is missing or zero. Callers own the file
-# (path + trap-driven cleanup).
-slurp_body() {
-    pb_cl="${CONTENT_LENGTH:-0}"
-    if [ "$pb_cl" -gt 0 ] 2>/dev/null; then
-        dd bs=1 count="$pb_cl" of="$1" 2>/dev/null
-    else
-        : >"$1"
-    fi
 }
 
 # --- ContentItem builder ------------------------------------------

--- a/admin/e2e/tests/mobile-overflow.spec.js
+++ b/admin/e2e/tests/mobile-overflow.spec.js
@@ -1,0 +1,67 @@
+// Issue #119 — mobile-viewport horizontal-overflow guard.
+//
+// All primary views (Now / Search / Browse / Settings) and the
+// station detail view must render without forcing a horizontal
+// scrollbar at a phone-sized viewport. The default viewport in
+// playwright.config.js is already 390x844 (iPhone 13); this spec
+// pins that contract so a stray fixed-width descendant or an
+// unbroken long label can't regress the layout again.
+//
+// The selector list in the container-query block at style.css
+// §1642 (`.np-view`, `[data-view="browse"]`, `[data-view="search"]`,
+// `.station-detail`, `.preset-modal`) is the load-bearing carrier
+// set — those wrapper classes / data-view attributes must stay on
+// the root of each view so the @container rules can fire. This
+// spec is the regression net for both that carrier set and the
+// defensive `overflow-x: hidden` on `.shell-body`.
+
+import { test, expect } from './_setup.js';
+
+// Tolerate sub-pixel rounding: a `scrollWidth` one CSS pixel beyond
+// `innerWidth` is the noisy boundary cross-browser rendering
+// produces and is not a real overflow.
+async function assertNoHorizontalOverflow(page) {
+  const { scrollWidth, innerWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    innerWidth:  window.innerWidth,
+  }));
+  expect(
+    scrollWidth,
+    `documentElement.scrollWidth (${scrollWidth}) exceeded window.innerWidth (${innerWidth}) — horizontal scroll on a phone viewport`,
+  ).toBeLessThanOrEqual(innerWidth + 1);
+}
+
+test('now-playing view fits the 390px viewport without horizontal overflow', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'load' });
+  await page.waitForSelector('[data-view="now-playing"]', { timeout: 15_000 });
+  await assertNoHorizontalOverflow(page);
+});
+
+test('search view fits the 390px viewport without horizontal overflow', async ({ page }) => {
+  await page.goto('/#/search', { waitUntil: 'load' });
+  await page.waitForSelector('[data-view="search"]', { timeout: 15_000 });
+  await assertNoHorizontalOverflow(page);
+});
+
+test('browse view (root tabs) fits the 390px viewport without horizontal overflow', async ({ page }) => {
+  await page.goto('/#/browse', { waitUntil: 'load' });
+  await page.waitForSelector('[data-view="browse"]', { timeout: 15_000 });
+  // Give the first tab's API body a moment to mount — the row
+  // entries are where most width risk lives (long station names).
+  await expect(page.locator('.browse-loading')).toHaveCount(0, { timeout: 15_000 });
+  await assertNoHorizontalOverflow(page);
+});
+
+test('settings view fits the 390px viewport without horizontal overflow', async ({ page }) => {
+  await page.goto('/#/settings', { waitUntil: 'load' });
+  await page.waitForSelector('[data-view="settings"]', { timeout: 15_000 });
+  await assertNoHorizontalOverflow(page);
+});
+
+test('station detail view fits the 390px viewport without horizontal overflow', async ({ page }) => {
+  // s12345 (KEXP) — the same known-real sid used by
+  // station-redirect.spec.js to assert the strict matcher.
+  await page.goto('/#/station/s12345', { waitUntil: 'load' });
+  await page.waitForSelector('[data-view="station"]', { timeout: 15_000 });
+  await assertNoHorizontalOverflow(page);
+});

--- a/admin/style.css
+++ b/admin/style.css
@@ -2003,6 +2003,12 @@ select.settings-input {
 
 .shell-body {
   overflow-y: auto;
+  /* Belt-and-braces: a stray wide descendant (long unbreakable label,
+     fixed-width artwork) must never force the whole shell to scroll
+     horizontally on a phone viewport. The container-query block at
+     §1642 narrows per-component layouts; this is the safety net for
+     anything those rules don't cover. Issue #119. */
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   padding: 0.75rem 1rem 1rem;
   max-width: 720px;
@@ -3033,6 +3039,12 @@ select.settings-input {
 a.browse-bar__crumb {
   text-decoration: none;
   color: var(--fg);
+  /* Long station names ("Bayerischer Rundfunk - Bayern 1") must wrap
+     inside the crumb rather than force the trail wider than its
+     parent. `anywhere` kicks in only when the segment can't fit on
+     a line otherwise. Issue #119. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 a.browse-bar__crumb:hover { text-decoration: underline; }
@@ -3054,6 +3066,11 @@ a.browse-bar__crumb:focus-visible {
   color: var(--fg);
   font-weight: 600;
   cursor: default;
+  /* Same wrap policy as the link crumbs above — the current segment
+     is often the longest text in the trail (full station / show
+     name) and must not push the trail past the viewport. Issue #119. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .browse-bar__crumb.is-current:hover { text-decoration: none; }

--- a/admin/test/fixtures/dom-shim.js
+++ b/admin/test/fixtures/dom-shim.js
@@ -640,6 +640,13 @@ export function ev(type, init = {}) {
 
 // sessionStorage stub — install once. Files that want to inspect or
 // reset between tests can grab the underlying store via the export.
+//
+// The shim is installed at module-evaluation time below so that any
+// production module imported transitively through this file (e.g.
+// tunein-cache.js, which captures `sessionStorage` once at load) sees
+// a working backing store. Node < 22 has no built-in sessionStorage,
+// so without this top-level install the cache silently no-ops on the
+// CI runner (Node 20) while passing locally on Node ≥ 22.
 let _sessionStore = null;
 export function installSessionStorage() {
   if (_sessionStore) return _sessionStore;
@@ -652,6 +659,7 @@ export function installSessionStorage() {
   };
   return _sessionStore;
 }
+installSessionStorage();
 
 // fetch stub — never-resolving promise. Override per-test by reassigning
 // globalThis.fetch after the dom-shim import.

--- a/admin/test/fixtures/tunein-drill/g79-page0.tunein.json
+++ b/admin/test/fixtures/tunein-drill/g79-page0.tunein.json
@@ -1,0 +1,91 @@
+{
+  "head": {
+    "title": "Folk",
+    "status": "200"
+  },
+  "body": [
+    {
+      "element": "outline",
+      "text": "Stations",
+      "key": "stations",
+      "children": [
+        {
+          "element": "outline",
+          "type": "audio",
+          "text": "Folk Alley",
+          "URL": "http://opml.radiotime.com/Tune.ashx?id=s10001",
+          "bitrate": "128",
+          "reliability": "98",
+          "guide_id": "s10001",
+          "subtext": "The best in folk music",
+          "genre_id": "g79",
+          "formats": "mp3",
+          "item": "station",
+          "image": "http://cdn-profiles.tunein.com/s10001/images/logoq.jpg?t=1",
+          "now_playing_id": "s10001",
+          "preset_id": "s10001"
+        },
+        {
+          "element": "outline",
+          "type": "audio",
+          "text": "Celtic Music Radio",
+          "URL": "http://opml.radiotime.com/Tune.ashx?id=s10002",
+          "bitrate": "128",
+          "reliability": "29",
+          "guide_id": "s10002",
+          "subtext": "Glasgow, UK",
+          "genre_id": "g79",
+          "formats": "mp3",
+          "item": "station",
+          "image": "http://cdn-profiles.tunein.com/s10002/images/logoq.jpg?t=1",
+          "now_playing_id": "s10002",
+          "preset_id": "s10002"
+        },
+        {
+          "element": "outline",
+          "type": "link",
+          "text": "More Stations",
+          "URL": "http://opml.radiotime.com/Browse.ashx?offset=2&id=g79&filter=s",
+          "key": "nextStations"
+        }
+      ]
+    },
+    {
+      "element": "outline",
+      "text": "Shows",
+      "key": "shows",
+      "children": [
+        {
+          "element": "outline",
+          "type": "link",
+          "text": "The Folk Show",
+          "URL": "http://opml.radiotime.com/Browse.ashx?id=p20001",
+          "guide_id": "p20001",
+          "item": "show",
+          "image": "http://cdn-profiles.tunein.com/p20001/images/logoq.jpg?t=1"
+        }
+      ]
+    },
+    {
+      "element": "outline",
+      "text": "Related",
+      "key": "related",
+      "children": [
+        {
+          "element": "outline",
+          "type": "link",
+          "text": "Country",
+          "URL": "http://opml.radiotime.com/Browse.ashx?id=g80",
+          "key": "pivotGenre"
+        },
+        {
+          "element": "outline",
+          "type": "link",
+          "text": "Bluegrass",
+          "URL": "http://opml.radiotime.com/Browse.ashx?id=g81",
+          "key": "pivotGenre"
+        }
+      ]
+    }
+  ]
+}

--- a/admin/test/fixtures/tunein-drill/g79-page1.tunein.json
+++ b/admin/test/fixtures/tunein-drill/g79-page1.tunein.json
@@ -1,0 +1,56 @@
+{
+  "head": {
+    "title": "More Stations - Folk",
+    "status": "200"
+  },
+  "body": [
+    {
+      "element": "outline",
+      "type": "audio",
+      "text": "Radio Folk Forever",
+      "URL": "http://opml.radiotime.com/Tune.ashx?id=s10003&filter=s",
+      "bitrate": "192",
+      "reliability": "85",
+      "guide_id": "s10003",
+      "subtext": "Folk anthems 24/7",
+      "genre_id": "g79",
+      "formats": "mp3",
+      "item": "station",
+      "image": "http://cdn-profiles.tunein.com/s10003/images/logoq.jpg?t=1",
+      "now_playing_id": "s10003",
+      "preset_id": "s10003"
+    },
+    {
+      "element": "outline",
+      "type": "audio",
+      "text": "Sligo Folk Radio",
+      "URL": "http://opml.radiotime.com/Tune.ashx?id=s10004&filter=s",
+      "bitrate": "128",
+      "reliability": "92",
+      "guide_id": "s10004",
+      "subtext": "From the West of Ireland",
+      "genre_id": "g79",
+      "formats": "mp3",
+      "item": "station",
+      "image": "http://cdn-profiles.tunein.com/s10004/images/logoq.jpg?t=1",
+      "now_playing_id": "s10004",
+      "preset_id": "s10004"
+    },
+    {
+      "element": "outline",
+      "type": "audio",
+      "text": "Folk Alley",
+      "URL": "http://opml.radiotime.com/Tune.ashx?id=s10001&filter=s",
+      "bitrate": "128",
+      "reliability": "98",
+      "guide_id": "s10001",
+      "subtext": "The best in folk music (re-rank)",
+      "genre_id": "g79",
+      "formats": "mp3",
+      "item": "station",
+      "image": "http://cdn-profiles.tunein.com/s10001/images/logoq.jpg?t=1",
+      "now_playing_id": "s10001",
+      "preset_id": "s10001"
+    }
+  ]
+}

--- a/admin/test/test_browse_crumbs.js
+++ b/admin/test/test_browse_crumbs.js
@@ -22,9 +22,12 @@ const {
   renderPillBar,
   renderFilterBadge,
   renderFilterBadges,
-  renderEntry,
   backHrefFor,
   crumbLabelFor,
+} = await import('../app/views/browse/crumbs.js');
+
+const {
+  renderEntry,
   _setChildCrumbsForTest,
 } = await import('../app/views/browse.js');
 

--- a/admin/test/test_browse_outline.js
+++ b/admin/test/test_browse_outline.js
@@ -356,6 +356,72 @@ test('primeLabelForEntry emits a `<anchor>:<filter>` combined token for filter-b
   tc.cache.invalidate('tunein.label.r101821:g26');
 });
 
+// --- issue #117: parasitic filter context on terminal entities ---------
+//
+// The TuneIn cursor URL for a section carries the parent's scoping
+// filter (`&filter=s` for a "stations only" cursor on a genre page).
+// The service echoes that filter back into every row URL on the
+// follow-on page, including `Tune.ashx?id=s<NNN>&filter=s` for leaf
+// stations where the filter has no functional meaning. The cache
+// key for a terminal entity is its identity — `guide_id` alone —
+// not the arrival path. The bare-anchor token rule keeps page-0 and
+// page-N visits of the same station from double-keying the cache.
+
+test('primeLabelForEntry strips parasitic filter context from station URLs (#117)', async () => {
+  const tc = await import('../app/tunein-cache.js');
+  tc.cache.invalidate('tunein.label.s10003');
+  tc.cache.invalidate('tunein.label.s10003:s');
+  // The wire shape the TuneIn service emits for cursor-page stations:
+  // a Tune URL with the parent cursor's `filter=s` echoed in.
+  primeLabelForEntry({
+    type: 'audio',
+    guide_id: 's10003',
+    text: 'Radio Folk Forever',
+    URL: 'http://opml.radiotime.com/Tune.ashx?id=s10003&filter=s',
+  });
+  assert.equal(tc.cache.get('tunein.label.s10003'), 'Radio Folk Forever',
+    'station label caches under the bare guide_id');
+  assert.equal(tc.cache.get('tunein.label.s10003:s'), undefined,
+    'no double-key under the parasitic filter token');
+  tc.cache.invalidate('tunein.label.s10003');
+});
+
+test('primeLabelForEntry strips parasitic filter context from topic URLs (#117)', async () => {
+  const tc = await import('../app/tunein-cache.js');
+  tc.cache.invalidate('tunein.label.t40001');
+  tc.cache.invalidate('tunein.label.t40001:s');
+  // Topics classify as `topic` and tune via Tune.ashx — same parasitic
+  // filter inheritance applies.
+  primeLabelForEntry({
+    type: 'link',
+    item: 'topic',
+    guide_id: 't40001',
+    text: 'Episode 42',
+    URL: 'http://opml.radiotime.com/Tune.ashx?id=t40001&filter=s',
+  });
+  assert.equal(tc.cache.get('tunein.label.t40001'), 'Episode 42',
+    'topic label caches under the bare guide_id');
+  assert.equal(tc.cache.get('tunein.label.t40001:s'), undefined,
+    'no double-key under the parasitic filter token');
+  tc.cache.invalidate('tunein.label.t40001');
+});
+
+test('primeLabelForEntry keeps the combined token for filter-bearing drill rows (#117)', async () => {
+  const tc = await import('../app/tunein-cache.js');
+  tc.cache.invalidate('tunein.label.r101821:g26');
+  // Drill rows whose URL carries a filter encode legitimate state
+  // (e.g. "Bayreuth filtered by Country" is a distinct page from
+  // bare "Bayreuth"), so the combined token rule from #106 stands.
+  primeLabelForEntry({
+    type: 'link',
+    text: 'Bayreuth · Country',
+    URL: 'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=g26',
+  });
+  assert.equal(tc.cache.get('tunein.label.r101821:g26'), 'Bayreuth · Country',
+    'filter-bearing drill row keeps the combined cache token');
+  tc.cache.invalidate('tunein.label.r101821:g26');
+});
+
 test('primeLabelForEntry skips entries with no usable label or drill target', async () => {
   const tc = await import('../app/tunein-cache.js');
   // No text → no write

--- a/admin/test/test_cgi_common/test_cgi_common_lib.sh
+++ b/admin/test/test_cgi_common/test_cgi_common_lib.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+#
+# test_cgi_common_lib — unit tests for admin/cgi-bin/lib/cgi-common.sh.
+#
+# Sources the library directly (so it runs anywhere, no live speaker
+# required) and exercises the pure helpers: json_escape, xml_escape,
+# slurp_body, csrf_guard, emit_error.
+#
+# Run with: sh admin/test/test_cgi_common/test_cgi_common_lib.sh
+# Exits non-zero on any failure.
+
+set -u
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+LIB="$THIS_DIR/../../cgi-bin/lib/cgi-common.sh"
+
+if [ ! -f "$LIB" ]; then
+    printf 'fixture missing: %s\n' "$LIB" >&2
+    exit 1
+fi
+
+# shellcheck source=../../cgi-bin/lib/cgi-common.sh
+. "$LIB"
+
+ok=0
+fail=0
+
+assert_eq() {
+    label=$1; expected=$2; actual=$3
+    if [ "$expected" = "$actual" ]; then
+        printf '  [ OK ] %s\n' "$label"
+        ok=$((ok + 1))
+    else
+        printf '  [FAIL] %s\n    expected: %s\n    actual:   %s\n' \
+            "$label" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+printf '\n=== xml_escape ===\n'
+assert_eq 'amp+lt+gt' '&amp;&lt;&gt;' "$(xml_escape '&<>')"
+assert_eq 'quote+apos' '&quot;&apos;' "$(xml_escape "\"'")"
+assert_eq 'plain text untouched' 'Fresh Air' "$(xml_escape 'Fresh Air')"
+
+printf '\n=== json_escape ===\n'
+assert_eq 'backslash escaped first' '\\' "$(json_escape '\')"
+assert_eq 'double-quote escaped' '\"' "$(json_escape '"')"
+assert_eq 'plain text untouched' 'hello world' "$(json_escape 'hello world')"
+
+printf '\n=== slurp_body ===\n'
+# CONTENT_LENGTH=0 → empty file (busybox httpd quirks fall here too).
+TMP="${TMPDIR:-/tmp}/cgi-common-test.$$"
+trap 'rm -f "$TMP"' EXIT INT TERM
+CONTENT_LENGTH=0 slurp_body "$TMP" </dev/null
+[ ! -s "$TMP" ] && {
+    printf '  [ OK ] %s\n' 'zero-length body produces empty file'
+    ok=$((ok + 1))
+} || {
+    printf '  [FAIL] %s\n' 'zero-length body produces empty file'
+    fail=$((fail + 1))
+}
+
+# Non-zero CONTENT_LENGTH copies that many bytes from stdin.
+printf 'abcdef' | CONTENT_LENGTH=6 slurp_body "$TMP"
+contents=$(cat "$TMP")
+assert_eq 'CONTENT_LENGTH=6 captures 6 bytes' 'abcdef' "$contents"
+
+printf '\n=== csrf_guard: same-origin Origin passes ===\n'
+# Capture stdout of csrf_guard via a subshell — if it emits a 403
+# envelope we'll see it; on pass it produces nothing and returns 0.
+out=$(HTTP_HOST='localhost' HTTP_ORIGIN='http://localhost' HTTP_REFERER='' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'|rc=0'*) printf '  [ OK ] %s\n' 'same-origin Origin accepted'
+                ok=$((ok + 1)) ;;
+    *)         printf '  [FAIL] %s\n    out: %s\n' 'same-origin Origin accepted' "$out"
+                fail=$((fail + 1)) ;;
+esac
+
+# Same-origin via https scheme should also pass.
+out=$(HTTP_HOST='admin.local' HTTP_ORIGIN='https://admin.local' HTTP_REFERER='' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'|rc=0'*) printf '  [ OK ] %s\n' 'same-origin https Origin accepted'
+                ok=$((ok + 1)) ;;
+    *)         printf '  [FAIL] %s\n    out: %s\n' 'same-origin https Origin accepted' "$out"
+                fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== csrf_guard: cross-origin Origin rejected with CSRF_BLOCKED ===\n'
+out=$(HTTP_HOST='localhost' HTTP_ORIGIN='http://evil.example' HTTP_REFERER='' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'Status: 403'*'CSRF_BLOCKED'*'|rc=1'*)
+        printf '  [ OK ] %s\n' 'cross-origin Origin → 403 + rc=1'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    out: %s\n' 'cross-origin Origin → 403 + rc=1' "$out"
+        fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== csrf_guard: cross-origin Referer rejected (busybox quirk) ===\n'
+# busybox httpd v1.19.4 doesn't always forward Origin, so the guard
+# falls back to Referer. A cross-origin Referer with empty Origin
+# must still be blocked.
+out=$(HTTP_HOST='localhost' HTTP_ORIGIN='' HTTP_REFERER='http://evil.example/page' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'CSRF_BLOCKED'*'|rc=1'*)
+        printf '  [ OK ] %s\n' 'cross-origin Referer → 403 + rc=1'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    out: %s\n' 'cross-origin Referer → 403 + rc=1' "$out"
+        fail=$((fail + 1)) ;;
+esac
+
+# Mismatched Referer host MUST reject even when Origin is empty.
+out=$(HTTP_HOST='speaker.lan' HTTP_ORIGIN='' HTTP_REFERER='http://other.host/path?q=1' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'CSRF_BLOCKED'*'|rc=1'*)
+        printf '  [ OK ] %s\n' 'mismatched Referer host → 403 + rc=1'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    out: %s\n' 'mismatched Referer host → 403 + rc=1' "$out"
+        fail=$((fail + 1)) ;;
+esac
+
+# Same-host Referer (browser navigation) must pass.
+out=$(HTTP_HOST='speaker.lan' HTTP_ORIGIN='' HTTP_REFERER='http://speaker.lan/admin/' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'|rc=0'*) printf '  [ OK ] %s\n' 'same-host Referer accepted'
+                ok=$((ok + 1)) ;;
+    *)         printf '  [FAIL] %s\n    out: %s\n' 'same-host Referer accepted' "$out"
+                fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== csrf_guard: absent Origin+Referer (curl) passes ===\n'
+out=$(HTTP_HOST='localhost' HTTP_ORIGIN='' HTTP_REFERER='' \
+    csrf_guard 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'|rc=0'*) printf '  [ OK ] %s\n' 'curl-style (no headers) accepted'
+                ok=$((ok + 1)) ;;
+    *)         printf '  [FAIL] %s\n    out: %s\n' 'curl-style (no headers) accepted' "$out"
+                fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== csrf_guard: GET bypasses (method gating in callers) ===\n'
+# The guard itself is method-agnostic; callers only invoke it for
+# mutating methods. Simulate the canonical call-site dispatch in a
+# helper function so we can assert the GET path emits nothing and
+# returns 0 without ever entering csrf_guard.
+gated_csrf() {
+    case "${REQUEST_METHOD:-GET}" in
+        POST|PUT|DELETE) csrf_guard || return 1 ;;
+    esac
+    return 0
+}
+out=$(REQUEST_METHOD='GET' HTTP_HOST='localhost' \
+    HTTP_ORIGIN='http://evil.example' HTTP_REFERER='' \
+    gated_csrf 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *CSRF_BLOCKED*)
+        printf '  [FAIL] %s\n    out: %s\n' 'GET should bypass CSRF entirely' "$out"
+        fail=$((fail + 1)) ;;
+    *'|rc=0'*)
+        printf '  [ OK ] %s\n' 'GET with cross-origin Origin bypasses CSRF'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    out: %s\n' 'GET with cross-origin Origin bypasses CSRF' "$out"
+        fail=$((fail + 1)) ;;
+esac
+
+# And the corollary: POST with cross-origin Origin DOES trigger
+# CSRF_BLOCKED through the same dispatch.
+out=$(REQUEST_METHOD='POST' HTTP_HOST='localhost' \
+    HTTP_ORIGIN='http://evil.example' HTTP_REFERER='' \
+    gated_csrf 2>&1; printf '|rc=%d' $?)
+case "$out" in
+    *'CSRF_BLOCKED'*'|rc=1'*)
+        printf '  [ OK ] %s\n' 'POST with cross-origin Origin triggers CSRF_BLOCKED'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    out: %s\n' 'POST with cross-origin Origin triggers CSRF_BLOCKED' "$out"
+        fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== emit_error: envelope shape matches existing CGIs ===\n'
+env=$(emit_error '400 Bad Request' INVALID_ID 'bad id' 2>&1)
+case "$env" in
+    *'Status: 400 Bad Request'*'"ok":false'*'"error":{"code":"INVALID_ID","message":"bad id"}'*)
+        printf '  [ OK ] %s\n' 'structured error envelope (status + JSON shape)'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    env: %s\n' 'structured error envelope (status + JSON shape)' "$env"
+        fail=$((fail + 1)) ;;
+esac
+
+# Headers must include Content-Type, Cache-Control, CORS.
+case "$env" in
+    *'Content-Type: application/json'*'Cache-Control: no-store'*'Access-Control-Allow-Origin: *'*)
+        printf '  [ OK ] %s\n' 'error envelope carries Content-Type / Cache-Control / CORS'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    env: %s\n' 'error envelope carries Content-Type / Cache-Control / CORS' "$env"
+        fail=$((fail + 1)) ;;
+esac
+
+# A message with a double-quote must round-trip safely as JSON.
+env=$(emit_error '500' WRITE_FAILED 'oh "noes"' 2>&1)
+case "$env" in
+    *'\"noes\"'*) printf '  [ OK ] %s\n' 'message double-quotes escaped'
+                  ok=$((ok + 1)) ;;
+    *)            printf '  [FAIL] %s\n    env: %s\n' 'message double-quotes escaped' "$env"
+                  fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== emit_ok_headers: success preamble ===\n'
+hdr=$(emit_ok_headers 2>&1)
+case "$hdr" in
+    *'Status: 200 OK'*'Content-Type: application/json'*'Access-Control-Allow-Methods: POST, OPTIONS'*)
+        printf '  [ OK ] %s\n' 'default allow-methods is POST, OPTIONS'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    hdr: %s\n' 'default allow-methods is POST, OPTIONS' "$hdr"
+        fail=$((fail + 1)) ;;
+esac
+
+hdr=$(emit_ok_headers 'GET, POST, OPTIONS' 2>&1)
+case "$hdr" in
+    *'Access-Control-Allow-Methods: GET, POST, OPTIONS'*)
+        printf '  [ OK ] %s\n' 'caller-supplied allow-methods override'
+        ok=$((ok + 1)) ;;
+    *)
+        printf '  [FAIL] %s\n    hdr: %s\n' 'caller-supplied allow-methods override' "$hdr"
+        fail=$((fail + 1)) ;;
+esac
+
+printf '\n=== Summary: %d ok, %d failed ===\n' "$ok" "$fail"
+
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi

--- a/admin/test/test_field_contracts.js
+++ b/admin/test/test_field_contracts.js
@@ -1,0 +1,301 @@
+// Per-field contract tests.
+//
+// For every FIELDS row with {path, tag, parseEl}, drive a fixture XML
+// body through xmlGet -> parseEl -> applyEntry via reconcileField, then
+// assert the resulting state.speaker[name] shape. The custom-fetcher row
+// (presets) is exercised separately: stub the row's fetcher with a
+// fixture JSON envelope and assert the apply() side-effect.
+//
+// The point of going through reconcileField (not parseEl in isolation) is
+// to lock in the end-to-end seam every speaker field crosses: a single
+// REST round-trip, a single applyEntry call, a single store.touch.
+// test_speaker_xml.js already covers parseEl-in-isolation; this file
+// covers the FIELDS-registry contract for the dispatch/reconcile path.
+//
+// Run: node --test admin/test
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { DOMParser as XmldomDOMParser } from '@xmldom/xmldom';
+globalThis.DOMParser = class extends XmldomDOMParser {
+  constructor() { super({ onError: () => {} }); }
+};
+
+import { FIELDS, reconcileField } from '../app/speaker-state.js';
+
+const HERE     = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures', 'api');
+
+async function fixture(name) {
+  return readFile(join(FIXTURES, name), 'utf8');
+}
+
+// One representative fixture per FIELDS row. The XML body must wrap the
+// row's `tag` so xmlGet's first-descendant lookup resolves cleanly.
+const FIXTURE_FOR_FIELD = {
+  info:          'info.xml',
+  nowPlaying:    'now-playing-tunein.xml',
+  volume:        'volume.xml',
+  sources:       'sources.xml',
+  bass:          'bass.xml',
+  balance:       'balance.xml',
+  dspMonoStereo: 'dsp-mono-stereo.xml',
+  zone:          'zone-master.xml',
+  bluetooth:     'bluetooth-info-empty.xml',
+  network:       'network-info.xml',
+  recents:       'recents.xml',
+  systemTimeout: 'systemtimeout.xml',
+};
+
+// Per-row contract: minimal assertions on the applied state shape.
+// Each entry returns nothing — assertion throws on failure.
+const CONTRACT_FOR_FIELD = {
+  info(state) {
+    const v = state.speaker.info;
+    assert.ok(v, 'info applied');
+    assert.equal(typeof v.deviceID, 'string');
+    assert.equal(typeof v.name, 'string');
+    assert.equal(typeof v.type, 'string');
+    assert.equal(typeof v.firmwareVersion, 'string');
+  },
+  nowPlaying(state) {
+    const v = state.speaker.nowPlaying;
+    assert.ok(v, 'nowPlaying applied');
+    assert.equal(typeof v.source, 'string');
+    assert.ok(v.item && typeof v.item === 'object', 'nowPlaying.item is an object');
+    assert.equal(typeof v.playStatus, 'string');
+  },
+  volume(state) {
+    const v = state.speaker.volume;
+    assert.ok(v, 'volume applied');
+    assert.equal(typeof v.targetVolume, 'number');
+    assert.equal(typeof v.actualVolume, 'number');
+    assert.equal(typeof v.muteEnabled, 'boolean');
+  },
+  sources(state) {
+    const v = state.speaker.sources;
+    assert.ok(Array.isArray(v), 'sources is an array');
+    assert.ok(v.length > 0, 'sources non-empty for the canonical fixture');
+    const first = v[0];
+    assert.equal(typeof first.source, 'string');
+    assert.equal(typeof first.status, 'string');
+    assert.equal(typeof first.isLocal, 'boolean');
+  },
+  bass(state) {
+    const v = state.speaker.bass;
+    assert.ok(v, 'bass applied');
+    assert.equal(typeof v.targetBass, 'number');
+    assert.equal(typeof v.actualBass, 'number');
+  },
+  balance(state) {
+    const v = state.speaker.balance;
+    assert.ok(v, 'balance applied');
+    assert.equal(typeof v.targetBalance, 'number');
+    assert.equal(typeof v.actualBalance, 'number');
+  },
+  dspMonoStereo(state) {
+    const v = state.speaker.dspMonoStereo;
+    assert.ok(v, 'dspMonoStereo applied');
+    assert.ok(v.mode === 'mono' || v.mode === 'stereo', 'mode is mono|stereo');
+  },
+  zone(state) {
+    const v = state.speaker.zone;
+    assert.ok(v, 'zone applied');
+    assert.equal(typeof v.master, 'string');
+    assert.equal(typeof v.isMaster, 'boolean');
+    assert.ok(Array.isArray(v.members));
+  },
+  bluetooth(state) {
+    const v = state.speaker.bluetooth;
+    assert.ok(v, 'bluetooth applied');
+    assert.equal(typeof v.macAddress, 'string');
+  },
+  network(state) {
+    const v = state.speaker.network;
+    assert.ok(v, 'network applied');
+    assert.equal(typeof v.macAddress, 'string');
+    assert.equal(typeof v.ssid, 'string');
+    assert.equal(typeof v.ipAddress, 'string');
+  },
+  recents(state) {
+    const v = state.speaker.recents;
+    assert.ok(Array.isArray(v), 'recents is an array');
+  },
+  systemTimeout(state) {
+    const v = state.speaker.systemTimeout;
+    assert.ok(v, 'systemTimeout applied');
+    assert.equal(typeof v.enabled, 'boolean');
+    assert.equal(typeof v.minutes, 'number');
+  },
+};
+
+function makeStore() {
+  const state = { speaker: {}, ws: {}, caches: {}, ui: {} };
+  const touched = [];
+  return {
+    state,
+    touch(key) { touched.push(key); },
+    _touched: touched,
+  };
+}
+
+// Install a fetch stub keyed by absolute path; returns a restorer.
+function installFetchStub(bodyByPath) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const path = typeof url === 'string' ? url : String(url);
+    const body = bodyByPath[path];
+    if (body == null) throw new Error(`unmocked fetch: ${path}`);
+    return { ok: true, status: 200, text: async () => body };
+  };
+  return () => { globalThis.fetch = original; };
+}
+
+// Override an entry's fetcher for the duration of fn (presets exception).
+function withFetcher(name, fetcher, fn) {
+  const entry = FIELDS.find((f) => f.name === name);
+  const original = entry.fetcher;
+  entry.fetcher = fetcher;
+  const restore = () => { entry.fetcher = original; };
+  const result = fn();
+  if (result && typeof result.then === 'function') {
+    return result.finally(restore);
+  }
+  restore();
+  return result;
+}
+
+// --- Parametric XML-row contract ------------------------------------
+
+const XML_ROWS = FIELDS.filter(
+  (f) => typeof f.path === 'string' &&
+         typeof f.tag === 'string' &&
+         typeof f.parseEl === 'function',
+);
+
+// Track which rows we cover so a new field shows up as a coverage gap.
+const COVERED = new Set();
+
+for (const row of XML_ROWS) {
+  test(`field contract: '${row.name}' — fixture XML drives parseEl → applyEntry → state.speaker.${row.name}`, async () => {
+    const fixtureName = FIXTURE_FOR_FIELD[row.name];
+    assert.ok(fixtureName, `no fixture mapped for '${row.name}' — add to FIXTURE_FOR_FIELD`);
+
+    const contract = CONTRACT_FOR_FIELD[row.name];
+    assert.equal(typeof contract, 'function',
+      `no contract for '${row.name}' — add to CONTRACT_FOR_FIELD`);
+
+    const body = await fixture(fixtureName);
+    const url  = `/cgi-bin/api/v1${row.path}`;
+    const restore = installFetchStub({ [url]: body });
+    try {
+      const store = makeStore();
+      await reconcileField(store, row.name);
+      assert.equal(store._touched.length, 1, 'touch called exactly once on success');
+      assert.equal(store._touched[0], 'speaker');
+      contract(store.state);
+      COVERED.add(row.name);
+    } finally {
+      restore();
+    }
+  });
+}
+
+// Guard: assert FIXTURE_FOR_FIELD covers every XML row (and only XML
+// rows). Drift trips the guard — either add a fixture for a new field
+// or remove an obsolete entry.
+test('FIXTURE_FOR_FIELD matches the XML rows in FIELDS', () => {
+  const xmlNames = XML_ROWS.map((r) => r.name).sort();
+  const mapped   = Object.keys(FIXTURE_FOR_FIELD).sort();
+  assert.deepEqual(mapped, xmlNames,
+    'FIXTURE_FOR_FIELD must list exactly the XML rows in FIELDS');
+});
+
+// Guard: at the end of the run, every XML row reported a covered contract.
+// The "parametric" tests above register a row only on a successful
+// run, so a registry-vs-fixture skew shows up here as a missing entry.
+test('every XML FIELDS row exercised a contract', () => {
+  const xmlNames = XML_ROWS.map((r) => r.name).sort();
+  const covered  = Array.from(COVERED).sort();
+  assert.deepEqual(covered, xmlNames,
+    'all XML FIELDS rows must run a contract test');
+});
+
+// --- Custom-fetcher row: presets ------------------------------------
+
+test('field contract: presets — JSON envelope drives apply → state.speaker.presets', () =>
+  withFetcher('presets', async () => ({
+    ok: true,
+    data: [
+      { slot: 1, source: 'TUNEIN', type: 'stationurl', location: '/v1/s1', itemName: 'R1', art: '' },
+      { slot: 2, source: 'TUNEIN', type: 'stationurl', location: '/v1/s2', itemName: 'R2', art: '' },
+    ],
+  }), async () => {
+    const store = makeStore();
+    await reconcileField(store, 'presets');
+
+    const v = store.state.speaker.presets;
+    assert.ok(Array.isArray(v), 'presets is an array');
+    assert.equal(v.length, 2);
+    assert.equal(v[0].slot, 1);
+    assert.equal(v[0].itemName, 'R1');
+    assert.equal(v[1].slot, 2);
+    assert.equal(store._touched.length, 1, 'single touch');
+  }),
+);
+
+test('field contract: presets — envelope with ok:false leaves presets unset', () =>
+  withFetcher('presets', async () => ({ ok: false, data: null }), async () => {
+    const store = makeStore();
+    store.state.speaker.presets = null;
+    await reconcileField(store, 'presets');
+
+    // apply() guards on env.ok && Array.isArray(env.data); a non-ok
+    // envelope is a no-op on state, but the envelope itself is a
+    // non-null value, so reconcileField does call store.touch.
+    assert.equal(store.state.speaker.presets, null);
+  }),
+);
+
+// --- reconcileField behaviour --------------------------------------
+
+test('reconcileField: unknown field name → no-op (no fetch, no touch)', async () => {
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url) => { calls.push(url); throw new Error('should not fetch'); };
+  try {
+    const store = makeStore();
+    await reconcileField(store, 'nonexistentField');
+    assert.equal(calls.length, 0, 'no fetch attempted for unknown field');
+    assert.equal(store._touched.length, 0, 'no touch for unknown field');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('reconcileField: fetcher rejection → swallowed, no touch, state unchanged', async () => {
+  const restore = installFetchStub({}); // any path → unmocked → throws
+  try {
+    const store = makeStore();
+    store.state.speaker.info = 'sentinel';
+    await assert.doesNotReject(() => reconcileField(store, 'info'));
+    assert.equal(store.state.speaker.info, 'sentinel', 'state untouched on rejection');
+    assert.equal(store._touched.length, 0, 'no touch on rejection');
+  } finally {
+    restore();
+  }
+});
+
+test('reconcileField: null fetcher payload → no apply, no touch', () =>
+  withFetcher('presets', async () => null, async () => {
+    const store = makeStore();
+    store.state.speaker.presets = 'sentinel';
+    await reconcileField(store, 'presets');
+    assert.equal(store.state.speaker.presets, 'sentinel', 'state untouched on null payload');
+    assert.equal(store._touched.length, 0, 'no touch on null payload');
+  }),
+);

--- a/admin/test/test_now_playing_data.js
+++ b/admin/test/test_now_playing_data.js
@@ -1,0 +1,326 @@
+// Tests for app/views/now-playing-data.js — the topic-cache
+// coordination helpers extracted out of views/now-playing.js.
+//
+// Unlike test_now_playing.js these don't mount the view. The data
+// module is a set of pure(-ish) functions over (json | topicId | np)
+// plus the shared tunein-cache, so the tests exercise it directly.
+//
+// Run: node --test admin/test
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { installSessionStorage } from './fixtures/dom-shim.js';
+
+installSessionStorage();
+
+// fetch stub for the lazyFetchTopicsList tests — overridden per-test.
+globalThis.fetch = () => new Promise(() => {});
+
+const {
+  extractTopicIds,
+  cacheTopicNames,
+  labelForTopic,
+  lazyFetchTopicsList,
+} = await import('../app/views/now-playing-data.js');
+
+const tc = await import('../app/tunein-cache.js');
+const ts = await import('../app/transport-state.js');
+
+// --- extractTopicIds -----------------------------------------------
+
+test('extractTopicIds: pulls t-prefix guide_ids out of a flat body', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic', guide_id: 't100', URL: 'Tune.ashx?id=t100&sid=p17' },
+      { type: 'link', item: 'topic', guide_id: 't200', URL: 'Tune.ashx?id=t200&sid=p17' },
+      { type: 'link', item: 'topic', guide_id: 't300', URL: 'Tune.ashx?id=t300&sid=p17' },
+    ],
+  };
+  assert.deepEqual(extractTopicIds(json), ['t100', 't200', 't300']);
+});
+
+test('extractTopicIds: descends into section.children containers', () => {
+  const json = {
+    body: [{
+      element: 'outline',
+      text: 'Episodes',
+      children: [
+        { type: 'link', item: 'topic', guide_id: 't100', URL: 'Tune.ashx?id=t100&sid=p17' },
+        { type: 'link', item: 'topic', guide_id: 't200', URL: 'Tune.ashx?id=t200&sid=p17' },
+      ],
+    }],
+  };
+  assert.deepEqual(extractTopicIds(json), ['t100', 't200']);
+});
+
+test('extractTopicIds: drops station siblings (s-prefix) in the same body', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic',   guide_id: 't100', URL: 'Tune.ashx?id=t100&sid=p17' },
+      { type: 'audio', item: 'station', guide_id: 's12345', URL: 'Tune.ashx?id=s12345' },
+      { type: 'link', item: 'topic',   guide_id: 't200', URL: 'Tune.ashx?id=t200&sid=p17' },
+    ],
+  };
+  assert.deepEqual(extractTopicIds(json), ['t100', 't200']);
+});
+
+test('extractTopicIds: drops cursors / pivots / non-outline entries', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic',  guide_id: 't100', URL: 'Tune.ashx?id=t100&sid=p17' },
+      // Cursor row — classifyOutline rejects this.
+      { type: 'link', text: 'More',   URL: 'http://example/next', key: 'nextStations' },
+      // Pivot row — also rejected.
+      { element: 'pivot', text: 'Country', URL: 'http://example/p' },
+      { type: 'link', item: 'topic',  guide_id: 't200', URL: 'Tune.ashx?id=t200&sid=p17' },
+    ],
+  };
+  assert.deepEqual(extractTopicIds(json), ['t100', 't200']);
+});
+
+test('extractTopicIds: missing body / wrong shape returns []', () => {
+  assert.deepEqual(extractTopicIds(null), []);
+  assert.deepEqual(extractTopicIds({}), []);
+  assert.deepEqual(extractTopicIds({ body: null }), []);
+  assert.deepEqual(extractTopicIds({ body: 'string' }), []);
+});
+
+test('extractTopicIds: ignores entries with non-t-prefix guide_ids', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic', guide_id: 'r123', URL: 'Tune.ashx?id=r123' },
+      { type: 'link', item: 'topic', guide_id: 't200', URL: 'Tune.ashx?id=t200&sid=p17' },
+    ],
+  };
+  assert.deepEqual(extractTopicIds(json), ['t200']);
+});
+
+// --- cacheTopicNames -----------------------------------------------
+
+test('cacheTopicNames: writes tunein.topicname.<t<N>> for each t-row', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic', guide_id: 't9100',
+        text: 'Episode A', URL: 'Tune.ashx?id=t9100&sid=p17' },
+      { type: 'link', item: 'topic', guide_id: 't9200',
+        text: 'Episode B', URL: 'Tune.ashx?id=t9200&sid=p17' },
+    ],
+  };
+  cacheTopicNames(json);
+  assert.equal(tc.cache.get(ts.topicNameKey('t9100')), 'Episode A');
+  assert.equal(tc.cache.get(ts.topicNameKey('t9200')), 'Episode B');
+  tc.cache.invalidate(ts.topicNameKey('t9100'));
+  tc.cache.invalidate(ts.topicNameKey('t9200'));
+});
+
+test('cacheTopicNames: descends into section.children containers', () => {
+  const json = {
+    body: [{
+      element: 'outline',
+      children: [
+        { type: 'link', item: 'topic', guide_id: 't9301',
+          text: 'Nested Episode', URL: 'Tune.ashx?id=t9301&sid=p17' },
+      ],
+    }],
+  };
+  cacheTopicNames(json);
+  assert.equal(tc.cache.get(ts.topicNameKey('t9301')), 'Nested Episode');
+  tc.cache.invalidate(ts.topicNameKey('t9301'));
+});
+
+test('cacheTopicNames: skips rows with empty / whitespace text', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic', guide_id: 't9400', text: '',
+        URL: 'Tune.ashx?id=t9400&sid=p17' },
+      { type: 'link', item: 'topic', guide_id: 't9401', text: '   ',
+        URL: 'Tune.ashx?id=t9401&sid=p17' },
+    ],
+  };
+  cacheTopicNames(json);
+  assert.equal(tc.cache.get(ts.topicNameKey('t9400')), undefined);
+  assert.equal(tc.cache.get(ts.topicNameKey('t9401')), undefined);
+});
+
+test('cacheTopicNames: ignores non-t-prefix guide_ids', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic',   guide_id: 's12345',
+        text: 'Station', URL: 'Tune.ashx?id=s12345' },
+      { type: 'link', item: 'topic',   guide_id: 'p17',
+        text: 'Show', URL: 'Tune.ashx?id=p17' },
+    ],
+  };
+  cacheTopicNames(json);
+  assert.equal(tc.cache.get(ts.topicNameKey('s12345')), undefined);
+  assert.equal(tc.cache.get(ts.topicNameKey('p17')), undefined);
+});
+
+test('cacheTopicNames: trims surrounding whitespace from the title', () => {
+  const json = {
+    body: [
+      { type: 'link', item: 'topic', guide_id: 't9500',
+        text: '   Padded Title   ', URL: 'Tune.ashx?id=t9500&sid=p17' },
+    ],
+  };
+  cacheTopicNames(json);
+  assert.equal(tc.cache.get(ts.topicNameKey('t9500')), 'Padded Title');
+  tc.cache.invalidate(ts.topicNameKey('t9500'));
+});
+
+// --- labelForTopic --------------------------------------------------
+
+test('labelForTopic: cached topicname wins over everything else', () => {
+  tc.cache.set(ts.topicNameKey('t9600'), 'Canonical Title', tc.TTL_LABEL);
+  const np = {
+    item: { name: 'Stale itemName', location: '/v1/playback/station/t9600' },
+  };
+  assert.equal(labelForTopic('t9600', np), 'Canonical Title');
+  tc.cache.invalidate(ts.topicNameKey('t9600'));
+});
+
+test('labelForTopic: falls back to nowPlaying.item.name when cache empty + same topic', () => {
+  tc.cache.invalidate(ts.topicNameKey('t9601'));
+  const np = {
+    item: { name: 'Episode From Firmware', location: '/v1/playback/station/t9601' },
+  };
+  assert.equal(labelForTopic('t9601', np), 'Episode From Firmware');
+});
+
+test('labelForTopic: ignores itemName when it equals the raw guide_id (stale sid degrade)', () => {
+  tc.cache.invalidate(ts.topicNameKey('t9602'));
+  const np = {
+    item: { name: 't9602', location: '/v1/playback/station/t9602' },
+  };
+  // Should fall through to the topic id as the last-resort label.
+  assert.equal(labelForTopic('t9602', np), 't9602');
+});
+
+test('labelForTopic: ignores itemName when nowPlaying is on a different topic', () => {
+  tc.cache.invalidate(ts.topicNameKey('t9603'));
+  const np = {
+    item: { name: 'Different Episode', location: '/v1/playback/station/t9700' },
+  };
+  // Asked about t9603 but nowPlaying is on t9700 — fall back to the id.
+  assert.equal(labelForTopic('t9603', np), 't9603');
+});
+
+test('labelForTopic: last-resort fallback is the topic id itself', () => {
+  tc.cache.invalidate(ts.topicNameKey('t9604'));
+  assert.equal(labelForTopic('t9604', null), 't9604');
+  assert.equal(labelForTopic('t9604', { item: {} }), 't9604');
+  assert.equal(labelForTopic('t9604', undefined), 't9604');
+});
+
+// --- lazyFetchTopicsList -------------------------------------------
+
+test('lazyFetchTopicsList: returns cached list without fetching', async () => {
+  const parent = 'p9700';
+  tc.cache.set(ts.topicsKey(parent), ['t100', 't200', 't300'], tc.TTL_DRILL_HEAD);
+
+  let fetchCalled = false;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = () => { fetchCalled = true; return Promise.reject(new Error('no fetch')); };
+
+  try {
+    const ids = await lazyFetchTopicsList(parent);
+    assert.deepEqual(ids, ['t100', 't200', 't300']);
+    assert.equal(fetchCalled, false, 'cached list short-circuits the fetch');
+  } finally {
+    globalThis.fetch = realFetch;
+    tc.cache.invalidate(ts.topicsKey(parent));
+  }
+});
+
+test('lazyFetchTopicsList: fetches, extracts ids, caches them, primes topic names', async () => {
+  const parent = 'p9701';
+  tc.cache.invalidate(ts.topicsKey(parent));
+
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        head: { status: '200' },
+        body: [
+          { type: 'link', item: 'topic', guide_id: 't9701',
+            text: 'Episode One',  URL: 'Tune.ashx?id=t9701&sid=p9701' },
+          { type: 'link', item: 'topic', guide_id: 't9702',
+            text: 'Episode Two',  URL: 'Tune.ashx?id=t9702&sid=p9701' },
+          { type: 'link', item: 'topic', guide_id: 't9703',
+            text: 'Episode Three', URL: 'Tune.ashx?id=t9703&sid=p9701' },
+        ],
+      }),
+    };
+  };
+
+  try {
+    const ids = await lazyFetchTopicsList(parent);
+    assert.deepEqual(ids, ['t9701', 't9702', 't9703']);
+    assert.equal(calls.length, 1, 'one fetch issued');
+    assert.ok(calls[0].includes('c=topics'), 'request asked for c=topics');
+    assert.ok(calls[0].includes(`id=${parent}`), 'request carried the parent id');
+    // Topic names should be cached alongside the list.
+    assert.equal(tc.cache.get(ts.topicNameKey('t9701')), 'Episode One');
+    assert.equal(tc.cache.get(ts.topicNameKey('t9702')), 'Episode Two');
+    assert.equal(tc.cache.get(ts.topicNameKey('t9703')), 'Episode Three');
+    // Topics list itself should be cached too.
+    assert.deepEqual(tc.cache.get(ts.topicsKey(parent)), ['t9701', 't9702', 't9703']);
+  } finally {
+    globalThis.fetch = realFetch;
+    tc.cache.invalidate(ts.topicsKey(parent));
+    tc.cache.invalidate(ts.topicNameKey('t9701'));
+    tc.cache.invalidate(ts.topicNameKey('t9702'));
+    tc.cache.invalidate(ts.topicNameKey('t9703'));
+  }
+});
+
+test('lazyFetchTopicsList: returns [] and swallows network errors', async () => {
+  const parent = 'p9702';
+  tc.cache.invalidate(ts.topicsKey(parent));
+
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('network down'); };
+
+  try {
+    const ids = await lazyFetchTopicsList(parent);
+    assert.deepEqual(ids, []);
+  } finally {
+    globalThis.fetch = realFetch;
+    tc.cache.invalidate(ts.topicsKey(parent));
+  }
+});
+
+test('lazyFetchTopicsList: caches 1-entry results (so we don\'t refetch on every tap)', async () => {
+  const parent = 'p9703';
+  tc.cache.invalidate(ts.topicsKey(parent));
+
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      head: { status: '200' },
+      body: [
+        { type: 'link', item: 'topic', guide_id: 't9704',
+          text: 'Only Episode', URL: 'Tune.ashx?id=t9704&sid=p9703' },
+      ],
+    }),
+  });
+
+  try {
+    const ids = await lazyFetchTopicsList(parent);
+    assert.deepEqual(ids, ['t9704']);
+    // Even a 1-entry result is cached — the classifier rejects length < 2
+    // anyway, but the cache write prevents a refetch storm.
+    assert.deepEqual(tc.cache.get(ts.topicsKey(parent)), ['t9704']);
+  } finally {
+    globalThis.fetch = realFetch;
+    tc.cache.invalidate(ts.topicsKey(parent));
+    tc.cache.invalidate(ts.topicNameKey('t9704'));
+  }
+});

--- a/admin/test/test_play_cgi/test_playback_lib.sh
+++ b/admin/test/test_play_cgi/test_playback_lib.sh
@@ -16,13 +16,20 @@ set -u
 # any cwd. POSIX-portable: %P doesn't exist, but the worktree path
 # always has admin/test/test_play_cgi as the deepest two segments.
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+COMMON="$THIS_DIR/../../cgi-bin/lib/cgi-common.sh"
 LIB="$THIS_DIR/../../cgi-bin/lib/playback.sh"
 
-if [ ! -f "$LIB" ]; then
-    printf 'fixture missing: %s\n' "$LIB" >&2
-    exit 1
-fi
+for f in "$COMMON" "$LIB"; do
+    if [ ! -f "$f" ]; then
+        printf 'fixture missing: %s\n' "$f" >&2
+        exit 1
+    fi
+done
 
+# Source the cross-CGI primitives first; playback.sh skips its own
+# source step when emit_error is already defined.
+# shellcheck source=../../cgi-bin/lib/cgi-common.sh
+. "$COMMON"
 # shellcheck source=../../cgi-bin/lib/playback.sh
 . "$LIB"
 

--- a/admin/test/test_tunein_drill_integration.js
+++ b/admin/test/test_tunein_drill_integration.js
@@ -305,15 +305,23 @@ test('TuneIn drill: cache miss → fetch page 0 → paginate → classify → re
   assert.equal(cache.get('tunein.label.g81'), 'Bluegrass',
     'pivot chip Bluegrass cached its label under tunein.label.g81');
 
-  // The page-1 rows we appended also primed their labels. Page-1 row
-  // URLs carry the parent's `filter=s` (the cursor-emitted filter; see
-  // tunein-url § 7.2), so the cache token folds the filter into the key:
-  // `tunein.label.<id>:<filter>`. That's the correct multi-filter
-  // composition rule from outline-render.crumbTokenForParts (#106).
-  assert.equal(cache.get('tunein.label.s10003:s'), 'Radio Folk Forever',
-    'page-1 station s10003 cached its label under the filter-bearing token');
-  assert.equal(cache.get('tunein.label.s10004:s'), 'Sligo Folk Radio',
-    'page-1 station s10004 cached its label under the filter-bearing token');
+  // The page-1 rows we appended also primed their labels under the
+  // bare guide_id. Their wire URLs carry the parent cursor's
+  // `&filter=s` ("stations only") which the TuneIn service echoes back
+  // into every emitted row URL — but that filter is parasitic on a
+  // Tune.ashx for a leaf station, so terminal-entity rows cache under
+  // the bare anchor regardless of arrival path (#117).
+  assert.equal(cache.get('tunein.label.s10003'), 'Radio Folk Forever',
+    'page-1 station s10003 cached its label under the bare guide_id');
+  assert.equal(cache.get('tunein.label.s10004'), 'Sligo Folk Radio',
+    'page-1 station s10004 cached its label under the bare guide_id');
+  // The parasitic-filter form must NOT exist — stations identify by
+  // guide_id alone, the inherited parent filter is not part of the
+  // entity's label key.
+  assert.equal(cache.get('tunein.label.s10003:s'), undefined,
+    'no parasitic filter-bearing cache entry leaks alongside the bare key');
+  assert.equal(cache.get('tunein.label.s10004:s'), undefined,
+    'no parasitic filter-bearing cache entry leaks alongside the bare key');
 
   // No leak: a guide_id we never rendered has no cache entry.
   assert.equal(cache.get('tunein.label.s99999'), undefined,

--- a/admin/test/test_tunein_drill_integration.js
+++ b/admin/test/test_tunein_drill_integration.js
@@ -1,0 +1,325 @@
+// Integration test for the TuneIn drill.
+//
+// The drill is implemented across seven files (tunein-url, tunein-pager,
+// tunein-outline, tunein-cache, tunein-sid, views/browse/outline-render,
+// views/browse/pager-crawl). Each has a dedicated unit test; this test
+// exercises the join end-to-end against a captured fixture pair.
+//
+// Scenario:
+//   1. The label cache is empty for the rows we are about to drill into
+//      (cache miss).
+//   2. Fetch the page-0 multi-section response for a genre root
+//      (`id=g79` — Folk). The page exercises three sections plus a
+//      related/pivot block.
+//   3. Render the page via outline-render.renderOutline → DOM structure
+//      (data-section markers, station/show/drill row classes, pivot
+//      chips, cursor URL parked on data-cursor-url).
+//   4. Walk the captured cursor with createPager, which canonicalises
+//      the cursor URL, fetches page 1 (a flat audio body), classifies
+//      every row, and dedupes against the page-0 rows we hand it via
+//      `initialIds`.
+//   5. Render the new flat rows via renderEntry (the row primitive the
+//      Load-more handler appends rows through) — verifying the same
+//      pipeline classify → normaliseRow → DOM emits.
+//   6. Assert the cache has been seeded with `tunein.label.<token>`
+//      entries for every row we rendered.
+//
+// Run: node --test admin/test
+//
+// READ-ONLY against production code. This test must not import any
+// helper that mutates tunein-* — it composes the public surfaces.
+
+import { test, before, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { doc } from './fixtures/dom-shim.js';
+
+// --- sessionStorage shim (per-test reset) --------------------------------
+
+const ssStore = new Map();
+globalThis.sessionStorage = {
+  getItem(k)    { return ssStore.has(k) ? ssStore.get(k) : null; },
+  setItem(k, v) { ssStore.set(k, String(v)); },
+  removeItem(k) { ssStore.delete(k); },
+  clear()       { ssStore.clear(); },
+};
+
+// Late import — these modules read `sessionStorage` at first use, so the
+// shim above must be installed before the import resolves.
+const { createPager }     = await import('../app/tunein-pager.js');
+const { classifyOutline } = await import('../app/tunein-outline.js');
+const { canonicaliseBrowseUrl } = await import('../app/tunein-url.js');
+const {
+  renderOutline,
+  renderEntry,
+  _setChildCrumbsForTest,
+  _setCurrentPartsForTest,
+} = await import('../app/views/browse/outline-render.js');
+const { cache } = await import('../app/tunein-cache.js');
+
+// --- helpers -------------------------------------------------------------
+
+function loadFixture(name) {
+  const p = path.resolve('admin/test/fixtures/tunein-drill', name);
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+// Scripted fetcher — returns each fixture in order; records every URL
+// it was called with so the test can assert canonicalisation + that no
+// extra calls leak out.
+function scriptedFetch(...pages) {
+  const calls = [];
+  const fn = async (url) => {
+    calls.push(url);
+    const next = pages.shift();
+    if (next === undefined) {
+      throw new Error(`scriptedFetch: extra call (url=${url})`);
+    }
+    return next;
+  };
+  fn.calls = calls;
+  fn.remaining = () => pages.length;
+  return fn;
+}
+
+function findAllBy(root, predicate) {
+  const out = [];
+  function walk(node) {
+    if (!node) return;
+    if (node.nodeType === 1 && predicate(node)) out.push(node);
+    for (const c of node.childNodes || []) walk(c);
+  }
+  walk(root);
+  return out;
+}
+
+function hasClass(el, cls) {
+  return (el.getAttribute && (el.getAttribute('class') || '').split(/\s+/).includes(cls));
+}
+
+function findFirstByClass(root, cls) {
+  if (!root) return null;
+  if (root.nodeType === 1 && hasClass(root, cls)) return root;
+  for (const c of root.childNodes || []) {
+    if (c && c.nodeType === 1) {
+      const found = findFirstByClass(c, cls);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+// The page-0 fixture's row guide_ids the renderer writes labels for. The
+// cache assertions read these back after the drill completes.
+const PAGE0_GUIDE_IDS = ['s10001', 's10002', 'p20001'];
+const PAGE0_PIVOT_TOKENS = ['g80', 'g81'];
+const PAGE1_NEW_GUIDE_IDS = ['s10003', 's10004'];  // s10001 re-emits and dedupes
+
+// --- reset between tests -------------------------------------------------
+
+before(() => {
+  // The renderer reads two module-locals (childCrumbs, currentParts). The
+  // drill simulates the top-level entry point so both are empty.
+  _setChildCrumbsForTest([]);
+  _setCurrentPartsForTest(null);
+});
+
+beforeEach(() => {
+  ssStore.clear();
+});
+
+// =============================================================
+// End-to-end: cache miss → fetch page 0 → render → paginate to page 1
+// → classify + render new rows → assert DOM + cache state.
+// =============================================================
+
+test('TuneIn drill: cache miss → fetch page 0 → paginate → classify → render', async () => {
+  // --- 1. Cache miss baseline --------------------------------------------
+  //
+  // The cache is empty (sessionStorage cleared in beforeEach). Every label
+  // key the drill is about to write is absent.
+  for (const gid of PAGE0_GUIDE_IDS) {
+    assert.equal(cache.get(`tunein.label.${gid}`), undefined,
+      `pre-drill cache miss for ${gid}`);
+  }
+  for (const tok of PAGE0_PIVOT_TOKENS) {
+    assert.equal(cache.get(`tunein.label.${tok}`), undefined,
+      `pre-drill cache miss for pivot token ${tok}`);
+  }
+
+  // --- 2. Fetch page 0 ----------------------------------------------------
+  //
+  // The drill entry-point URL is the canonical genre root for Folk.
+  // The fetcher is mocked: a cache-miss browse path would hand this URL
+  // through canonicaliseBrowseUrl in production (api.js does that at the
+  // wire seam); here we simulate the post-canonical fetch directly.
+  const entryUrl = 'http://opml.radiotime.com/Browse.ashx?id=g79&render=json';
+  const page0 = loadFixture('g79-page0.tunein.json');
+  const page1 = loadFixture('g79-page1.tunein.json');
+
+  // First "fetch": page-0 outline. The drill's outer integration would
+  // call api.tuneinBrowse(entryUrl); for this test we resolve it directly.
+  const drillFetch = scriptedFetch(page0, page1);
+  const json0 = await drillFetch(entryUrl);
+  assert.equal(json0, page0, 'page 0 returned from the fetcher');
+
+  // --- 3. Render page 0 ---------------------------------------------------
+  //
+  // renderOutline emits one .browse-section per top-level entry that has
+  // .children; tombstones / empty bodies short-circuit. The Folk page has
+  // three sections (stations, shows, related) so we expect three
+  // [data-section] cards.
+  const body = doc.createElement('div');
+  const visibleCount = renderOutline(body, json0);
+
+  // Two stations + one show row count as "visible" rows in the drill UI.
+  // The pivots / cursor are meta and don't increment the count.
+  assert.equal(visibleCount, 3,
+    'page-0 visible-row count = 2 stations + 1 show; pivots/cursors excluded');
+
+  const sections = findAllBy(body, (el) => el.getAttribute('data-section') != null);
+  const sectionKeys = sections.map((s) => s.getAttribute('data-section'));
+  assert.deepEqual(
+    sectionKeys.sort(),
+    ['related', 'shows', 'stations'].sort(),
+    'three sections rendered (stations, shows, related)',
+  );
+
+  // The stations section captured a cursor — it should park its URL on
+  // data-cursor-url so the Load-more wiring can find it.
+  const stationsSection = sections.find((s) => s.getAttribute('data-section') === 'stations');
+  const cursorUrl = stationsSection.getAttribute('data-cursor-url');
+  assert.ok(cursorUrl, 'stations section parked the cursor URL');
+  assert.match(cursorUrl, /offset=2/, 'cursor URL carries the offset');
+  assert.match(cursorUrl, /id=g79/, 'cursor URL carries the parent id');
+
+  // The shows section has no cursor → no data-cursor-url.
+  const showsSection = sections.find((s) => s.getAttribute('data-section') === 'shows');
+  assert.equal(showsSection.getAttribute('data-cursor-url'), null,
+    'shows section has no cursor — no data-cursor-url attribute');
+
+  // Station rows in the stations section.
+  const stationRowsP0 = findAllBy(stationsSection,
+    (el) => hasClass(el, 'station-row'));
+  assert.equal(stationRowsP0.length, 2, 'two .station-row entries in page-0 stations');
+  const sidsP0 = stationRowsP0.map((el) => el.getAttribute('data-sid'));
+  assert.deepEqual(sidsP0.sort(), ['s10001', 's10002']);
+
+  // Show row in the shows section — uses .station-row layout but drills
+  // (anchor href goes to #/browse).
+  const showRows = findAllBy(showsSection, (el) => hasClass(el, 'station-row'));
+  assert.equal(showRows.length, 1, 'one show row in page-0 shows');
+  const showHref = showRows[0].getAttribute('href');
+  assert.match(showHref, /^#\/browse\?/, 'show row drills via the browse hash');
+  assert.match(showHref, /id=p20001/, 'show row drill target is p20001');
+
+  // The related section's pivots render as chips, not rows.
+  const relatedSection = sections.find((s) => s.getAttribute('data-section') === 'related');
+  const pivots = findAllBy(relatedSection,
+    (el) => el.getAttribute('data-chip-kind') === 'pivot');
+  assert.equal(pivots.length, 2, 'two pivot chips rendered in related');
+  const pivotTexts = pivots.map((p) => (p.textContent || '').trim());
+  assert.deepEqual(pivotTexts.sort(), ['Bluegrass', 'Country']);
+
+  // --- 4. Paginate the stations section -----------------------------------
+  //
+  // The pager seam: take the cursor URL the renderer parked, hand it to
+  // createPager along with a fetcher and the page-0 guide_ids (so the
+  // re-rank that re-emits s10001 on page 1 is deduped).
+  const pager = createPager(cursorUrl, {
+    fetch: drillFetch,                 // shares the scripted fetcher
+    section: 'stations',
+    initialIds: sidsP0,                // seed the dedup set
+  });
+
+  assert.equal(pager.exhausted, false, 'pager is alive');
+  const r = await pager.loadMore();
+  assert.equal(r.exhausted, true,
+    'page-1 has no further cursor → pager hits the short-page terminator');
+  assert.equal(r.added, 2,
+    'page-1 contributed 3 audio rows; s10001 dedupes against page 0 → 2 net new');
+  assert.equal(pager.rows.length, 2);
+  const sidsP1 = pager.rows.map((row) => row.guide_id).sort();
+  assert.deepEqual(sidsP1, PAGE1_NEW_GUIDE_IDS.slice().sort(),
+    'the deduped page-1 rows are the two fresh ones');
+
+  // The pager canonicalised the cursor URL — render=json must be present
+  // on the URL actually fetched (the API never emits cursors with it).
+  assert.equal(drillFetch.calls.length, 2,
+    'exactly two fetches happened (page 0 + page 1)');
+  const cursorFetchUrl = drillFetch.calls[1];
+  assert.match(cursorFetchUrl, /render=json/,
+    'cursor follow URL carries render=json (canonicalised at the seam)');
+  assert.equal(cursorFetchUrl, canonicaliseBrowseUrl(cursorUrl),
+    'pager fetch URL == canonicaliseBrowseUrl(cursorUrl)');
+
+  // --- 5. Classify + render the page-1 rows ------------------------------
+  //
+  // Each new row classifies as 'station' and renders into a .station-row.
+  // The Load-more handler appends these into the existing section's card
+  // — here we drive the same code path (renderEntry) directly so the test
+  // covers the classify → renderEntry seam.
+  const stationCard = findFirstByClass(stationsSection, 'browse-card');
+  assert.ok(stationCard, 'stations section has a browse-card from page-0 render');
+  for (const row of pager.rows) {
+    assert.equal(classifyOutline(row), 'station',
+      `page-1 row ${row.guide_id} classifies as station`);
+    const node = renderEntry(row);
+    assert.ok(hasClass(node, 'station-row'),
+      `page-1 row ${row.guide_id} renders into .station-row`);
+    stationCard.appendChild(node);
+  }
+
+  // After append: stations section now carries all four unique sids
+  // (2 from page 0 + 2 net new from page 1 after dedup).
+  const allSids = findAllBy(stationsSection,
+    (el) => el.getAttribute('data-sid') != null)
+    .map((el) => el.getAttribute('data-sid'));
+  const uniqSids = new Set(allSids);
+  assert.equal(allSids.length, uniqSids.size,
+    'no duplicate guide_ids across the full stations section');
+  assert.equal(allSids.length, 4,
+    'two page-0 + two net-new page-1 = four station rows total');
+  for (const expected of ['s10001', 's10002', 's10003', 's10004']) {
+    assert.ok(uniqSids.has(expected), `expected sid ${expected} present`);
+  }
+
+  // --- 6. Cache state assertions -----------------------------------------
+  //
+  // renderEntry calls primeLabelForEntry for every row it emits. After
+  // the drill the cache holds the label for every visible row (stations,
+  // shows, pivots) plus the page-1 rows we just appended.
+  assert.equal(cache.get('tunein.label.s10001'), 'Folk Alley',
+    'page-0 station s10001 cached its label');
+  assert.equal(cache.get('tunein.label.s10002'), 'Celtic Music Radio',
+    'page-0 station s10002 cached its label');
+  assert.equal(cache.get('tunein.label.p20001'), 'The Folk Show',
+    'page-0 show p20001 cached its label');
+
+  // Pivot chips prime under their bare token (the URL anchor — they are
+  // plain drill chips, not filter-bearing ones).
+  assert.equal(cache.get('tunein.label.g80'), 'Country',
+    'pivot chip Country cached its label under tunein.label.g80');
+  assert.equal(cache.get('tunein.label.g81'), 'Bluegrass',
+    'pivot chip Bluegrass cached its label under tunein.label.g81');
+
+  // The page-1 rows we appended also primed their labels. Page-1 row
+  // URLs carry the parent's `filter=s` (the cursor-emitted filter; see
+  // tunein-url § 7.2), so the cache token folds the filter into the key:
+  // `tunein.label.<id>:<filter>`. That's the correct multi-filter
+  // composition rule from outline-render.crumbTokenForParts (#106).
+  assert.equal(cache.get('tunein.label.s10003:s'), 'Radio Folk Forever',
+    'page-1 station s10003 cached its label under the filter-bearing token');
+  assert.equal(cache.get('tunein.label.s10004:s'), 'Sligo Folk Radio',
+    'page-1 station s10004 cached its label under the filter-bearing token');
+
+  // No leak: a guide_id we never rendered has no cache entry.
+  assert.equal(cache.get('tunein.label.s99999'), undefined,
+    'rows that never rendered have no cache entry (no leak)');
+
+  // No extra fetches occurred. The scripted fetcher would have thrown on
+  // a third call.
+  assert.equal(drillFetch.remaining(), 0, 'fetcher fully drained');
+});

--- a/docs/adr/0002-sliders-and-optimistic-stay-separate.md
+++ b/docs/adr/0002-sliders-and-optimistic-stay-separate.md
@@ -1,0 +1,11 @@
+# Sliders and optimistic stay separate
+
+`admin/app/sliders.js` and `admin/app/optimistic.js` both encode "local-first
+then reconcile," but the shapes differ: sliders coalesces value-with-target
+drags with intermediate frames and a queue; optimistic does fire-and-rollback
+for discrete actions. They are two adapters of two different concepts, not one
+concept with two adapters. We considered merging and rejected: a unified
+module would need both shapes behind one interface, widening it without
+giving callers more leverage. Future architecture reviews should not
+re-suggest the merge; one-line `// see also` comments cross-reference the two
+files at their tops.

--- a/docs/adr/0002-sliders-and-optimistic-stay-separate.md
+++ b/docs/adr/0002-sliders-and-optimistic-stay-separate.md
@@ -1,11 +1,44 @@
 # Sliders and optimistic stay separate
 
-`admin/app/sliders.js` and `admin/app/optimistic.js` both encode "local-first
-then reconcile," but the shapes differ: sliders coalesces value-with-target
-drags with intermediate frames and a queue; optimistic does fire-and-rollback
-for discrete actions. They are two adapters of two different concepts, not one
-concept with two adapters. We considered merging and rejected: a unified
-module would need both shapes behind one interface, widening it without
-giving callers more leverage. Future architecture reviews should not
-re-suggest the merge; one-line `// see also` comments cross-reference the two
-files at their tops.
+- **Status**: accepted
+- **Date**: 2026-05-13
+- **Supersedes**: —
+- **Related**: `admin/app/sliders.js`, `admin/app/optimistic.js`
+
+## Context
+
+`admin/app/sliders.js` and `admin/app/optimistic.js` both encode the pattern
+"local-first then reconcile with the speaker," and the surface similarity is
+strong enough that every architecture review re-suggests collapsing them into
+one module.
+
+The shapes differ where it matters:
+
+- **`sliders.js`** coalesces *value-with-target* drags. The user holds a thumb
+  while a stream of intermediate frames flows past; the module needs a queue
+  with coalescence so only the latest target is in-flight, and a way to keep
+  the thumb pinned to the user's gesture while the speaker catches up.
+- **`optimistic.js`** does *fire-and-rollback* for discrete actions (preset
+  tap, source pick, mute toggle). One action goes out, one of two outcomes
+  comes back, and on rejection the UI snaps to the pre-action state.
+
+The two are adapters of two different concepts, not one concept with two
+adapters.
+
+## Decision
+
+Keep them as separate modules. Do not merge them under a shared "local-first
+reconciler" interface.
+
+## Consequences
+
+- A unified module would need both shapes behind one interface, widening the
+  surface without giving callers more leverage. Callers always know which
+  shape they want; forcing them through a polymorphic layer just adds a
+  branch at each call site.
+- Future architecture reviews should not re-propose the merge. To make that
+  judgement local rather than tribal, both files carry a one-line
+  `// see also` comment at their top cross-referencing the other.
+- If a third "local-first" shape appears (e.g. long-poll with optimistic
+  preview), prefer adding a third sibling over generalising. Re-open this
+  ADR only if two of the three shapes turn out to be the same.


### PR DESCRIPTION
## Summary

Architecture deepening release: turn shallow modules into deep ones along seams that surfaced after 0.5. Six refactor / new-test slices, plus three follow-up fixes the work exposed.

## Structural changes

- **CGI shared library** — extract `lib/cgi-common.sh` (CSRF guard, error envelope, body slurp, JSON/XML escape, OK-header preamble). `speaker`, `tunein`, and `refresh-all` stop re-implementing `playback.sh` helpers; the two-copy CSRF drift risk closes.
- **Crumb stack module** — extract `views/browse/crumbs.js` from `views/browse.js`. The new module owns parsing, rendering, hydration, and the `parts` value type. `browse.js` drops from 1185 → 520 LOC.
- **Now-playing data module** — extract `views/now-playing-data.js` (topic-id extraction + topic-name cache priming). The view becomes templating + binding only. `now-playing.js` drops from 725 → 618 LOC.
- **Per-field reconcile** — add `reconcileField(store, fieldName)` to `speaker-state.js` for one-field refresh through the existing pipeline. New per-FIELDS-row contract test catches WS/HTTP shape drift at unit-test speed.
- **TuneIn drill integration test** — one end-to-end test against captured fixtures: cache miss → fetch → paginate → classify → render.
- **Sliders / optimistic separation** — ADR-0002 records why the two stay separate (continuous value-with-target drag vs discrete fire-and-rollback); `// see also` cross-references at the top of each module.
- **CONTEXT.md** — new repo-root glossary introducing crumb stack, TuneIn drill, field, FIELDS registry.

## Follow-ups exposed by the work

- **TuneIn cache double-keying** — terminal-entity rows (`station` / `topic`) now cache under the bare `guide_id`; drill rows keep the filter-suffixed token where it identifies a distinct page. Fixes a same-`guide_id`-in-two-cache-entries split surfaced by the new integration test.
- **CHANGELOG entry** — documents the intentional `tunein` CGI 404 envelope shape change (flat `{error}` → structured `{ok:false,error:{code,message}}`) that fell out of the CGI shared-library extraction.
- **Mobile-viewport overflow** — `.shell-body { overflow-x: hidden }` plus `min-width: 0; overflow-wrap: anywhere` on the crumb trail. New Playwright spec at 390×844 asserts no horizontal scrollbar across all five primary views.
- **CI Node 20 sessionStorage fix** — `dom-shim.js` now installs the sessionStorage shim at module-eval time. Without this, 27 admin tests silently failed on the CI runner (Node 20) while passing locally on Node ≥ 22, which ships a built-in sessionStorage the cache picked up by accident.

## Test plan

- [x] `npm test` — 934 / 934 on Node 20 *and* Node 25
- [x] `shellcheck --severity=warning` — clean on every touched shell file
- [x] `scripts/playwright-smoke.mjs` against a real speaker — 33 / 33
- [x] `admin/e2e/tests/mobile-overflow.spec.js` against a real speaker — 5 / 5 at 390×844
- [ ] CI green on this PR

Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119