### PR TITLE
0.7 — favourites + drill seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.7.0] - 2026-05-14
+
+### Added
+
+- **Favourites** — admin-owned record of hearted stations and shows,
+  persisted on the speaker. Disjoint from the firmware-owned six
+  hardware **Presets**: a TuneIn id can appear as a favourite, a preset,
+  both, or neither. Favourites do not own the **Stream URL**; playback
+  routes through the resolver's per-station entry under
+  `/v1/playback/station/<id>`, the same source of truth the presets,
+  preview, and inline-play paths already use.
+  - **Persistent store** at `/mnt/nv/resolver/admin-data/favorites.json`.
+    JSON array; array index = position. Atomic tmp+mv writes.
+  - **CGI** at `admin/cgi-bin/api/v1/favorites` — GET / POST,
+    structured-envelope errors (`INVALID_ID`, `INVALID_NAME`,
+    `INVALID_ART`, `DUPLICATE_ID`, `INVALID_JSON`), CSRF guard + CORS
+    preflight via the shared `playback.sh` lib (mirrors the `presets`
+    CGI shape).
+  - **Inline heart on every playable row + the Now-Playing card** —
+    search rows, browse rows, show-landing rows, recently-viewed and
+    popular rows in the search empty state, and the Now-Playing card
+    next to the station name. Heart replaces the row's trailing chevron
+    where present; the row body remains a link to station-detail. Heart
+    visibility everywhere: `^[sp]\d+$` only — topic (`t`), artist (`m`),
+    and non-Bose entries render no heart. The Now-Playing card heart
+    additionally hides on AUX / BLUETOOTH / STANDBY.
+  - **Favourites tab** (`#/favorites`) in the rail between Browse and
+    Settings. Each row carries always-on affordances:
+    `[drag-handle] [body — tap to play] [pencil] [trash]`. Pencil
+    expands the row vertically in place for name / art / note editing
+    (Save commits + POSTs; Cancel collapses without writing). Trash
+    optimistically removes + POSTs immediately and surfaces a 5-second
+    toast with Undo; tapping Undo restores at the previous index and
+    POSTs the restored list. Drag-handle uses the same pointer-events
+    idiom as the preset long-press detector — ghost row + drop
+    indicator during drag, splice + POST on pointerup, pointercancel /
+    Escape aborts with no POST.
+  - **Now-Playing 3×3 preview grid** below the preset grid, rendering
+    the first 9 entries. 0 favourites hides the section; 1–8 renders
+    only the present cards (no placeholder slots). Tap = play; long-press
+    / right-click = `#/favorites?focus=<id>` deep-link that scrolls the
+    matching entry into view with a brief highlight on mount. Visual
+    style mirrors preset cards (tinted background per `hashHue(name)`).
+- **`resolveBrowseDrill` seam** at `admin/app/tunein-drill.js` —
+  consolidates the **TuneIn drill** one-shot fetch policy behind a
+  single tagged-result interface
+  (`{kind:'ok'|'empty'|'error'}`). Browse's `renderDrill` and
+  show-landing's browse half both consume the seam; `renderOutline`'s
+  empty-body and single-tombstone branches move upstream of the
+  renderer. Adding a new wire-shape case is now a single-file change
+  in one classification table.
+- **`Crumb stack` split** — `admin/app/views/browse/crumbs.js` splits
+  into a pure `crumb-parts.js` (value type + label-resolution reads, no
+  DOM, no `api.js` import; only depends on `tunein-cache` +
+  `tunein-url`) and a DOM-bound `crumb-renderer.js` (pillbar render +
+  async hydration). `outline-render.js` imports `stringifyCrumbs` from
+  `crumb-parts` cleanly, deleting the local duplicate that worked
+  around the previous import cycle.
+
 ### Changed
 
-- **`tunein` CGI 404 envelope shape** — as an intended side-effect of
-  the shared CGI library extraction (#111), the `tunein` CGI's 404
-  response now uses the structured error envelope shared by every
-  other CGI under `admin/cgi-bin/api/v1`.
-  - Old shape: `{"error": "..."}`
-  - New shape: `{"ok": false, "error": {"code": "...", "message": "..."}}`
-  - The SPA is unaffected — no in-tree caller hits a 404-producing
-    `tunein` route. External scripted callers that parse the flat
-    `error` field will need to read `error.message` (or branch on
-    `error.code`) instead.
+- **Favourites CGI uses POST, not PUT.** Bo's firmware ships busybox
+  httpd v1.19.4 (2017) which returns `501 Not Implemented` for PUT
+  before the CGI runs. POST is the only mutating method that reaches
+  CGI scripts on the speaker; mirrors the `presets` convention.
+- **`renderOutline` no longer owns body-level emptiness.** Top-level
+  `rawItems.length === 0` and single-tombstone branches now live in
+  the `resolveBrowseDrill` classifier. Per-section emptiness inside a
+  non-empty body stays in `renderOutline` (sectioned bodies can still
+  contain individual empty sections).
 
 ## [v0.4.0] - 2026-05-10
 
@@ -211,4 +269,5 @@ Calling these out so future maintainers don't re-derive them:
 - CI: GitHub Actions workflow running shellcheck on `scripts/` and a
   Python compile + error-path check on `resolver/build.py`.
 
+[v0.7.0]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.7.0
 [v0.1.0]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.1.0

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,8 +19,12 @@ _Avoid_: server, mock, emulator (used elsewhere for off-speaker variants).
 _Avoid_: config, redirect.
 
 **Preset**:
-One of the six physical preset buttons on the speaker, each holding a station reference.
+One of the six physical preset buttons on the speaker, each holding a station reference. Firmware-owned; mutates via `/storePreset` (proxied by the presets CGI).
 _Avoid_: slot, favorite, channel.
+
+**Favourite**:
+An admin-owned record of a hearted **Station** or show, persisted on the speaker at `/mnt/nv/resolver/admin-data/favorites.json`. Disjoint from a **Preset** — the same **TuneIn ID** can be both. A favourite is `{id, name, art, note}`; it does not own the **Stream URL** (resolution stays with the resolver entry under `/v1/playback/station/<id>`, shared across preset / preview / play / favourite).
+_Avoid_: bookmark, star, like.
 
 **Station**:
 A TuneIn radio entry referenced by a `sNNNNN` TuneIn ID. The thing a preset points at.
@@ -47,8 +51,11 @@ The act of crawling TuneIn's outline tree — from a root (genre / location / la
 _Avoid_: browse, search (those are distinct concepts in TuneIn's API).
 
 **Crumb stack**:
-The breadcrumb trail in the browse view plus the `parts` value type that backs it. Owns parsing, rendering, hydration, and the trail's relationship to the URL hash.
+The breadcrumb trail in the browse view plus the `parts` value type that backs it. Owns parsing, rendering, hydration, and the trail's relationship to the URL hash. Split across two sibling modules: `crumb-parts.js` (pure value type + label-resolution reads, no DOM) and `crumb-renderer.js` (DOM pillbar + async hydration).
 _Avoid_: breadcrumb, trail (those refer to the visual element only; the stack is the value).
+
+**Drill seam**:
+`admin/app/tunein-drill.js` — single classifier owning the one-shot **TuneIn drill** fetch policy. Maps every wire shape (transport throws, structured envelopes, raw `{"error":"..."}` bodies, `head.status` non-200 + empty body, status-200 empty body, single-tombstone bodies, ok payloads) onto a tagged result: `{kind:'ok'|'empty'|'error'}`. Browse's drill renderer and show-landing's browse half both consume it.
 
 **Field**:
 The unit of speaker-state synchronisation. A row in the `FIELDS` registry in `admin/app/speaker-state.js`, encoding `path` (REST), `tag` (XML), `parseEl` (decoder), `apply` (writer), and optional `eventTag` (WS event). Both the polling reconcile and the WS dispatch path converge on a field.
@@ -60,11 +67,13 @@ The list of all known speaker fields — single source of truth for what gets sy
 ## Relationships
 
 - A **Preset** points to a **Station** by its **TuneIn ID**.
-- The **Resolver** maps a **TuneIn ID** to a **Stream URL**; the **Speaker** then streams audio from that URL directly.
+- A **Favourite** references a **Station** or show by its **TuneIn ID** and is disjoint from any **Preset** — the same id can be both.
+- The **Resolver** maps a **TuneIn ID** to a **Stream URL**; the **Speaker** then streams audio from that URL directly. **Preset**, **Favourite**, preview, and inline-play all route through this single mapping.
 - The **Admin SPA** mutates speaker state through **CGIs** that proxy or augment the speaker's port-8090 REST API.
-- A **TuneIn drill** terminates at a **Station**; a station can be assigned to a **Preset**.
+- A **TuneIn drill** terminates at a **Station**; a station can be assigned to a **Preset** or hearted into the **Favourite** list.
+- The **Drill seam** is the single classifier every drill consumer goes through.
 - The **Crumb stack** represents the user's path through a **TuneIn drill**.
-- Every **Field** is reconciled either by polling (REST) or by WS dispatch (inline payload or hint + refetch).
+- Every **Field** is reconciled either by polling (REST) or by WS dispatch (inline payload or hint + refetch). The **Favourite** list is itself a **Field** (fetch-only — the speaker firmware doesn't know about favourites).
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ admin SPA is the everyday interface — the SoundTouch mobile app is
 no longer viable post-cloud-shutdown.
 
 - **Now playing** — compact card with album art, transport, dynamic
-  source switcher, and a 3×2 grid of art-style preset cards
+  source switcher, a 3×2 grid of art-style preset cards, and a 3×3
+  preview of your first nine favourites below it
+- **Favourites** — heart any station or show from any row; manage in
+  the dedicated tab with inline edit, toast-undo delete, and drag
+  reorder. Disjoint from the six hardware presets — same station can
+  be both
 - **Search + Browse** — search TuneIn directly; browse by genre /
   location / language; recently-viewed cache
 - **Station detail** — preview-play, assign to a preset slot, see
@@ -44,7 +49,7 @@ no longer viable post-cloud-shutdown.
 - Self-hosted Geist fonts; zero CDN dependencies — works whether or
   not your home internet is up
 
-See [CHANGELOG.md](CHANGELOG.md) for the full v0.4 surface.
+See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 ## How it works
 
@@ -125,8 +130,8 @@ settings). Roughly two minutes of work per drift.
 
 ## What this doesn't do
 
-The 0.4 release surfaced several Bose-firmware constraints that
-shape what's feasible. Calling them out so you know what to expect:
+Several Bose-firmware constraints shape what's feasible. Calling them
+out so you know what to expect:
 
 - **No firmware patches.** Bose stopped shipping updates. If a
   security issue surfaces in the speaker's firmware, this project

--- a/admin/app/api.js
+++ b/admin/app/api.js
@@ -24,6 +24,7 @@
 //   getListMediaServers() — discovery surface; SoundTouch peers appear as
 //     media_servers whose manufacturer contains "Bose"
 //   presetsList(), presetsAssign() — presets CGI envelope client
+//   favoritesList(), favoritesReplace() — favorites CGI envelope client
 
 import {
   parseNowPlayingEl,
@@ -727,6 +728,76 @@ export async function presetsAssign(slot, payload) {
     body = await res.json();
   } catch (err) {
     throw new Error(`presetsAssign: malformed response (HTTP ${res.status})`);
+  }
+  const reason = upstreamFailureReason(body);
+  if (reason) notifyUpstreamFailure(reason);
+  else if (body && body.ok) notifyUpstreamSuccess();
+  return body;
+}
+
+// --- favorites ------------------------------------------------------
+//
+// The favourites list is the admin's persistent record of stations and
+// shows the user has hearted. It is DISJOINT from the firmware-owned
+// six hardware presets — same id may appear in both, neither, or one.
+// See admin/cgi-bin/api/v1/favorites for the CGI surface.
+
+// GET /favorites → { ok:true, data:[{id,name,art,note}, ...] } | error envelope.
+// Absent file resolves as `{ ok:true, data:[] }`. Transport errors throw;
+// structured envelopes resolve normally so callers can route them to a toast.
+export async function favoritesList() {
+  let res;
+  try {
+    res = await fetchWithTimeout(`${apiBase}/favorites`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    }, DEFAULT_READ_TIMEOUT_MS);
+  } catch (err) {
+    if (err && err.name === 'TimeoutError') notifyUpstreamFailure('TIMEOUT');
+    throw err;
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    throw new Error(`favoritesList: malformed response (HTTP ${res.status})`);
+  }
+  const reason = upstreamFailureReason(body);
+  if (reason) notifyUpstreamFailure(reason);
+  else if (body && body.ok) notifyUpstreamSuccess();
+  return body;
+}
+
+// PUT /favorites with the full array body. Returns the CGI envelope.
+// Transport errors throw; structured `{ok:false, error}` envelopes
+// resolve normally so the caller can roll back optimistic state and
+// surface a toast. The PUT body is the raw array — the CGI wraps it
+// in the success envelope when serving the next GET.
+export async function favoritesReplace(entries) {
+  let res;
+  try {
+    res = await fetchWithTimeout(`${apiBase}/favorites`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(entries),
+      cache: 'no-store',
+    }, DEFAULT_WRITE_TIMEOUT_MS);
+  } catch (err) {
+    if (err && err.name === 'TimeoutError') {
+      notifyUpstreamFailure('TIMEOUT');
+      return timeoutEnvelope();
+    }
+    throw err;
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    throw new Error(`favoritesReplace: malformed response (HTTP ${res.status})`);
   }
   const reason = upstreamFailureReason(body);
   if (reason) notifyUpstreamFailure(reason);

--- a/admin/app/api.js
+++ b/admin/app/api.js
@@ -769,16 +769,19 @@ export async function favoritesList() {
   return body;
 }
 
-// PUT /favorites with the full array body. Returns the CGI envelope.
+// POST /favorites with the full array body. Returns the CGI envelope.
 // Transport errors throw; structured `{ok:false, error}` envelopes
 // resolve normally so the caller can roll back optimistic state and
-// surface a toast. The PUT body is the raw array — the CGI wraps it
+// surface a toast. The POST body is the raw array — the CGI wraps it
 // in the success envelope when serving the next GET.
+//
+// POST (not PUT) because busybox httpd on the speaker firmware refuses
+// PUT before the CGI ever runs; see admin/cgi-bin/api/v1/favorites.
 export async function favoritesReplace(entries) {
   let res;
   try {
     res = await fetchWithTimeout(`${apiBase}/favorites`, {
-      method: 'PUT',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',

--- a/admin/app/components.js
+++ b/admin/app/components.js
@@ -11,6 +11,7 @@ import * as theme from './theme.js';
 import { canonicaliseBrowseUrl } from './tunein-url.js';
 import { parseSid, isPlayableSid } from './tunein-sid.js';
 import { createPlayButton } from './play-button.js';
+import { favoriteHeart, isFavoriteId } from './favorites.js';
 
 export { isPlayableSid };
 
@@ -465,6 +466,13 @@ export function stationCard({ sid, name, art, location, format }) {
 // drills to the detail view; only the icon plays. Other prefixes
 // (`g`, `c`, `r`, `m`, `a`, `l`, `n` — drill-only types) get no Play
 // button.
+//
+// `favorite: { store, getEntry }` — when supplied and the sid matches
+// `^[sp]\d+$`, the row swaps its trailing chevron for an inline
+// favourite-heart toggle (issue #126). Other rows keep the chevron.
+// Topic (`t`), artist (`m`), and any non-Bose prefix render with the
+// chevron unchanged. `getEntry` returns `{ id, name, art, note }` at
+// click time; the row's static metadata is the natural source.
 export function stationRow({
   sid,
   name,
@@ -475,6 +483,7 @@ export function stationRow({
   tertiary = '',
   badges,
   chips,
+  favorite,
 } = {}) {
   const row = document.createElement('a');
   row.className = 'station-row';
@@ -561,12 +570,39 @@ export function stationRow({
     row.appendChild(createPlayButton({ sid, label: name || sid }));
   }
 
+  // Trailing affordance: heart on favouritable rows (sid matches
+  // `^[sp]\d+$`) when a favourite handle is wired in, chevron
+  // otherwise. The body remains the link to detail; the heart's own
+  // click handler stops propagation so toggling doesn't navigate.
+  row.appendChild(trailingAffordance({ sid, name, art, favorite }));
+
+  return row;
+}
+
+// trailingAffordance — return the heart toggle or the row chevron,
+// depending on favourite-eligibility. Shared with showRow in the
+// browse outline renderer so the "heart replaces chevron" rule sits
+// at one seam.
+//
+// `favorite: { store, getEntry? }`. When `getEntry` is omitted, the
+// entry shape is built from the static row fields. The `getEntry`
+// override exists for callers that want to resolve a live name/art
+// at click time (e.g. now-playing).
+export function trailingAffordance({ sid, name, art = '', favorite } = {}) {
+  if (favorite && favorite.store && isFavoriteId(sid)) {
+    const getEntry = typeof favorite.getEntry === 'function'
+      ? favorite.getEntry
+      : () => ({ id: sid, name: name || sid, art: art || '', note: '' });
+    return favoriteHeart({
+      store: favorite.store,
+      getEntry,
+      onCleanup: favorite.onCleanup,
+    });
+  }
   const chev = document.createElement('span');
   chev.className = 'station-row__chev';
   chev.appendChild(icon('arrow', 14));
-  row.appendChild(chev);
-
-  return row;
+  return chev;
 }
 
 // Append a "·" dot to a meta line. Used between each segment of the

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -74,6 +74,56 @@ export function withFavoriteRemoved(list, id) {
   return list.slice(0, idx).concat(list.slice(idx + 1));
 }
 
+// replaceFavorites — write a hand-built next-list to the speaker, with
+// optimistic state + rollback to the supplied snapshot on failure.
+//
+// Used by the favourites tab (#127) for edit-in-place save, optimistic
+// delete, and undo-restore — each of which mutates the list in a shape
+// that withFavoriteAdded / withFavoriteRemoved can't express alone (e.g.
+// editing an entry's fields, restoring at a specific index).
+//
+// Behaviour:
+//   1. Sets state.speaker.favorites = next + touch('speaker') so the UI
+//      paints the optimistic state.
+//   2. POSTs the next array.
+//   3. On structured-error or transport throw, restores `prev`, touches
+//      again, and surfaces a toast. The caller picks the toast prefix
+//      via `errorLabel` ("Couldn't save favourite", "Couldn't delete
+//      favourite", etc.) so toasts stay specific to the action.
+//
+// Returns the envelope on success, the envelope or a synthetic
+// TRANSPORT envelope on failure (mirror of toggleFavorite).
+export async function replaceFavorites(store, next, prev, errorLabel) {
+  const safeNext = Array.isArray(next) ? next : [];
+  const safePrev = Array.isArray(prev) ? prev : [];
+  const label = typeof errorLabel === 'string' && errorLabel
+    ? errorLabel
+    : "Couldn't update favourites";
+
+  store.state.speaker.favorites = safeNext;
+  store.touch('speaker');
+
+  let envelope;
+  try {
+    envelope = await favoritesReplace(safeNext);
+  } catch (err) {
+    store.state.speaker.favorites = safePrev;
+    store.touch('speaker');
+    const msg = (err && err.message) || 'transport error';
+    showToast(`${label}: ${msg}`);
+    return { ok: false, error: { code: 'TRANSPORT', message: msg } };
+  }
+
+  if (!envelope || envelope.ok !== true) {
+    store.state.speaker.favorites = safePrev;
+    store.touch('speaker');
+    const code = (envelope && envelope.error && envelope.error.code) || 'UNKNOWN';
+    showToast(`${label} (${code})`);
+    return envelope || { ok: false, error: { code, message: '' } };
+  }
+  return envelope;
+}
+
 // toggleFavorite — optimistic add-or-remove with POST-side reconcile.
 //
 // store: the live observable store (state.js).

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -9,7 +9,7 @@
 //
 //   2. `toggleFavorite(store, entry)` — the optimistic-toggle action.
 //      Mirrors the optimistic pattern in `optimistic.js`: mutate state,
-//      fire PUT, roll back on rejection + toast. Used by the heart on
+//      fire POST, roll back on rejection + toast. Used by the heart on
 //      station-detail today; reusable by row-level hearts (#126) and the
 //      favourites-tab pencil/trash (#128/#129) without modification.
 //
@@ -74,7 +74,7 @@ export function withFavoriteRemoved(list, id) {
   return list.slice(0, idx).concat(list.slice(idx + 1));
 }
 
-// toggleFavorite — optimistic add-or-remove with PUT-side reconcile.
+// toggleFavorite — optimistic add-or-remove with POST-side reconcile.
 //
 // store: the live observable store (state.js).
 // entry: { id, name, art?, note? }. `id` is required; `name` falls back
@@ -83,7 +83,7 @@ export function withFavoriteRemoved(list, id) {
 // Behaviour:
 //   1. Snapshot current state.speaker.favorites.
 //   2. Apply the toggle locally and touch('speaker').
-//   3. PUT the new list. On structured-error or transport failure,
+//   3. POST the new list. On structured-error or transport failure,
 //      restore the snapshot, touch('speaker') again, surface a toast.
 //
 // Returns the response envelope on success, or a synthetic

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -1,0 +1,224 @@
+// Favourites — admin-owned record of hearted stations and shows.
+//
+// Seams in this file are deliberately small. Three building blocks:
+//
+//   1. State helpers (pure): `indexOfFavorite`, `withFavoriteAdded`,
+//      `withFavoriteRemoved`. Work on the array shape the CGI emits.
+//      Pure list transforms so #127's reorder/edit slice can compose
+//      with the toggle without forking the data shape.
+//
+//   2. `toggleFavorite(store, entry)` — the optimistic-toggle action.
+//      Mirrors the optimistic pattern in `optimistic.js`: mutate state,
+//      fire PUT, roll back on rejection + toast. Used by the heart on
+//      station-detail today; reusable by row-level hearts (#126) and the
+//      favourites-tab pencil/trash (#128/#129) without modification.
+//
+//   3. `favoriteHeart({ getEntry, store })` — the heart toggle DOM
+//      primitive. Subscribes to `state.speaker.favorites` and repaints
+//      the filled / outline state on every change. Hidden when the id
+//      isn't `^[sp]\d+$`. Exported separately so #126 can mount one per
+//      row without re-implementing the click + paint dance.
+
+import { showToast } from './toast.js';
+import { favoritesReplace } from './api.js';
+import { icon } from './icons.js';
+import { isPlayableSid } from './tunein-sid.js';
+
+// Match `^[sp]\d+$` — the favourites id grammar. station-detail also
+// gates on this so the heart never appears on non-playable rows.
+export function isFavoriteId(id) {
+  if (typeof id !== 'string' || id.length < 2) return false;
+  const first = id.charAt(0);
+  if (first !== 's' && first !== 'p') return false;
+  for (let i = 1; i < id.length; i++) {
+    const c = id.charCodeAt(i);
+    if (c < 48 || c > 57) return false;
+  }
+  return true;
+}
+
+// indexOfFavorite — return the array index of `id` in the favourites
+// list, or -1. null/undefined lists are treated as empty.
+export function indexOfFavorite(list, id) {
+  if (!Array.isArray(list)) return -1;
+  for (let i = 0; i < list.length; i++) {
+    const e = list[i];
+    if (e && e.id === id) return i;
+  }
+  return -1;
+}
+
+// withFavoriteAdded — append the entry to a copy of `list` unless its id
+// is already present. Returns the original list when the id is already
+// there (no-op) so callers can `if (next !== list)` to detect a real
+// change. Defensive on shape: missing fields collapse to empty strings.
+export function withFavoriteAdded(list, entry) {
+  const base = Array.isArray(list) ? list : [];
+  if (!entry || typeof entry.id !== 'string') return base;
+  if (indexOfFavorite(base, entry.id) >= 0) return base;
+  const normalised = {
+    id:   entry.id,
+    name: typeof entry.name === 'string' ? entry.name : '',
+    art:  typeof entry.art  === 'string' ? entry.art  : '',
+    note: typeof entry.note === 'string' ? entry.note : '',
+  };
+  return base.concat([normalised]);
+}
+
+// withFavoriteRemoved — return a copy of `list` with the first entry
+// matching `id` dropped. Returns the original list when nothing matched.
+export function withFavoriteRemoved(list, id) {
+  if (!Array.isArray(list)) return [];
+  const idx = indexOfFavorite(list, id);
+  if (idx < 0) return list;
+  return list.slice(0, idx).concat(list.slice(idx + 1));
+}
+
+// toggleFavorite — optimistic add-or-remove with PUT-side reconcile.
+//
+// store: the live observable store (state.js).
+// entry: { id, name, art?, note? }. `id` is required; `name` falls back
+//        to the id if missing so the persisted record always has a label.
+//
+// Behaviour:
+//   1. Snapshot current state.speaker.favorites.
+//   2. Apply the toggle locally and touch('speaker').
+//   3. PUT the new list. On structured-error or transport failure,
+//      restore the snapshot, touch('speaker') again, surface a toast.
+//
+// Returns the response envelope on success, or a synthetic
+// `{ ok:false, error:{code:'TRANSPORT', message}}` on transport throw
+// so callers don't need to distinguish thrown vs structured failure.
+export async function toggleFavorite(store, entry) {
+  if (!entry || !isFavoriteId(entry.id)) {
+    return { ok: false, error: { code: 'INVALID_ID', message: 'bad id' } };
+  }
+  const prev = Array.isArray(store.state.speaker.favorites)
+    ? store.state.speaker.favorites.slice()
+    : [];
+  const isFav = indexOfFavorite(prev, entry.id) >= 0;
+  const safeEntry = {
+    id:   entry.id,
+    name: typeof entry.name === 'string' && entry.name ? entry.name : entry.id,
+    art:  typeof entry.art  === 'string' ? entry.art  : '',
+    note: typeof entry.note === 'string' ? entry.note : '',
+  };
+  const next = isFav
+    ? withFavoriteRemoved(prev, entry.id)
+    : withFavoriteAdded(prev, safeEntry);
+  store.state.speaker.favorites = next;
+  store.touch('speaker');
+
+  let envelope;
+  try {
+    envelope = await favoritesReplace(next);
+  } catch (err) {
+    store.state.speaker.favorites = prev;
+    store.touch('speaker');
+    const msg = (err && err.message) || 'transport error';
+    showToast(`Couldn't update favourites: ${msg}`);
+    return { ok: false, error: { code: 'TRANSPORT', message: msg } };
+  }
+
+  if (!envelope || envelope.ok !== true) {
+    store.state.speaker.favorites = prev;
+    store.touch('speaker');
+    const code = (envelope && envelope.error && envelope.error.code) || 'UNKNOWN';
+    showToast(`Couldn't update favourites (${code})`);
+    return envelope || { ok: false, error: { code, message: '' } };
+  }
+  return envelope;
+}
+
+// favoriteHeart({ getEntry, store, sizePx, onCleanup? }) — heart toggle
+// primitive. `getEntry` is called at click time (so the caller can
+// resolve the live name/art after async metadata lands) and on every
+// repaint (so the visibility gate honours the latest id).
+//
+// The returned element is a <button> that:
+//   - is `hidden` whenever getEntry()?.id doesn't match ^[sp]\d+$
+//   - paints `.is-filled` / `.is-empty` based on the current favourites
+//     list, subscribing to 'speaker' for re-paints
+//   - on click, calls toggleFavorite() with the freshest entry
+//
+// Subscriptions auto-detach via the optional `onCleanup` register
+// (defineView's env.onCleanup) so the button doesn't leak in a route
+// transition. Callers that don't pass onCleanup own the unsubscribe.
+//
+// The CSS hooks (.fav-heart, .is-filled, .is-empty) are styled in
+// style.css; this module only sets classes.
+export function favoriteHeart({ getEntry, store, sizePx = 22, onCleanup } = {}) {
+  if (typeof getEntry !== 'function' || !store) {
+    throw new Error('favoriteHeart: getEntry + store are required');
+  }
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'fav-heart';
+  btn.dataset.testFav = '1';
+  btn.appendChild(icon('heart', sizePx));
+
+  let busy = false;
+
+  function currentEntry() {
+    try { return getEntry() || null; }
+    catch (_err) { return null; }
+  }
+
+  function paint() {
+    const entry = currentEntry();
+    const id = entry && entry.id;
+    const eligible = typeof id === 'string' && isFavoriteId(id);
+    btn.hidden = !eligible;
+    if (!eligible) {
+      btn.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('tabindex', '-1');
+      return;
+    }
+    btn.removeAttribute('aria-hidden');
+    btn.removeAttribute('tabindex');
+    const list = (store.state && store.state.speaker && store.state.speaker.favorites) || [];
+    const isFav = indexOfFavorite(list, id) >= 0;
+    btn.classList.toggle('is-filled', isFav);
+    btn.classList.toggle('is-empty', !isFav);
+    btn.setAttribute('aria-pressed', isFav ? 'true' : 'false');
+    btn.setAttribute('aria-label', isFav ? 'Remove from favourites' : 'Add to favourites');
+    btn.setAttribute('title', isFav ? 'Remove from favourites' : 'Add to favourites');
+  }
+
+  async function onClick(evt) {
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+    if (busy) return;
+    const entry = currentEntry();
+    if (!entry || !isFavoriteId(entry.id)) return;
+    busy = true;
+    btn.classList.add('is-busy');
+    btn.disabled = true;
+    try {
+      await toggleFavorite(store, entry);
+    } finally {
+      busy = false;
+      btn.classList.remove('is-busy');
+      btn.disabled = false;
+      // Paint defensively after the toggle in case the speaker
+      // subscription hasn't fired yet (e.g. tests without a live store).
+      paint();
+    }
+  }
+
+  btn.addEventListener('click', onClick);
+
+  paint();
+  const unsub = store.subscribe ? store.subscribe('speaker', paint) : null;
+  if (typeof onCleanup === 'function' && typeof unsub === 'function') {
+    onCleanup(unsub);
+  }
+  btn.repaint = paint;
+  btn.unsubscribe = unsub || (() => {});
+  return btn;
+}
+
+// Re-export the id-shape predicate from tunein-sid for callers that
+// already think in terms of "playable" — favourites accept the same
+// `s` / `p` prefix grammar that the play-button gates on.
+export { isPlayableSid as isFavoritableSid };

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -74,6 +74,36 @@ export function withFavoriteRemoved(list, id) {
   return list.slice(0, idx).concat(list.slice(idx + 1));
 }
 
+// spliceReorder — move the entry at `fromIdx` to the gap `toGap`. Gaps
+// are numbered 0..length, where gap g sits before the row currently at
+// index g (so gap 0 is "above the first row" and gap length is "below
+// the last row"). The drag UI in #128 thinks in gaps because the drop
+// indicator renders between rows; this helper translates a gap drop
+// into the final array shape.
+//
+// Drops at the source's own gap (`fromIdx` or `fromIdx + 1`) are no-ops
+// — both describe "release where you picked it up". The helper returns
+// the original list reference in that case so callers can `if (next !==
+// list)` to skip the POST.
+//
+// Pure: no DOM, no mutation. Tested directly in `test_favorites_drag.js`.
+export function spliceReorder(list, fromIdx, toGap) {
+  if (!Array.isArray(list)) return [];
+  const n = list.length;
+  if (!Number.isInteger(fromIdx) || fromIdx < 0 || fromIdx >= n) return list;
+  if (!Number.isInteger(toGap)   || toGap   < 0 || toGap   >  n) return list;
+  // No-op: dropping at the gap immediately before or after the source
+  // leaves the entry in place.
+  if (toGap === fromIdx || toGap === fromIdx + 1) return list;
+  const next = list.slice();
+  const [picked] = next.splice(fromIdx, 1);
+  // Removing from `fromIdx` shifts every later index down by one, so
+  // gaps strictly after the source need a -1 correction before insert.
+  const insertAt = toGap > fromIdx ? toGap - 1 : toGap;
+  next.splice(insertAt, 0, picked);
+  return next;
+}
+
 // replaceFavorites — write a hand-built next-list to the speaker, with
 // optimistic state + rollback to the supplied snapshot on failure.
 //

--- a/admin/app/icons.js
+++ b/admin/app/icons.js
@@ -111,6 +111,23 @@ const SHAPES = {
     ['path', { d: 'M14 11v6' }],
     ['path', { d: 'M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2' }],
   ],
+  // Pencil — used by the favourites tab's "edit row" affordance. Two
+  // strokes: the body of the pencil (top-right to bottom-left diagonal)
+  // and the tip notch. Lucide's `pencil` glyph, simplified.
+  pencil: [
+    ['path', { d: 'M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z' }],
+  ],
+  // Drag-handle — six-dot grip column. Used as a visual stub on the
+  // favourites tab in #127 so the row layout is correct; #128 wires the
+  // actual drag behaviour.
+  'drag-handle': [
+    ['circle', { cx: '9',  cy: '5',  r: '1' }],
+    ['circle', { cx: '9',  cy: '12', r: '1' }],
+    ['circle', { cx: '9',  cy: '19', r: '1' }],
+    ['circle', { cx: '15', cy: '5',  r: '1' }],
+    ['circle', { cx: '15', cy: '12', r: '1' }],
+    ['circle', { cx: '15', cy: '19', r: '1' }],
+  ],
   arrow: [
     ['line', { x1: '5', y1: '12', x2: '19', y2: '12' }],
     ['polyline', { points: '12 5 19 12 12 19' }],

--- a/admin/app/icons.js
+++ b/admin/app/icons.js
@@ -141,6 +141,13 @@ const SHAPES = {
   'chevron-left': [
     ['polyline', { points: '15 18 9 12 15 6' }],
   ],
+  // Heart — used by the favourites toggle on station-detail and as the
+  // favourites tab glyph. Rendered as an outline by default; the
+  // station-detail toggle paints the same shape with `fill="currentColor"`
+  // (via the `is-filled` CSS class) to indicate "in favourites".
+  heart: [
+    ['path', { d: 'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z' }],
+  ],
   // Buffering — three horizontal dots. Used on the play/pause control
   // while the speaker is in BUFFERING_STATE (or any non-PLAY non-
   // STANDBY state with a selected item) so the visual is distinct

--- a/admin/app/main.js
+++ b/admin/app/main.js
@@ -10,6 +10,7 @@ import browse     from './views/browse.js';
 import search     from './views/search.js';
 import station    from './views/station.js';
 import preset     from './views/preset.js';
+import favorites  from './views/favorites.js';
 import settings   from './views/settings.js';
 
 import { installVersionDriftCheck } from './version.js';
@@ -93,6 +94,7 @@ const routes = [
   // when the strict matcher misses.
   { pattern: /^\/station\/(?<id>[^/]+)$/,        view: stationRedirect },
   { pattern: /^\/preset\/(?<slot>[1-6])$/,       view: preset },
+  { pattern: /^\/favorites$/,                    view: favorites },
   { pattern: /^\/settings$/,                     view: settings },
 ];
 

--- a/admin/app/play-button.js
+++ b/admin/app/play-button.js
@@ -16,6 +16,45 @@ import { cgiErrorMessage } from './error-messages.js';
 import { showToast } from './toast.js';
 import { icon } from './icons.js';
 
+// playSid({ sid, label, parentOutline? }) — shared play action for the
+// inline play button and any other caller (e.g. the favourites tab's
+// row body, which acts as a play target on tap). Centralises the
+// cache-priming + cache-stash + toast routing so callers don't drift.
+//
+// Returns a Promise<void>. Failures are surfaced via toast; no envelope
+// is bubbled up because callers don't need to branch on it. `busy`
+// guarding is the caller's responsibility — this function does not
+// debounce on its own.
+export async function playSid({ sid, label, parentOutline } = {}) {
+  if (typeof sid !== 'string' || !sid) return;
+  if (typeof label !== 'string' || !label) return;
+
+  // Issue #88: prime the parent-show cache the moment a topic plays.
+  if (sid.charAt(0) === 't' && parentOutline) {
+    const parent = extractParentShowId(parentOutline);
+    if (parent) cache.set(tuneinParentKey(sid), parent, TTL_LABEL);
+  }
+
+  const cacheKey = `tunein.stream.${sid}`;
+  const cached = cache.get(cacheKey);
+
+  try {
+    const result = await playGuideId(sid, label, cached);
+    if (result && result.ok) {
+      if (typeof result.url === 'string' && result.url) {
+        cache.set(cacheKey, result.url, TTL_STREAM);
+      }
+      showToast(`Playing on Bo: ${label}`);
+    } else {
+      cache.invalidate(cacheKey);
+      showToast(cgiErrorMessage(result));
+    }
+  } catch (_err) {
+    cache.invalidate(cacheKey);
+    showToast('Could not reach Bo');
+  }
+}
+
 export function createPlayButton({ sid, label } = {}) {
   if (typeof sid !== 'string' || !sid) {
     throw new Error('createPlayButton: sid is required');
@@ -42,34 +81,15 @@ export function createPlayButton({ sid, label } = {}) {
     busy = true;
     btn.classList.add('is-loading');
 
-    // Issue #88: prime the parent-show cache the moment a topic plays
-    // so the now-playing Prev/Next classifier can answer "what show is
-    // this from?" without re-fetching. The outline is stashed on the
-    // parent node by the render path; when absent (hand-crafted
-    // callers, tests) the write silently skips.
-    if (sid.charAt(0) === 't') {
-      const outline = btn.parentNode && btn.parentNode._outline;
-      const parent = outline ? extractParentShowId(outline) : null;
-      if (parent) cache.set(tuneinParentKey(sid), parent, TTL_LABEL);
-    }
-
-    const cacheKey = `tunein.stream.${sid}`;
-    const cached = cache.get(cacheKey);
+    // The outline is stashed on the parent node by the render path; when
+    // absent (hand-crafted callers, tests) playSid skips the topic-parent
+    // cache write silently.
+    const parentOutline = sid.charAt(0) === 't'
+      ? (btn.parentNode && btn.parentNode._outline) || null
+      : null;
 
     try {
-      const result = await playGuideId(sid, label, cached);
-      if (result && result.ok) {
-        if (typeof result.url === 'string' && result.url) {
-          cache.set(cacheKey, result.url, TTL_STREAM);
-        }
-        showToast(`Playing on Bo: ${label}`);
-      } else {
-        cache.invalidate(cacheKey);
-        showToast(cgiErrorMessage(result));
-      }
-    } catch (_err) {
-      cache.invalidate(cacheKey);
-      showToast('Could not reach Bo');
+      await playSid({ sid, label, parentOutline });
     } finally {
       btn.classList.remove('is-loading');
       busy = false;

--- a/admin/app/shell.js
+++ b/admin/app/shell.js
@@ -41,10 +41,11 @@ export function computePillState(state) {
 // --- activeTab routing rule ----------------------------------------
 
 const TOP_LEVEL_TABS = {
-  '/':         'now',
-  '/search':   'search',
-  '/browse':   'browse',
-  '/settings': 'settings',
+  '/':          'now',
+  '/search':    'search',
+  '/browse':    'browse',
+  '/favorites': 'favorites',
+  '/settings':  'settings',
 };
 
 export function tabForPath(path) {
@@ -92,10 +93,13 @@ function tabButton(tab, label, iconName) {
 }
 
 const TAB_DEFS = [
-  { tab: 'now',      label: 'Now',      icon: 'play' },
-  { tab: 'search',   label: 'Search',   icon: 'search' },
-  { tab: 'browse',   label: 'Browse',   icon: 'list' },
-  { tab: 'settings', label: 'Settings', icon: 'settings' },
+  { tab: 'now',       label: 'Now',        icon: 'play' },
+  { tab: 'search',    label: 'Search',     icon: 'search' },
+  { tab: 'browse',    label: 'Browse',     icon: 'list' },
+  // Favourites sits between Browse and Settings so the navigation rail
+  // reads "discover → save → configure" left-to-right (#125).
+  { tab: 'favorites', label: 'Favourites', icon: 'heart' },
+  { tab: 'settings',  label: 'Settings',   icon: 'settings' },
 ];
 
 function renderRail(railEl, store) {

--- a/admin/app/show-hero.js
+++ b/admin/app/show-hero.js
@@ -23,6 +23,7 @@ import { stationArt } from './components.js';
 import { isPlayableSid } from './tunein-sid.js';
 import { canonicaliseBrowseUrl } from './tunein-url.js';
 import { createPlayButton } from './play-button.js';
+import { favoriteHeart, isFavoriteId } from './favorites.js';
 
 // Drill-only prefixes / unknown specs render nothing useful as a hero,
 // but the caller is in charge of whether to mount one. We mirror the
@@ -34,6 +35,7 @@ export function showHero({
   art = '',
   location = '',
   chips,
+  favorite,
 } = {}) {
   const hero = document.createElement('div');
   hero.className = 'station-row station-row--hero';
@@ -44,10 +46,30 @@ export function showHero({
   const body = document.createElement('span');
   body.className = 'station-row__body';
 
+  // Wrap the name + heart in a flex row so the heart sits next to the
+  // title, mirroring the station-detail's `station-name-row` (#126).
+  // When the sid isn't favouritable or no favourite handle was wired
+  // in, the row collapses to just the name span.
+  const nameRow = document.createElement('span');
+  nameRow.className = 'station-row__name-row';
+
   const nameEl = document.createElement('span');
   nameEl.className = 'station-row__name';
   nameEl.textContent = name || sid;
-  body.appendChild(nameEl);
+  nameRow.appendChild(nameEl);
+
+  if (favorite && favorite.store && isFavoriteId(sid)) {
+    const getEntry = typeof favorite.getEntry === 'function'
+      ? favorite.getEntry
+      : () => ({ id: sid, name: name || sid, art: art || '', note: '' });
+    nameRow.appendChild(favoriteHeart({
+      store: favorite.store,
+      getEntry,
+      onCleanup: favorite.onCleanup,
+    }));
+  }
+
+  body.appendChild(nameRow);
 
   // --- secondary meta line (location · chips) -----------------------
   const meta = document.createElement('span');

--- a/admin/app/speaker-state.js
+++ b/admin/app/speaker-state.js
@@ -19,6 +19,7 @@
 import {
   xmlGet,
   presetsList,
+  favoritesList,
 } from './api.js';
 import {
   parseNowPlayingEl,
@@ -89,6 +90,21 @@ export const FIELDS = [
     apply(state, env) {
       if (env && env.ok && Array.isArray(env.data)) {
         state.speaker.presets = env.data;
+      }
+    },
+  },
+  {
+    // favourites — admin-owned, disjoint from firmware presets. No WS
+    // event (the speaker firmware doesn't know about favourites), so
+    // reconciliation is fetch-only: on app boot and on visibility-change
+    // to visible. The PUT round-trip updates state optimistically from
+    // the caller; the GET path is the floor in case another tab
+    // mutated the list.
+    name: 'favorites',
+    fetcher: favoritesList,
+    apply(state, env) {
+      if (env && env.ok && Array.isArray(env.data)) {
+        state.speaker.favorites = env.data;
       }
     },
   },

--- a/admin/app/speaker-state.js
+++ b/admin/app/speaker-state.js
@@ -97,7 +97,7 @@ export const FIELDS = [
     // favourites — admin-owned, disjoint from firmware presets. No WS
     // event (the speaker firmware doesn't know about favourites), so
     // reconciliation is fetch-only: on app boot and on visibility-change
-    // to visible. The PUT round-trip updates state optimistically from
+    // to visible. The POST round-trip updates state optimistically from
     // the caller; the GET path is the floor in case another tab
     // mutated the list.
     name: 'favorites',

--- a/admin/app/state.js
+++ b/admin/app/state.js
@@ -56,6 +56,10 @@ export const store = observable({
     recents:        null,   // [{utcTime, source, sourceAccount, type, location, itemName, containerArt}, ...]
     capabilities:   null,   // {deviceID, dspMonoStereo, lrStereoCapable, ..., capabilities:[{name,url}]}
     systemTimeout:    null, // {enabled, minutes}
+    // favourites — admin-owned, disjoint from the firmware-owned six
+    // hardware presets. null = unfetched; [] = fetched-and-empty.
+    // Entries: {id, name, art, note}. Position = array index.
+    favorites:      null,
   },
   caches: {
     probe:          new Map(),               // sid → Probe = {sid, verdict, tuneinJson, expires} — TTL 10 min

--- a/admin/app/toast.js
+++ b/admin/app/toast.js
@@ -5,6 +5,11 @@
 //
 // Used by the station detail view's preset-assign feedback and by ws.js
 // for "pressed on speaker" toasts.
+//
+// `showActionToast` extends the surface with a single inline action
+// button (e.g. "Undo" for the favourites-tab delete in #127). Its
+// dismiss() handle lets callers tear it down early — when the user
+// performs any other action, the in-flight toast collapses.
 
 const CONTAINER_ID = 'toast-container';
 const DEFAULT_DWELL_MS = 2000;
@@ -19,6 +24,17 @@ function ensureContainer() {
   el.setAttribute('aria-atomic', 'false');
   document.body.appendChild(el);
   return el;
+}
+
+// Animate-out + remove. Safe to call twice (idempotent on the node
+// already detached).
+function dismissNode(node) {
+  if (!node || node.__dismissed) return;
+  node.__dismissed = true;
+  node.classList.remove('is-shown');
+  setTimeout(() => {
+    if (node.parentNode) node.parentNode.removeChild(node);
+  }, FADE_MS);
 }
 
 // Show a toast with the given message. Returns the toast node so
@@ -40,12 +56,86 @@ export function showToast(message, dwellMs) {
   node.classList.add('is-shown');
 
   const ttl = Number.isFinite(dwellMs) && dwellMs > 0 ? dwellMs : DEFAULT_DWELL_MS;
-  setTimeout(() => {
-    node.classList.remove('is-shown');
-    setTimeout(() => {
-      if (node.parentNode) node.parentNode.removeChild(node);
-    }, FADE_MS);
-  }, ttl);
+  setTimeout(() => dismissNode(node), ttl);
 
   return node;
+}
+
+// Show a toast with an inline action button (label + onAction handler).
+// Returns `{ node, dismiss(reason) }`:
+//   - `dismiss('action')`  — fired internally when the user taps the
+//                            action; onAction has already been called.
+//   - `dismiss('timeout')` — auto-fired after `dwellMs` (5 s for
+//                            favourites delete) and signals that the
+//                            window of opportunity has closed; the
+//                            `onTimeout` callback runs.
+//   - `dismiss('early')`   — caller-driven (e.g. "any other user action
+//                            collapses the in-flight toast"); fires
+//                            `onEarlyDismiss` if provided.
+//
+// Only the first dismiss wins; subsequent calls are no-ops, so a
+// double-tap or a timeout firing during the action callback can't
+// double-dispatch the delete-permanent path.
+export function showActionToast({ message, actionLabel, onAction, onTimeout, onEarlyDismiss, dwellMs } = {}) {
+  if (typeof message !== 'string' || !message) return null;
+  if (typeof document === 'undefined') return null;
+
+  const container = ensureContainer();
+  const node = document.createElement('div');
+  node.className = 'toast toast--action';
+  node.setAttribute('role', 'status');
+
+  const text = document.createElement('span');
+  text.className = 'toast__text';
+  text.textContent = message;
+  node.appendChild(text);
+
+  let settled = false;
+
+  function dismiss(reason) {
+    if (settled) return;
+    settled = true;
+    dismissNode(node);
+    if (reason === 'timeout' && typeof onTimeout === 'function') {
+      try { onTimeout(); } catch (_e) { /* swallow */ }
+    } else if (reason === 'early' && typeof onEarlyDismiss === 'function') {
+      try { onEarlyDismiss(); } catch (_e) { /* swallow */ }
+    }
+  }
+
+  if (typeof actionLabel === 'string' && actionLabel) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'toast__action';
+    btn.textContent = actionLabel;
+    btn.addEventListener('click', (evt) => {
+      if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+      if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+      if (settled) return;
+      // Mark settled BEFORE firing the action so a re-entrant call into
+      // dismiss() (or a timeout racing in mid-action) can't double-fire.
+      settled = true;
+      try {
+        if (typeof onAction === 'function') onAction();
+      } finally {
+        dismissNode(node);
+      }
+    });
+    node.appendChild(btn);
+  }
+
+  container.appendChild(node);
+  void node.offsetWidth;
+  node.classList.add('is-shown');
+
+  const ttl = Number.isFinite(dwellMs) && dwellMs > 0 ? dwellMs : DEFAULT_DWELL_MS;
+  const timer = setTimeout(() => dismiss('timeout'), ttl);
+
+  // Wrap dismiss so the timer is cleared on any external dismissal too.
+  function dismissAndClear(reason) {
+    clearTimeout(timer);
+    dismiss(reason);
+  }
+
+  return { node, dismiss: dismissAndClear };
 }

--- a/admin/app/tunein-drill.js
+++ b/admin/app/tunein-drill.js
@@ -1,0 +1,212 @@
+// tunein-drill — one-shot TuneIn drill resolver.
+//
+// Owns the fetch policy for a single Browse.ashx drill: transport,
+// structured-error envelopes, empty / tombstone classification, and the
+// head.status discrimination that turns "TuneIn rejected the drill but
+// the CGI still returned 200" (e.g. c=pbrowse on Bo's egress, see
+// issue #84) into the empty state. Before this seam those branches were
+// scattered across browse.js renderDrill, show-landing.js, and
+// renderOutline's body-emptiness check; the seam concentrates them so
+// the renderer sees a tagged DrillResult rather than a raw JSON envelope
+// that could be a payload, an empty state, or a structured error.
+//
+// Contract:
+//
+//   resolveBrowseDrill(parts, opts?) -> Promise<DrillResult>
+//
+//   DrillResult =
+//     | { kind: 'ok',    json }
+//     | { kind: 'empty', message }
+//     | { kind: 'error', error: { code, message } }
+//
+// Classification (matches the table in issue #122):
+//
+//   - `fetch` throws (timeout / CGI 5xx / network)
+//       → { kind: 'error', error: { code, message } }
+//   - body is `{ ok: false, error: { code, message } }`
+//       → { kind: 'error', error: { code, message } }  (pass-through)
+//   - body is raw `{ error: "..." }` (wget upstream-fetch failure)
+//       → { kind: 'error', error: { code: 'UPSTREAM_FETCH_FAILED', message } }
+//   - `head.status` is non-200 AND `body:[]` (TuneIn rejected drill,
+//     e.g. c=pbrowse on Bo's egress)
+//       → { kind: 'empty', message }
+//   - `body:[]` with head.status 200
+//       → { kind: 'empty', message: 'Nothing here.' }
+//   - single-entry body whose only row classifies as tombstone AND
+//     carries no children
+//       → { kind: 'empty', message: entry.text || 'Nothing here.' }
+//   - otherwise
+//       → { kind: 'ok', json }
+//
+// Caching of drill bodies is intentionally out of scope (see #122 body).
+// The label cache continues to be primed downstream by the renderer's
+// row pipeline.
+
+import { tuneinBrowse } from './api.js';
+import { classifyOutline } from './tunein-outline.js';
+
+const FALLBACK_EMPTY_MESSAGE = 'Nothing here.';
+
+// The error code the CGI's raw `{"error":"..."}` body maps to. The
+// busybox-shell tunein CGI emits this exact body when its `wget` call
+// against opml.radiotime.com fails (network down, DNS, etc.) — see
+// admin/cgi-bin/api/v1/tunein. The shape pre-dates the structured
+// envelope and only the tunein route still emits it, so we recognise
+// it here rather than promote it to the CGI-shared envelope schema.
+const UPSTREAM_FETCH_FAILED = 'UPSTREAM_FETCH_FAILED';
+
+// Pull a usable head.status string out of the response head. Empty
+// when missing / non-string. Numeric statuses are coerced to string so
+// the comparison against '200' is reliable regardless of upstream
+// shape drift.
+function headStatus(json) {
+  const head = json && typeof json === 'object' ? json.head : null;
+  if (!head || typeof head !== 'object') return '';
+  const s = head.status;
+  if (typeof s === 'string') return s;
+  if (typeof s === 'number' && Number.isFinite(s)) return String(s);
+  return '';
+}
+
+// Pull a usable head.title / head.fault string for the empty-state
+// message when TuneIn rejects the drill. Prefer `fault` (the rejection
+// reason, e.g. "Invalid root category") over `title` (often "Music" or
+// the request's category label, which carries no signal about why the
+// drill came back empty). Final fallback is FALLBACK_EMPTY_MESSAGE so
+// the user always sees something readable.
+function headFaultMessage(json) {
+  const head = json && typeof json === 'object' ? json.head : null;
+  if (head && typeof head === 'object') {
+    if (typeof head.fault === 'string' && head.fault !== '') return head.fault;
+  }
+  return FALLBACK_EMPTY_MESSAGE;
+}
+
+// Recognise the CGI's structured `{ok:false, error:{code, message}}`
+// envelope. Returns the normalised `{code, message}` pair when the
+// envelope matches, null otherwise.
+function pickStructuredError(json) {
+  if (!json || typeof json !== 'object') return null;
+  if (json.ok !== false) return null;
+  const err = json.error;
+  if (!err || typeof err !== 'object') return null;
+  const code = typeof err.code === 'string' && err.code !== ''
+    ? err.code
+    : 'ERROR';
+  const message = typeof err.message === 'string' && err.message !== ''
+    ? err.message
+    : code;
+  return { code, message };
+}
+
+// Recognise the raw `{ "error": "<text>" }` body the busybox CGI emits
+// on upstream wget failure. Returns the normalised error pair (with a
+// stable code) when matched, null otherwise. Defensive against the
+// structured-error envelope above — only triggers when `error` is a
+// bare string AND `ok` is absent.
+function pickRawError(json) {
+  if (!json || typeof json !== 'object') return null;
+  if (Object.prototype.hasOwnProperty.call(json, 'ok')) return null;
+  const e = json.error;
+  if (typeof e !== 'string' || e === '') return null;
+  return { code: UPSTREAM_FETCH_FAILED, message: e };
+}
+
+// Normalise an error thrown by the fetcher (timeout, CGI 5xx, network).
+// fetchWithTimeout decorates timeouts with `name === 'TimeoutError'`;
+// every other throw lands here as a bare Error. Returns the
+// `{code, message}` pair the DrillResult contract expects.
+function normaliseThrownError(err) {
+  if (!err) {
+    return { code: 'ERROR', message: 'Unknown error' };
+  }
+  const name = typeof err.name === 'string' ? err.name : '';
+  if (name === 'TimeoutError') {
+    return {
+      code: 'TIMEOUT',
+      message: typeof err.message === 'string' && err.message
+        ? err.message
+        : 'Drill fetch timed out',
+    };
+  }
+  const message = typeof err.message === 'string' && err.message
+    ? err.message
+    : String(err);
+  return { code: 'ERROR', message };
+}
+
+// True when this is the canonical "single tombstone" body shape: one
+// top-level entry that classifies as tombstone AND carries no children.
+// A section header with children (e.g. an empty `local` wrapper) can
+// also classify as tombstone via the typeless fallback, so we guard on
+// children-absence to keep section-bearing payloads on the `ok` path
+// (per-section emptiness is renderOutline's job).
+function isSingleTombstone(items) {
+  if (!Array.isArray(items) || items.length !== 1) return false;
+  const only = items[0];
+  if (classifyOutline(only) !== 'tombstone') return false;
+  if (only && Array.isArray(only.children) && only.children.length > 0) {
+    return false;
+  }
+  return true;
+}
+
+// resolveBrowseDrill — fetch + classify a single Browse.ashx drill.
+//
+// `parts` is the same shape browse.js renderDrill already constructs:
+// either `{ id: '<guide_id>' }` for bare-id drills, or `{ c: 'music',
+// filter: 'l109' }` for the c-style top-level (URLSearchParams handles
+// both). `tuneinBrowse(parts)` is the existing fetcher; it returns the
+// raw TuneIn JSON body and throws on transport / non-2xx.
+//
+// `opts.fetch` lets tests dependency-inject a scripted fetcher so the
+// classification table is exercised without going through `globalThis
+// .fetch`. Default is the production tuneinBrowse.
+export async function resolveBrowseDrill(parts, opts) {
+  const fetchDrill = (opts && typeof opts.fetch === 'function')
+    ? opts.fetch
+    : tuneinBrowse;
+
+  let json;
+  try {
+    json = await fetchDrill(parts);
+  } catch (err) {
+    return { kind: 'error', error: normaliseThrownError(err) };
+  }
+
+  // Structured envelope — pass code / message through verbatim. Order
+  // matters: the structured envelope sets `ok:false`, so this must run
+  // before the raw `{error:'...'}` check which only triggers when `ok`
+  // is absent.
+  const structured = pickStructuredError(json);
+  if (structured) return { kind: 'error', error: structured };
+
+  // Raw wget-failure envelope from the busybox CGI.
+  const raw = pickRawError(json);
+  if (raw) return { kind: 'error', error: raw };
+
+  const body = json && Array.isArray(json.body) ? json.body : [];
+
+  // head.status non-200 with body:[] — TuneIn rejected the drill but
+  // the CGI still surfaced a 200. The head.fault carries the reason
+  // (e.g. "Invalid root category" for c=pbrowse on Bo's egress).
+  if (body.length === 0) {
+    const status = headStatus(json);
+    if (status !== '' && status !== '200') {
+      return { kind: 'empty', message: headFaultMessage(json) };
+    }
+    return { kind: 'empty', message: FALLBACK_EMPTY_MESSAGE };
+  }
+
+  // Single-entry tombstone — the canonical "No stations or shows
+  // available" body shape (§ 6.2). A section wrapper with children is
+  // not a tombstone even when classifyOutline tags it that way.
+  if (isSingleTombstone(body)) {
+    const text = (body[0] && typeof body[0].text === 'string' && body[0].text !== '')
+      ? body[0].text
+      : FALLBACK_EMPTY_MESSAGE;
+    return { kind: 'empty', message: text };
+  }
+
+  return { kind: 'ok', json };
+}

--- a/admin/app/views/browse.js
+++ b/admin/app/views/browse.js
@@ -5,7 +5,9 @@
 // "Load more" pagination, the eager-serial crawl coordinator, and
 // the c=pbrowse show-landing body all live in the per-concern
 // submodules under `./browse/`. The crumb-stack value type +
-// renderers + hydrators live in `./browse/crumbs.js`.
+// renderers + hydrators are split between `./browse/crumb-parts.js`
+// (pure value type + label-resolution reads) and
+// `./browse/crumb-renderer.js` (DOM pillbar + async label hydration).
 //
 // Two modes:
 //   1. Root view (#/browse): three-tab segmented control (Genre /
@@ -64,13 +66,15 @@ import {
   crumbLabelFor,
   backHrefFor,
   initialHeaderTitle,
+} from './browse/crumb-parts.js';
+import {
   renderPillBar,
   renderCrumbTrail,
   renderFilterBadge,
   renderFilterBadges,
   hydrateCrumbLabels,
   patchTrailCrumb,
-} from './browse/crumbs.js';
+} from './browse/crumb-renderer.js';
 
 // Re-export the entry/render primitives + crumb helpers + test hooks
 // so existing callers (test_browse, test_browse_crumbs,

--- a/admin/app/views/browse.js
+++ b/admin/app/views/browse.js
@@ -22,6 +22,7 @@ import { html, mount, defineView } from '../dom.js';
 import { tuneinBrowse } from '../api.js';
 import { lcodeLabel, LCODES_LOADED_EVENT } from '../tunein-url.js';
 import { cache, TTL_LABEL } from '../tunein-cache.js';
+import { resolveBrowseDrill } from '../tunein-drill.js';
 
 import {
   renderOutline,
@@ -31,6 +32,7 @@ import {
   pluralize,
   skeleton,
   errorNode,
+  emptyNode,
   _setChildCrumbsForTest,
 } from './browse/outline-render.js';
 import {
@@ -329,15 +331,79 @@ function renderDrill(root, parts, crumbs) {
   // next navigation. (#89, #90)
   registerLcodeRepatch(parts, frame.crumbId, frame.trailEl, frame.stack, frame.backEl, frame.bar && frame.bar._filter);
 
-  // tuneinBrowse accepts a parts object as the c-style top-level form
-  // (`{c: 'music', filter: 'l216'}`) or a bare id string. The c+filter
-  // shape is the language-tree rewrite output (§ 7.3); pass parts
-  // through verbatim.
-  loadInto(body, tuneinBrowse(parts), frame.headerCount, {
+  // One-shot drill — the seam owns the fetch policy: transport throws,
+  // structured-error envelopes, the head.status non-200 + body:[] case
+  // (c=pbrowse on Bo's egress, etc.), and the canonical empty / single-
+  // tombstone shapes all collapse to a tagged DrillResult. The renderer
+  // here is the thin shell that paints each kind. parts pass through
+  // verbatim — the seam consumes the c-style top-level form
+  // (`{c:'music', filter:'l216'}`) or a bare-id form the same way
+  // tuneinBrowse does.
+  loadDrillBody(body, parts, frame.headerCount, {
     titleEl: frame.titleEl,
     crumbToken: frame.currentToken,
     trailEl: frame.trailEl,
   });
+}
+
+// loadDrillBody — drill-specific body loader. Reads the seam's
+// classified DrillResult and paints exactly one of three outcomes;
+// the renderOutline branch keeps the success-path side-effects the
+// original loadInto carried (header count, title upgrade, crumb-label
+// cache write, Load-more wiring, sticky-filter rehydration).
+function loadDrillBody(body, parts, headerCount, head) {
+  body.replaceChildren();
+  body.appendChild(skeleton());
+  if (headerCount) headerCount.textContent = '';
+  resolveBrowseDrill(parts)
+    .then((r) => {
+      body.replaceChildren();
+      if (r.kind === 'error') {
+        body.appendChild(errorNode(r.error));
+        return;
+      }
+      if (r.kind === 'empty') {
+        body.appendChild(emptyNode(r.message));
+        return;
+      }
+      const json = r.json;
+      const total = renderOutline(body, json);
+      if (headerCount && total > 0) {
+        headerCount.textContent = `${total.toLocaleString()} ${pluralize(total)}`;
+      }
+      const title = json && json.head && typeof json.head.title === 'string'
+        ? json.head.title
+        : '';
+      if (head && head.titleEl && title) {
+        head.titleEl.textContent = title;
+      }
+      if (head && head.crumbToken && title) {
+        cache.set(`tunein.label.${head.crumbToken}`, title, TTL_LABEL);
+        // Also refresh the trail's current-crumb segment so the bolded
+        // tail matches the h1 (was rendering as the raw sid until
+        // Describe resolved). The patcher is a no-op when the trail
+        // isn't mounted.
+        if (head.trailEl) patchTrailCrumb(head.trailEl, head.crumbToken, title);
+      }
+      // Mount one pager + Load-more button per section that came back
+      // with a cursor URL parked on it by renderSection / renderFlatSection.
+      mountLoadMoreButtons(body);
+      // If the filter input already has text (e.g. user navigates with
+      // a sticky filter), apply it to the freshly-rendered rows and
+      // kick the coordinator.
+      if (currentFilterQuery() !== '') {
+        applyDomFilter();
+        ensureCoordinator();
+      }
+    })
+    .catch((err) => {
+      // Defence: resolveBrowseDrill is structured to never reject — every
+      // transport throw collapses into kind:'error'. A reject here would
+      // be a programmer error in the seam itself; render an error node
+      // rather than leaving the skeleton mounted.
+      body.replaceChildren();
+      body.appendChild(errorNode(err));
+    });
 }
 
 // One-shot listener: when the lcode catalogue is broadcast as loaded,

--- a/admin/app/views/browse/crumb-parts.js
+++ b/admin/app/views/browse/crumb-parts.js
@@ -1,0 +1,298 @@
+// crumb-parts — the Crumb stack value type plus its label-resolution
+// read-side. Pure: no DOM, no fetch, no api.js. The companion
+// `crumb-renderer.js` owns the DOM pillbar + async label hydration that
+// builds on these primitives.
+//
+// What lives here:
+//   - Value type: `parts` (drill state) ↔ crumb token ↔ `from=…` stack.
+//     parseCrumbs / stringifyCrumbs, crumbTokenFor / partsFromCrumb,
+//     pickDrillParts, filtersOf / setFilters, MAX_CRUMBS.
+//   - Label readers (no fetch): initialHeaderTitle, initialCrumbLabel,
+//     initialFilterLabel, crumbLabelFor, backAriaLabel.
+//   - URL composers: backHrefFor (pops the rightmost crumb).
+//   - Tab-token override table: TAB_LABEL_BY_TOKEN.
+//
+// Only dependencies allowed by issue #124: tunein-cache.js (label cache
+// reads) and tunein-url.js (lcodeLabel for the language catalogue).
+// Anything that touches the DOM, kicks a Describe / Browse fetch, or
+// patches a rendered crumb lives in `crumb-renderer.js`.
+
+import { lcodeLabel } from '../../tunein-url.js';
+import { cache } from '../../tunein-cache.js';
+
+// Maximum depth of the URL crumb stack (`from=...`). Deeper than the
+// deepest observed location-tree depth (5); see issue #74 notes. Any
+// crumbs beyond this are dropped from the head of the stack.
+export const MAX_CRUMBS = 8;
+
+// Trail label override for the entry-point tab tokens. The first
+// crumb on any rooted drill is the tab — the spec wants its label
+// to read as the tab name (`Genre` / `Location` / `Language`), not
+// the cached API title ("Music" / "By Location" / "By Language").
+// Matched against the bare anchor portion of a crumb token; tokens
+// with an `:lXXX` filter suffix fall through to the cache /
+// catalogue path so e.g. `lang:l109` still resolves to "German".
+export const TAB_LABEL_BY_TOKEN = Object.freeze({
+  music: 'Genre',
+  r0:    'Location',
+  lang:  'Language',
+});
+
+// ---- value type: parts + crumb token --------------------------------
+
+// Parse the comma-separated `from=` query parameter into an array of
+// crumb tokens. Empty / missing input returns []. Trims, drops empty
+// segments, caps to MAX_CRUMBS by keeping the tail (the most recent
+// crumbs — the ones closest to the current node).
+export function parseCrumbs(raw) {
+  if (typeof raw !== 'string' || raw === '') return [];
+  const segs = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return segs.length > MAX_CRUMBS ? segs.slice(segs.length - MAX_CRUMBS) : segs;
+}
+
+// Inverse of parseCrumbs: stringify the crumb array into a `from=`
+// value. Returns '' for an empty array so callers can skip emitting
+// the parameter entirely.
+export function stringifyCrumbs(crumbs) {
+  if (!Array.isArray(crumbs) || crumbs.length === 0) return '';
+  return crumbs.join(',');
+}
+
+// Helpers for the `filters` array shape. Always returns a fresh array
+// of trimmed non-empty strings. Tolerates legacy callers still passing
+// `parts.filter` as a single string (or a pre-joined comma list).
+export function filtersOf(parts) {
+  if (!parts) return [];
+  if (Array.isArray(parts.filters)) {
+    return parts.filters.filter((s) => typeof s === 'string' && s !== '');
+  }
+  if (typeof parts.filter === 'string' && parts.filter !== '') {
+    return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+// Stash a `filters: string[]` (and back-compat `filter: string`) on a
+// parts object. Empty arrays drop both fields so the URL composer emits
+// the bare drill (no `filter=` param).
+export function setFilters(parts, list) {
+  const cleaned = (Array.isArray(list) ? list : []).filter((s) => typeof s === 'string' && s !== '');
+  if (cleaned.length > 0) {
+    parts.filters = cleaned;
+    parts.filter  = cleaned.join(',');
+  } else {
+    delete parts.filters;
+    delete parts.filter;
+  }
+  return parts;
+}
+
+// Crumb token for a drill-parts object. The token is the value the
+// user would land on if they clicked Back to this level: prefer `id`,
+// fall back to `c`. When filters accompany the anchor we encode them
+// as `<anchor>:<f1>+<f2>+…` so two drills that share the same anchor
+// but differ in their filters (e.g. the language tree, where every
+// level emits `c=lang` or `c=music` with a different `filter=l<NNN>`)
+// produce distinct, navigable crumbs (#89, #106). pivots / offsets
+// remain refinements that do not become crumbs.
+// Returns null when neither anchor is set (root view).
+export function crumbTokenFor(parts) {
+  if (!parts) return null;
+  let anchor = '';
+  if (typeof parts.id === 'string' && parts.id !== '') anchor = parts.id;
+  else if (typeof parts.c === 'string' && parts.c !== '') anchor = parts.c;
+  if (!anchor) return null;
+  const filters = filtersOf(parts);
+  if (filters.length > 0) {
+    return `${anchor}:${filters.join('+')}`;
+  }
+  return anchor;
+}
+
+// Inverse of crumbTokenFor: turn a crumb token back into the drill
+// parts the user should land on. Heuristic:
+//   - bare tokens matching /^[a-z]\d+$/ are guide_ids (`id=` anchor)
+//   - bare tokens otherwise are category short names (`c=`)
+//   - tokens with a `:f1+f2+…` suffix attach N filters to whichever
+//     anchor form applies (so `lang:l109` → `{c:'lang', filters:['l109']}`,
+//     `r101821:g26+l170` → `{id:'r101821', filters:['g26','l170']}`)
+export function partsFromCrumb(token) {
+  if (typeof token !== 'string' || token === '') return null;
+  const colonIdx = token.indexOf(':');
+  let anchor = token;
+  let filterRaw = '';
+  if (colonIdx >= 0) {
+    anchor = token.slice(0, colonIdx);
+    filterRaw = token.slice(colonIdx + 1);
+  }
+  if (!anchor) return null;
+  const parts = /^[a-z]\d+$/.test(anchor) ? { id: anchor } : { c: anchor };
+  if (filterRaw) {
+    const list = filterRaw.split('+').map((s) => s.trim()).filter(Boolean);
+    setFilters(parts, list);
+  }
+  return parts;
+}
+
+// A drill URL can carry any of {id, c, filter, pivot, offset}. The
+// presence of `id` or `c` is the load-bearing signal; the others
+// modify the drill. The URL's `filter=` may be comma-separated values
+// (multi-filter wire shape, #106); the resulting parts object carries
+// `filters: string[]` plus back-compat `filter: string`. Returns null
+// when neither anchor is set (root view).
+export function pickDrillParts(query) {
+  if (!query || (typeof query.id !== 'string' && typeof query.c !== 'string')) {
+    return null;
+  }
+  const out = {};
+  for (const key of ['id', 'c', 'pivot', 'offset']) {
+    if (typeof query[key] === 'string' && query[key] !== '') out[key] = query[key];
+  }
+  if (typeof query.filter === 'string' && query.filter !== '') {
+    const list = query.filter.split(',').map((s) => s.trim()).filter(Boolean);
+    setFilters(out, list);
+  }
+  return out;
+}
+
+// Display label for the drill crumb — a compact form of the parts.
+// `c=music&filter=l216` reads more usefully than just `music`. When
+// the filter is an lcode (`l<NNN>`) and we have a cached language
+// name for it, append the human form so end users get an at-a-glance
+// translation of the otherwise opaque numeric filter (#90). With
+// multi-filter drills (#106) the comma-joined wire value is shown;
+// a single-lcode filter still resolves to its language name.
+export function crumbLabelFor(parts) {
+  const segs = [];
+  const filters = filtersOf(parts);
+  const filterStr = filters.join(',');
+  if (parts.id) segs.push(parts.id);
+  if (parts.c)  segs.push(`c=${parts.c}`);
+  if (filterStr) segs.push(`filter=${filterStr}`);
+  if (parts.pivot)  segs.push(`pivot=${parts.pivot}`);
+  if (parts.offset) segs.push(`offset=${parts.offset}`);
+  let label = segs.join(' · ');
+  if (filters.length === 1 && /^l\d+$/.test(filters[0])) {
+    const name = lcodeLabel(filters[0]);
+    if (name) label += ` (${name})`;
+  }
+  return label;
+}
+
+// Pure URL composer for the SPA-internal drill hash. Mirrors
+// outline-render's drillHashFor but takes the crumb prefix explicitly
+// instead of reading the module-level `_childCrumbs` — this is the
+// pure surface backHrefFor needs (crumb-parts.js may not depend on
+// outline-render.js, which is DOM-bound).
+function drillHash(parts, crumbs) {
+  const qs = new URLSearchParams();
+  if (parts.id)     qs.set('id', parts.id);
+  if (parts.c)      qs.set('c', parts.c);
+  const filters = filtersOf(parts);
+  if (filters.length > 0) qs.set('filter', filters.join(','));
+  if (parts.pivot)  qs.set('pivot', parts.pivot);
+  if (parts.offset) qs.set('offset', parts.offset);
+  const fromStr = stringifyCrumbs(crumbs);
+  if (fromStr) qs.set('from', fromStr);
+  return `#/browse?${qs.toString()}`;
+}
+
+// Compose the Back-button href. Pops the rightmost crumb and navigates
+// to it; the popped crumb keeps the remaining stack as its own `from=`.
+// An empty stack lands at #/browse (the root tabs view).
+export function backHrefFor(stack) {
+  if (!Array.isArray(stack) || stack.length === 0) return '#/browse';
+  const head = stack.slice(0, -1);
+  const tail = stack[stack.length - 1];
+  const parts = partsFromCrumb(tail);
+  if (!parts) return '#/browse';
+  return drillHash(parts, head);
+}
+
+// Initial page-header title before the API response arrives. Prefer
+// the cached label for this node's token; fall back to crumbLabelFor
+// so the user sees *something* during the load.
+//
+// Filter-bearing tokens (`<anchor>:<filter>`) try the bare anchor too:
+// the page IS the anchor node (just filtered), so a cached title for
+// `r101821` should surface as the h1 / current-crumb text for the
+// `r101821:g26` drill too. The filter surface is the badge, not the
+// title.
+export function initialHeaderTitle(parts, token) {
+  if (token) {
+    const cached = cache.get(`tunein.label.${token}`);
+    if (typeof cached === 'string' && cached !== '') return cached;
+    const colon = token.indexOf(':');
+    if (colon > 0) {
+      const bare = token.slice(0, colon);
+      const cachedBare = cache.get(`tunein.label.${bare}`);
+      if (typeof cachedBare === 'string' && cachedBare !== '') return cachedBare;
+    }
+  }
+  return crumbLabelFor(parts);
+}
+
+// Pick the best already-known label for a crumb token without doing
+// any network work. Order of preference for ancestors:
+//   - tab-token override (only at stack[0] — the entry-point tab)
+//   - cached label under `tunein.label.<token>` (from a previous
+//     resolve)
+//   - in-memory lcode catalogue (free for `<anchor>:l<NNN>` tokens)
+//   - raw token fallback
+// The async hydrateCrumbLabels path (in crumb-renderer) upgrades any
+// token still rendered as raw once its Describe / Browse lookup
+// completes.
+export function initialCrumbLabel(token, parts, isFirstInStack) {
+  // The first crumb in the stack is the entry-point tab — render it
+  // with the tab's display label (`Genre` / `Location` / `Language`)
+  // rather than the cached API title ("Music" / "By Location" / "By
+  // Language"). Filter-bearing tokens (`lang:lXXX`) intentionally
+  // fall through to the catalogue path so they read as the language
+  // name, not "Language".
+  if (isFirstInStack) {
+    const bareAnchor = parts && typeof parts.id === 'string'
+      ? parts.id
+      : (parts && typeof parts.c === 'string' ? parts.c : '');
+    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
+    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) {
+      return TAB_LABEL_BY_TOKEN[bareAnchor];
+    }
+  }
+  const cached = cache.get(`tunein.label.${token}`);
+  if (typeof cached === 'string' && cached !== '') return cached;
+  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
+    const name = lcodeLabel(parts.filter);
+    if (name) return name;
+  }
+  return token;
+}
+
+// Pick the best already-known label for a filter token without any
+// network work. Mirrors the trail's `initialCrumbLabel` ladder for the
+// filter-only case: lcode catalogue for `lXXX`, then the cache, then
+// the raw token as a last resort.
+export function initialFilterLabel(filterToken) {
+  if (/^l\d+$/.test(filterToken)) {
+    const name = lcodeLabel(filterToken);
+    if (name) return name;
+  }
+  const cached = cache.get(`tunein.label.${filterToken}`);
+  if (typeof cached === 'string' && cached !== '') return cached;
+  return filterToken;
+}
+
+// Compose the Back chevron's aria-label from the popped destination.
+// Empty stack → root tabs view ("Back to Browse"). Otherwise the
+// destination is the last crumb in the stack; prefer the resolved
+// label (cache / catalogue) and fall back to the raw token.
+export function backAriaLabel(stack) {
+  if (!Array.isArray(stack) || stack.length === 0) return 'Back to Browse';
+  const destToken = stack[stack.length - 1];
+  if (!destToken) return 'Back to Browse';
+  const destParts = partsFromCrumb(destToken);
+  // The last crumb in the stack is the trail's tail-before-current —
+  // it's an ancestor, not the entry-point tab, so isFirstInStack is
+  // only relevant when stack length is 1.
+  const label = initialCrumbLabel(destToken, destParts, stack.length === 1);
+  return `Back to ${label}`;
+}

--- a/admin/app/views/browse/crumb-renderer.js
+++ b/admin/app/views/browse/crumb-renderer.js
@@ -1,17 +1,19 @@
-// crumbs — the URL crumb stack as a self-contained module. Owns the
-// `parts` value type (the canonical drill-state shape passed around the
-// browser), the crumb token parser/emitter pair (parseCrumbs /
-// stringifyCrumbs, crumbTokenFor / partsFromCrumb), the pill-bar
-// renderer with its inline trail + filter badges (renderPillBar,
-// renderCrumbTrail, renderFilterBadges, renderFilterBadge), and the
-// async label hydration that upgrades raw-token renderings to
-// human-readable names once Describe/Browse resolves (hydrateCrumbLabels,
-// hydrateFilterLabel, patchTrailCrumb, patchBackAria,
-// resolveLabelAndApply).
+// crumb-renderer — DOM + async hydration half of the Crumb stack
+// module. The pure value type, parsing/emission, and label-resolution
+// reads live in `./crumb-parts.js`; this file builds on those to
+// render the pill bar (Back chevron + inline trail + filter badges)
+// and to upgrade raw-token renderings to human-readable names once
+// Describe / Browse resolves.
 //
-// The companion `views/browse.js` mounts the view; this module owns
-// everything below the mount boundary that deals with crumb-state
-// arithmetic.
+// What lives here:
+//   - DOM builders: renderPillBar, renderCrumbTrail, renderFilterBadges,
+//     renderFilterBadge (legacy single-filter shim), buildFilterBadge,
+//     makeSeparator.
+//   - Async label hydration: hydrateCrumbLabels, hydrateFilterLabel,
+//     resolveLabelAndApply, patchTrailCrumb, patchBackAria.
+//   - Small infrastructure: DESCRIBE_CONCURRENCY (concurrency cap for
+//     the cold-load label-fill wave), cssEscape (defensive attribute
+//     escape — CSS.escape isn't available under xmldom in tests).
 
 import { tuneinBrowse, tuneinDescribe } from '../../api.js';
 import { icon } from '../../icons.js';
@@ -19,209 +21,24 @@ import { lcodeLabel } from '../../tunein-url.js';
 import { cache, TTL_LABEL } from '../../tunein-cache.js';
 
 import { drillHashFor } from './outline-render.js';
-
-// Maximum depth of the URL crumb stack (`from=...`). Deeper than the
-// deepest observed location-tree depth (5); see issue #74 notes. Any
-// crumbs beyond this are dropped from the head of the stack.
-export const MAX_CRUMBS = 8;
+import {
+  TAB_LABEL_BY_TOKEN,
+  backAriaLabel,
+  backHrefFor,
+  crumbTokenFor,
+  filtersOf,
+  initialCrumbLabel,
+  initialFilterLabel,
+  initialHeaderTitle,
+  partsFromCrumb,
+  setFilters,
+} from './crumb-parts.js';
 
 // Maximum number of `Describe.ashx?id=<X>` calls in flight at once
 // during cold-load label-fill. Matches MAX_CRUMBS so the worst case
 // (a fully-deep shared URL with no cached labels) saturates in one
 // wave.
 const DESCRIBE_CONCURRENCY = 5;
-
-// Trail label override for the entry-point tab tokens. The first
-// crumb on any rooted drill is the tab — the spec wants its label
-// to read as the tab name (`Genre` / `Location` / `Language`), not
-// the cached API title ("Music" / "By Location" / "By Language").
-// Matched against the bare anchor portion of a crumb token; tokens
-// with an `:lXXX` filter suffix fall through to the cache /
-// catalogue path so e.g. `lang:l109` still resolves to "German".
-const TAB_LABEL_BY_TOKEN = Object.freeze({
-  music: 'Genre',
-  r0:    'Location',
-  lang:  'Language',
-});
-
-// ---- value type: parts + crumb token --------------------------------
-
-// Parse the comma-separated `from=` query parameter into an array of
-// crumb tokens. Empty / missing input returns []. Trims, drops empty
-// segments, caps to MAX_CRUMBS by keeping the tail (the most recent
-// crumbs — the ones closest to the current node).
-export function parseCrumbs(raw) {
-  if (typeof raw !== 'string' || raw === '') return [];
-  const segs = raw.split(',').map((s) => s.trim()).filter(Boolean);
-  return segs.length > MAX_CRUMBS ? segs.slice(segs.length - MAX_CRUMBS) : segs;
-}
-
-// Inverse of parseCrumbs: stringify the crumb array into a `from=`
-// value. Returns '' for an empty array so callers can skip emitting
-// the parameter entirely.
-export function stringifyCrumbs(crumbs) {
-  if (!Array.isArray(crumbs) || crumbs.length === 0) return '';
-  return crumbs.join(',');
-}
-
-// Helpers for the `filters` array shape. Always returns a fresh array
-// of trimmed non-empty strings. Tolerates legacy callers still passing
-// `parts.filter` as a single string (or a pre-joined comma list).
-export function filtersOf(parts) {
-  if (!parts) return [];
-  if (Array.isArray(parts.filters)) {
-    return parts.filters.filter((s) => typeof s === 'string' && s !== '');
-  }
-  if (typeof parts.filter === 'string' && parts.filter !== '') {
-    return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
-  }
-  return [];
-}
-
-// Stash a `filters: string[]` (and back-compat `filter: string`) on a
-// parts object. Empty arrays drop both fields so the URL composer emits
-// the bare drill (no `filter=` param).
-export function setFilters(parts, list) {
-  const cleaned = (Array.isArray(list) ? list : []).filter((s) => typeof s === 'string' && s !== '');
-  if (cleaned.length > 0) {
-    parts.filters = cleaned;
-    parts.filter  = cleaned.join(',');
-  } else {
-    delete parts.filters;
-    delete parts.filter;
-  }
-  return parts;
-}
-
-// Crumb token for a drill-parts object. The token is the value the
-// user would land on if they clicked Back to this level: prefer `id`,
-// fall back to `c`. When filters accompany the anchor we encode them
-// as `<anchor>:<f1>+<f2>+…` so two drills that share the same anchor
-// but differ in their filters (e.g. the language tree, where every
-// level emits `c=lang` or `c=music` with a different `filter=l<NNN>`)
-// produce distinct, navigable crumbs (#89, #106). pivots / offsets
-// remain refinements that do not become crumbs.
-// Returns null when neither anchor is set (root view).
-export function crumbTokenFor(parts) {
-  if (!parts) return null;
-  let anchor = '';
-  if (typeof parts.id === 'string' && parts.id !== '') anchor = parts.id;
-  else if (typeof parts.c === 'string' && parts.c !== '') anchor = parts.c;
-  if (!anchor) return null;
-  const filters = filtersOf(parts);
-  if (filters.length > 0) {
-    return `${anchor}:${filters.join('+')}`;
-  }
-  return anchor;
-}
-
-// Inverse of crumbTokenFor: turn a crumb token back into the drill
-// parts the user should land on. Heuristic:
-//   - bare tokens matching /^[a-z]\d+$/ are guide_ids (`id=` anchor)
-//   - bare tokens otherwise are category short names (`c=`)
-//   - tokens with a `:f1+f2+…` suffix attach N filters to whichever
-//     anchor form applies (so `lang:l109` → `{c:'lang', filters:['l109']}`,
-//     `r101821:g26+l170` → `{id:'r101821', filters:['g26','l170']}`)
-export function partsFromCrumb(token) {
-  if (typeof token !== 'string' || token === '') return null;
-  const colonIdx = token.indexOf(':');
-  let anchor = token;
-  let filterRaw = '';
-  if (colonIdx >= 0) {
-    anchor = token.slice(0, colonIdx);
-    filterRaw = token.slice(colonIdx + 1);
-  }
-  if (!anchor) return null;
-  const parts = /^[a-z]\d+$/.test(anchor) ? { id: anchor } : { c: anchor };
-  if (filterRaw) {
-    const list = filterRaw.split('+').map((s) => s.trim()).filter(Boolean);
-    setFilters(parts, list);
-  }
-  return parts;
-}
-
-// A drill URL can carry any of {id, c, filter, pivot, offset}. The
-// presence of `id` or `c` is the load-bearing signal; the others
-// modify the drill. The URL's `filter=` may be comma-separated values
-// (multi-filter wire shape, #106); the resulting parts object carries
-// `filters: string[]` plus back-compat `filter: string`. Returns null
-// when neither anchor is set (root view).
-export function pickDrillParts(query) {
-  if (!query || (typeof query.id !== 'string' && typeof query.c !== 'string')) {
-    return null;
-  }
-  const out = {};
-  for (const key of ['id', 'c', 'pivot', 'offset']) {
-    if (typeof query[key] === 'string' && query[key] !== '') out[key] = query[key];
-  }
-  if (typeof query.filter === 'string' && query.filter !== '') {
-    const list = query.filter.split(',').map((s) => s.trim()).filter(Boolean);
-    setFilters(out, list);
-  }
-  return out;
-}
-
-// Display label for the drill crumb — a compact form of the parts.
-// `c=music&filter=l216` reads more usefully than just `music`. When
-// the filter is an lcode (`l<NNN>`) and we have a cached language
-// name for it, append the human form so end users get an at-a-glance
-// translation of the otherwise opaque numeric filter (#90). With
-// multi-filter drills (#106) the comma-joined wire value is shown;
-// a single-lcode filter still resolves to its language name.
-export function crumbLabelFor(parts) {
-  const segs = [];
-  const filters = filtersOf(parts);
-  const filterStr = filters.join(',');
-  if (parts.id) segs.push(parts.id);
-  if (parts.c)  segs.push(`c=${parts.c}`);
-  if (filterStr) segs.push(`filter=${filterStr}`);
-  if (parts.pivot)  segs.push(`pivot=${parts.pivot}`);
-  if (parts.offset) segs.push(`offset=${parts.offset}`);
-  let label = segs.join(' · ');
-  if (filters.length === 1 && /^l\d+$/.test(filters[0])) {
-    const name = lcodeLabel(filters[0]);
-    if (name) label += ` (${name})`;
-  }
-  return label;
-}
-
-// Compose the Back-button href. Pops the rightmost crumb and navigates
-// to it; the popped crumb keeps the remaining stack as its own `from=`.
-// An empty stack lands at #/browse (the root tabs view).
-export function backHrefFor(stack) {
-  if (!Array.isArray(stack) || stack.length === 0) return '#/browse';
-  const head = stack.slice(0, -1);
-  const tail = stack[stack.length - 1];
-  const parts = partsFromCrumb(tail);
-  if (!parts) return '#/browse';
-  // Always pass the trimmed crumb stack explicitly so we don't pick up
-  // a stale value of _childCrumbs (set later, after this Back-link is
-  // built — but we want backHref deterministic regardless of order).
-  return drillHashFor(parts, head);
-}
-
-// Initial page-header title before the API response arrives. Prefer
-// the cached label for this node's token; fall back to crumbLabelFor
-// so the user sees *something* during the load.
-//
-// Filter-bearing tokens (`<anchor>:<filter>`) try the bare anchor too:
-// the page IS the anchor node (just filtered), so a cached title for
-// `r101821` should surface as the h1 / current-crumb text for the
-// `r101821:g26` drill too. The filter surface is the badge, not the
-// title.
-export function initialHeaderTitle(parts, token) {
-  if (token) {
-    const cached = cache.get(`tunein.label.${token}`);
-    if (typeof cached === 'string' && cached !== '') return cached;
-    const colon = token.indexOf(':');
-    if (colon > 0) {
-      const bare = token.slice(0, colon);
-      const cachedBare = cache.get(`tunein.label.${bare}`);
-      if (typeof cachedBare === 'string' && cachedBare !== '') return cachedBare;
-    }
-  }
-  return crumbLabelFor(parts);
-}
 
 // ---- pill bar + inline trail (top of every drill body) -------------
 //
@@ -316,7 +133,7 @@ export function renderFilterBadges(parts, stack) {
 // Build one badge node for `filterToken`, given the full filter list
 // and current parts / stack so the × close anchor can drop only this
 // filter while preserving the rest.
-function buildFilterBadge(filterToken, parts, filters, stack) {
+export function buildFilterBadge(filterToken, parts, filters, stack) {
   const badge = document.createElement('span');
   badge.className = 'browse-bar__filter';
   badge.dataset.filterToken = filterToken;
@@ -361,20 +178,6 @@ function buildFilterBadge(filterToken, parts, filters, stack) {
 export function renderFilterBadge(parts, stack) {
   const badges = renderFilterBadges(parts, stack);
   return badges.length > 0 ? badges[0] : null;
-}
-
-// Pick the best already-known label for a filter token without any
-// network work. Mirrors the trail's `initialCrumbLabel` ladder for the
-// filter-only case: lcode catalogue for `lXXX`, then the cache, then
-// the raw token as a last resort.
-function initialFilterLabel(filterToken) {
-  if (/^l\d+$/.test(filterToken)) {
-    const name = lcodeLabel(filterToken);
-    if (name) return name;
-  }
-  const cached = cache.get(`tunein.label.${filterToken}`);
-  if (typeof cached === 'string' && cached !== '') return cached;
-  return filterToken;
 }
 
 // One-shot label fetch for a filter token whose initial render is the
@@ -512,56 +315,6 @@ export function makeSeparator() {
   sep.setAttribute('aria-hidden', 'true');
   sep.textContent = '›'; // ›
   return sep;
-}
-
-// Pick the best already-known label for a crumb token without doing
-// any network work. Order of preference for ancestors:
-//   - tab-token override (only at stack[0] — the entry-point tab)
-//   - cached label under `tunein.label.<token>` (from a previous
-//     resolve)
-//   - in-memory lcode catalogue (free for `<anchor>:l<NNN>` tokens)
-//   - raw token fallback
-// The async hydrateCrumbLabels path upgrades any token still
-// rendered as raw once its Describe / Browse lookup completes.
-export function initialCrumbLabel(token, parts, isFirstInStack) {
-  // The first crumb in the stack is the entry-point tab — render it
-  // with the tab's display label (`Genre` / `Location` / `Language`)
-  // rather than the cached API title ("Music" / "By Location" / "By
-  // Language"). Filter-bearing tokens (`lang:lXXX`) intentionally
-  // fall through to the catalogue path so they read as the language
-  // name, not "Language".
-  if (isFirstInStack) {
-    const bareAnchor = parts && typeof parts.id === 'string'
-      ? parts.id
-      : (parts && typeof parts.c === 'string' ? parts.c : '');
-    const isFilterBearing = parts && typeof parts.filter === 'string' && parts.filter !== '';
-    if (!isFilterBearing && bareAnchor && TAB_LABEL_BY_TOKEN[bareAnchor]) {
-      return TAB_LABEL_BY_TOKEN[bareAnchor];
-    }
-  }
-  const cached = cache.get(`tunein.label.${token}`);
-  if (typeof cached === 'string' && cached !== '') return cached;
-  if (parts && typeof parts.filter === 'string' && /^l\d+$/.test(parts.filter)) {
-    const name = lcodeLabel(parts.filter);
-    if (name) return name;
-  }
-  return token;
-}
-
-// Compose the Back chevron's aria-label from the popped destination.
-// Empty stack → root tabs view ("Back to Browse"). Otherwise the
-// destination is the last crumb in the stack; prefer the resolved
-// label (cache / catalogue) and fall back to the raw token.
-export function backAriaLabel(stack) {
-  if (!Array.isArray(stack) || stack.length === 0) return 'Back to Browse';
-  const destToken = stack[stack.length - 1];
-  if (!destToken) return 'Back to Browse';
-  const destParts = partsFromCrumb(destToken);
-  // The last crumb in the stack is the trail's tail-before-current —
-  // it's an ancestor, not the entry-point tab, so isFirstInStack is
-  // only relevant when stack length is 1.
-  const label = initialCrumbLabel(destToken, destParts, stack.length === 1);
-  return `Back to ${label}`;
 }
 
 // ---- hydration: resolve raw tokens to human-readable labels --------

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -166,30 +166,18 @@ export function emptyNode(message) {
 // card (header taken verbatim from the API's `text`, e.g.
 // "Local Stations (2)", "Stations", "Shows", "Explore Folk").
 // Flat payload → one card with no section header.
-// Tombstone payload → empty-state message.
+//
+// Body-level emptiness (body:[] or a lone tombstone) is resolved
+// upstream by tunein-drill.resolveBrowseDrill — those payloads never
+// reach this function; the drill renderer paints emptyNode directly.
+// Per-section emptiness inside a non-empty body is still handled here
+// (a sectioned body can have one empty section alongside populated
+// ones).
 //
 // Returns the total visible row count (cursors + pivots are excluded
 // — they're meta, not rows the user reads through).
 export function renderOutline(body, json) {
   const rawItems = Array.isArray(json && json.body) ? json.body : [];
-
-  if (rawItems.length === 0) {
-    body.appendChild(emptyNode('Nothing here.'));
-    return 0;
-  }
-
-  // Tombstone check (single text-only entry): § 6.2. A section
-  // container (anything with children) is not a tombstone even if
-  // classifyOutline tags it that way — the fallback in tunein-outline
-  // returns 'tombstone' for any type-less typeless URL-less guide-less
-  // outline, which also matches a bare section header.
-  const onlyEntryIsTombstone = rawItems.length === 1
-    && classifyOutline(rawItems[0]) === 'tombstone'
-    && !(Array.isArray(rawItems[0].children) && rawItems[0].children.length > 0);
-  if (onlyEntryIsTombstone) {
-    body.appendChild(emptyNode(rawItems[0].text || 'Nothing here.'));
-    return 0;
-  }
 
   // Local Radio surface (issue #82): c=local responses include a
   // `key="localCountry"` link pointing at the corresponding r-prefix

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -36,6 +36,7 @@ import {
   renderLiveShowCard,
   renderTopicsCard,
 } from './show-landing.js';
+import { stringifyCrumbs } from './crumb-parts.js';
 
 // The crumb-token prefix that child links should embed in `from=...`.
 // Set by renderDrill / selectTab before the row constructor runs, and
@@ -122,14 +123,6 @@ function filtersOfParts(parts) {
     return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
   }
   return [];
-}
-
-// Local copy of stringifyCrumbs so drillHashFor doesn't pull in the
-// full crumb module. Kept in sync with browse.js's exported version
-// (single token: comma-joined, empty array → '').
-function stringifyCrumbs(crumbs) {
-  if (!Array.isArray(crumbs) || crumbs.length === 0) return '';
-  return crumbs.join(',');
 }
 
 export function pluralize(n) {

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -16,6 +16,7 @@
 
 import { stationRow } from '../../components.js';
 import { icon } from '../../icons.js';
+import { store as appStore } from '../../state.js';
 import {
   canonicaliseBrowseUrl,
   extractDrillKey,
@@ -37,6 +38,7 @@ import {
   renderTopicsCard,
 } from './show-landing.js';
 import { stringifyCrumbs } from './crumb-parts.js';
+import { trailingAffordance } from '../../components.js';
 
 // The crumb-token prefix that child links should embed in `from=...`.
 // Set by renderDrill / selectTab before the row constructor runs, and
@@ -698,8 +700,9 @@ export function renderEntry(entry) {
 
   let node;
   if (kind === 'station' || kind === 'topic') {
+    const sid = norm.id || entry.guide_id || '';
     node = stationRow({
-      sid:      norm.id || entry.guide_id || '',
+      sid,
       name:     norm.primary,
       art:      norm.image,
       location: norm.secondary,
@@ -708,6 +711,18 @@ export function renderEntry(entry) {
       tertiary: norm.tertiary,
       badges:   norm.badges,
       chips:    norm.chips,
+      // Heart visibility is gated by favoriteHeart on `^[sp]\d+$`, so
+      // topic (t) rows fall through to the chevron unchanged. Browse
+      // capture rule per #126: {id, name, art, note: ''} from row data.
+      favorite: {
+        store: appStore,
+        getEntry: () => ({
+          id:   sid,
+          name: norm.primary || '',
+          art:  norm.image || '',
+          note: '',
+        }),
+      },
     });
   } else if (kind === 'show') {
     // Shows are drill-into-detail, not direct play. Reuse stationRow
@@ -780,10 +795,23 @@ function showRow(entry, norm) {
   }
   row.appendChild(body);
 
-  const chev = document.createElement('span');
-  chev.className = 'station-row__chev';
-  chev.appendChild(icon('arrow', 14));
-  row.appendChild(chev);
+  // Show rows take a heart in place of the chevron (#126). p-prefix
+  // ids satisfy isFavoriteId; the body link still drills into the
+  // show landing.
+  row.appendChild(trailingAffordance({
+    sid:  id,
+    name: norm.primary || id || '',
+    art:  norm.image || '',
+    favorite: {
+      store: appStore,
+      getEntry: () => ({
+        id,
+        name: norm.primary || id || '',
+        art:  norm.image || '',
+        note: '',
+      }),
+    },
+  }));
   return row;
 }
 

--- a/admin/app/views/browse/show-landing.js
+++ b/admin/app/views/browse/show-landing.js
@@ -35,6 +35,7 @@ import { stationRow } from '../../components.js';
 import { showHero } from '../../show-hero.js';
 import { cache, TTL_LABEL } from '../../tunein-cache.js';
 import { normaliseRow } from '../../tunein-outline.js';
+import { store as appStore } from '../../state.js';
 import {
   renderSection,
   emptyNode,
@@ -201,6 +202,17 @@ function renderShowLandingCard(show) {
     art:  logo,
     location: secondary,
     chips,
+    // Show-landing capture rule per #126: {id: pid, name: show.name,
+    // art: show.art, note: ''} from the Describe-resolved show entry.
+    favorite: {
+      store: appStore,
+      getEntry: () => ({
+        id:   sid,
+        name: title,
+        art:  logo,
+        note: '',
+      }),
+    },
   });
   // Mark the hero so tests / CSS can target it specifically.
   row.setAttribute('data-show-landing', '1');
@@ -275,6 +287,15 @@ function renderLiveShowRow(entry) {
     name:     norm.primary || id,
     art:      norm.image,
     location: norm.secondary,
+    favorite: {
+      store: appStore,
+      getEntry: () => ({
+        id,
+        name: norm.primary || id || '',
+        art:  norm.image || '',
+        note: '',
+      }),
+    },
   });
 }
 

--- a/admin/app/views/browse/show-landing.js
+++ b/admin/app/views/browse/show-landing.js
@@ -30,11 +30,12 @@
 // render) because the topic-row layout and liveShow hero pattern are
 // part of the show-drill flow.
 
-import { tuneinDescribe, tuneinBrowse } from '../../api.js';
+import { tuneinDescribe } from '../../api.js';
 import { stationRow } from '../../components.js';
 import { showHero } from '../../show-hero.js';
 import { cache, TTL_LABEL } from '../../tunein-cache.js';
 import { normaliseRow } from '../../tunein-outline.js';
+import { resolveBrowseDrill } from '../../tunein-drill.js';
 import {
   renderSection,
   emptyNode,
@@ -48,17 +49,25 @@ import {
 // Drive the two-fetch composite. Describe is the load-bearing call (it
 // drives the show card); Browse-by-bare-id is best-effort — its
 // failure does not block the show card from rendering. Both fetches
-// fire in parallel; we wait on Describe synchronously and treat
-// Browse's failure as "no related sections".
+// fire in parallel; we wait on Describe synchronously and route the
+// Browse half through resolveBrowseDrill so empty / error / tombstone
+// classification is structured rather than swallowed.
 export function loadShowLanding(body, showId, headerCount, head) {
   body.replaceChildren();
   body.appendChild(skeleton());
   if (headerCount) headerCount.textContent = '';
 
   const describePromise = tuneinDescribe({ id: showId });
-  // Browse(bare id) is best-effort — we swallow its rejection so the
-  // describe-driven card still renders even if Browse 4xxs.
-  const browsePromise = tuneinBrowse(showId).catch(() => null);
+  // Browse(bare id) flows through the one-shot drill seam. The seam
+  // never rejects: transport throws, structured CGI errors, and TuneIn-
+  // rejected drills (c=pbrowse on Bo's egress — head.status="400" with
+  // body:[]) all surface as `kind:'error'` or `kind:'empty'`. Both
+  // collapse to "no related sections" here — parity with the swallowed-
+  // rejection / empty-body behaviour the previous .catch(() => null)
+  // implemented — so we hand `null` down to renderShowLandingBody for
+  // anything that isn't an ok-with-payload result.
+  const browsePromise = resolveBrowseDrill(showId)
+    .then((r) => (r.kind === 'ok' ? r.json : null));
 
   Promise.all([describePromise, browsePromise])
     .then(([describeJson, browseJson]) => {

--- a/admin/app/views/favorites-drag.js
+++ b/admin/app/views/favorites-drag.js
@@ -1,0 +1,292 @@
+// favorites-drag — pointer-events-based row reorder for the favourites
+// tab (#128). Wires one drag-handle per row; the controller owns the
+// in-flight drag state for the whole list.
+//
+// Why this lives in its own module:
+//   - views/favorites.js already owns CRUD + focus-flash; the drag
+//     surface is its own concern with its own pointer lifecycle.
+//   - Splitting keeps the test surface focused: the splice math lives
+//     in app/favorites.js (pure), the DOM choreography lives here, and
+//     the integration test in test_favorites_drag.js drives both
+//     through synthetic pointer events.
+//
+// Lifecycle, per drag:
+//
+//   pointerdown on .favorites-row__drag
+//     → setPointerCapture(pointerId)
+//     → snapshot fromIdx + a ghost (semi-transparent fixed clone)
+//     → mount a drop indicator (a thin <div>) into the list container
+//     → install pointermove / pointerup / pointercancel + Escape
+//   pointermove
+//     → move the ghost to follow pointer Y
+//     → compute the target gap from row rects + pointer Y
+//     → reposition the drop indicator
+//   pointerup
+//     → spliceReorder(list, from, gap) → next
+//     → if next !== list, call onDrop(next, prev); else no-op
+//     → tear down ghost + indicator
+//   pointercancel | Escape
+//     → tear down ghost + indicator; no POST
+//
+// Listeners are added on the handle for pointerdown only; the rest of
+// the lifecycle attaches to the document so the drag survives the
+// pointer leaving the handle. setPointerCapture would do most of this
+// itself in production browsers, but JSDOM / xmldom don't honour it,
+// and document-scoped listeners are the same code path either way.
+//
+// Tests stub `row.getBoundingClientRect()` on each rendered row so the
+// gap-mapping math has something to chew on; production code uses the
+// real DOM rect.
+
+import { spliceReorder } from '../favorites.js';
+
+function indexOfRow(rows, row) {
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i] === row) return i;
+  }
+  return -1;
+}
+
+// Map a pointer Y to the gap index ∈ [0..rows.length]. Each row votes
+// for "before me" or "after me" based on its midline; the first row
+// whose midline beats the pointer wins. Falls back to "last gap" if the
+// pointer is below every midline.
+function gapFromPointer(rows, pointerY) {
+  for (let i = 0; i < rows.length; i++) {
+    const rect = typeof rows[i].getBoundingClientRect === 'function'
+      ? rows[i].getBoundingClientRect()
+      : null;
+    if (!rect) continue;
+    const mid = rect.top + rect.height / 2;
+    if (pointerY < mid) return i;
+  }
+  return rows.length;
+}
+
+function buildGhost(sourceRow) {
+  // Cheap clone: a div that mirrors the source's visible class list and
+  // copies its textual signature. We don't need a pixel-perfect copy —
+  // a translucent silhouette that follows the pointer is enough to read
+  // as "this row is in flight". Falling back to cloneNode when the
+  // host supports it keeps the ghost faithful in real browsers; the
+  // text-only path keeps the DOM shim happy in tests.
+  const ghost = document.createElement('div');
+  ghost.className = 'favorites-drag-ghost';
+  ghost.setAttribute('aria-hidden', 'true');
+  if (typeof sourceRow.cloneNode === 'function') {
+    try {
+      const clone = sourceRow.cloneNode(true);
+      // Strip ids / dataset hooks from the clone so duplicate-id rules
+      // and event handlers don't fight the live row.
+      if (clone && clone.removeAttribute) clone.removeAttribute('data-fav-id');
+      ghost.appendChild(clone);
+    } catch (_err) {
+      const text = document.createElement('span');
+      text.textContent = sourceRow.textContent || '';
+      ghost.appendChild(text);
+    }
+  } else {
+    const text = document.createElement('span');
+    text.textContent = sourceRow.textContent || '';
+    ghost.appendChild(text);
+  }
+  return ghost;
+}
+
+function positionGhost(ghost, x, y) {
+  if (!ghost || !ghost.style) return;
+  ghost.style.setProperty('position', 'fixed');
+  ghost.style.setProperty('left', `${x}px`);
+  ghost.style.setProperty('top',  `${y}px`);
+  ghost.style.setProperty('pointer-events', 'none');
+}
+
+function buildIndicator() {
+  const ind = document.createElement('div');
+  ind.className = 'favorites-drag-indicator';
+  ind.setAttribute('aria-hidden', 'true');
+  return ind;
+}
+
+// Move the indicator into the list at the slot matching `gap`. Inserts
+// before the row at `gap` when one exists; appends when `gap` is past
+// the end. The indicator is always re-parented even when its position
+// hasn't changed — cheap, and avoids a "did it move?" diff.
+function placeIndicator(listEl, indicator, rows, gap) {
+  if (!indicator || !listEl) return;
+  if (indicator.parentNode) indicator.parentNode.removeChild(indicator);
+  const before = gap < rows.length ? rows[gap] : null;
+  if (before && before.parentNode === listEl) {
+    listEl.insertBefore(indicator, before);
+  } else {
+    listEl.appendChild(indicator);
+  }
+}
+
+// installFavoriteDrag — wire one drag handle. Called per row.
+//
+//   handle      — the .favorites-row__drag span
+//   row         — the .favorites-row element (used as source + rect)
+//   listEl      — the .favorites-list container (parent of all rows)
+//   getList     — () → current favourites array (pulled from store at
+//                  pointerdown so a mid-flight reconcile doesn't strand
+//                  the drag against a stale snapshot)
+//   getFromIdx  — () → index of this row's entry in the live list at
+//                  pointerdown. Resolved on every pointerdown so list
+//                  mutations between renders don't desync.
+//   onDrop      — (next, prev) → void. Called once per successful drop
+//                  when the list actually changed. The caller fires the
+//                  POST.
+//   onCleanup   — defineView env.onCleanup, so the handle's pointerdown
+//                  listener is removed when the view unmounts.
+//
+// Returns nothing; side-effects only.
+export function installFavoriteDrag({
+  handle, row, listEl, getList, getFromIdx, onDrop, onCleanup,
+}) {
+  if (!handle || !row || !listEl) return;
+
+  // Per-drag state. Reset to nulls between drags so a stale ghost from
+  // one drag can't survive into the next.
+  let active        = false;
+  let pointerId     = null;
+  let fromIdx       = -1;
+  let snapshotList  = null;
+  let ghost         = null;
+  let indicator     = null;
+  let rowsCache     = [];
+  let currentGap    = -1;
+
+  function rowList() {
+    // Re-read on every move — the DOM is the source of truth for which
+    // rows are currently rendered (replaceChildren during a render
+    // would otherwise leave the cache pointing at detached nodes).
+    return Array.from(listEl.querySelectorAll('.favorites-row'));
+  }
+
+  function teardown() {
+    if (!active) return;
+    active = false;
+    try {
+      if (pointerId != null && typeof handle.releasePointerCapture === 'function') {
+        handle.releasePointerCapture(pointerId);
+      }
+    } catch (_err) { /* not all hosts implement it */ }
+    pointerId = null;
+    if (ghost && ghost.parentNode) ghost.parentNode.removeChild(ghost);
+    if (indicator && indicator.parentNode) indicator.parentNode.removeChild(indicator);
+    ghost = null;
+    indicator = null;
+    row.classList.remove('is-dragging');
+    if (listEl.classList) listEl.classList.remove('is-drag-active');
+    if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+      document.removeEventListener('pointermove',   onPointerMove);
+      document.removeEventListener('pointerup',     onPointerUp);
+      document.removeEventListener('pointercancel', onPointerCancel);
+      document.removeEventListener('keydown',       onKeyDown);
+    }
+    snapshotList = null;
+    rowsCache = [];
+    fromIdx = -1;
+    currentGap = -1;
+  }
+
+  function onPointerDown(evt) {
+    if (evt && evt.button !== undefined && evt.button !== 0) return;
+    if (active) return;
+    const list = typeof getList === 'function' ? getList() : null;
+    const idx  = typeof getFromIdx === 'function' ? getFromIdx() : -1;
+    if (!Array.isArray(list) || list.length < 2) return;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= list.length) return;
+
+    active = true;
+    snapshotList = list.slice();
+    fromIdx = idx;
+    pointerId = evt && evt.pointerId != null ? evt.pointerId : null;
+
+    try {
+      if (pointerId != null && typeof handle.setPointerCapture === 'function') {
+        handle.setPointerCapture(pointerId);
+      }
+    } catch (_err) { /* not all hosts implement it */ }
+
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+
+    row.classList.add('is-dragging');
+    if (listEl.classList) listEl.classList.add('is-drag-active');
+
+    rowsCache = rowList();
+
+    ghost = buildGhost(row);
+    document.body.appendChild(ghost);
+    const px = evt && typeof evt.clientX === 'number' ? evt.clientX : 0;
+    const py = evt && typeof evt.clientY === 'number' ? evt.clientY : 0;
+    positionGhost(ghost, px, py);
+
+    indicator = buildIndicator();
+    // Render the indicator at the source's own position first so the
+    // initial visual reads as "this row is picked up, drop slot is
+    // where it currently sits".
+    currentGap = fromIdx;
+    placeIndicator(listEl, indicator, rowsCache, currentGap);
+
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+      document.addEventListener('pointermove',   onPointerMove);
+      document.addEventListener('pointerup',     onPointerUp);
+      document.addEventListener('pointercancel', onPointerCancel);
+      document.addEventListener('keydown',       onKeyDown);
+    }
+  }
+
+  function onPointerMove(evt) {
+    if (!active) return;
+    if (pointerId != null && evt && evt.pointerId != null && evt.pointerId !== pointerId) return;
+    const px = evt && typeof evt.clientX === 'number' ? evt.clientX : 0;
+    const py = evt && typeof evt.clientY === 'number' ? evt.clientY : 0;
+    positionGhost(ghost, px, py);
+    // Recompute against the current DOM, not the snapshot — the
+    // indicator could be sitting between rows that were re-rendered.
+    rowsCache = rowList().filter((r) => r !== indicator && r !== ghost);
+    const gap = gapFromPointer(rowsCache, py);
+    if (gap !== currentGap) {
+      currentGap = gap;
+      placeIndicator(listEl, indicator, rowsCache, gap);
+    }
+  }
+
+  function onPointerUp(evt) {
+    if (!active) return;
+    if (pointerId != null && evt && evt.pointerId != null && evt.pointerId !== pointerId) return;
+    const prev = snapshotList || [];
+    const gap  = currentGap >= 0 ? currentGap : fromIdx;
+    const next = spliceReorder(prev, fromIdx, gap);
+    teardown();
+    // Identity check: spliceReorder returns the same array reference
+    // when the drop is a no-op (same gap or off-by-one at source).
+    if (next !== prev && typeof onDrop === 'function') {
+      onDrop(next, prev);
+    }
+  }
+
+  function onPointerCancel(evt) {
+    if (!active) return;
+    if (pointerId != null && evt && evt.pointerId != null && evt.pointerId !== pointerId) return;
+    teardown();
+  }
+
+  function onKeyDown(evt) {
+    if (!active) return;
+    if (evt && evt.key === 'Escape') {
+      if (typeof evt.preventDefault === 'function') evt.preventDefault();
+      teardown();
+    }
+  }
+
+  handle.addEventListener('pointerdown', onPointerDown);
+  if (typeof onCleanup === 'function') {
+    onCleanup(() => {
+      handle.removeEventListener('pointerdown', onPointerDown);
+      teardown();
+    });
+  }
+}

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -55,8 +55,35 @@ function buildList(entries) {
   return list;
 }
 
+// Deep-link focus (#129). The Now-Playing favourites grid sets
+// `#/favorites?focus=<id>` on long-press; the router decodes the query
+// string and passes it through `ctx.query`. We honour it once at mount
+// (and once after the initial render lands data) by scrolling the
+// matching row into view and applying `.is-focused` for a brief flash.
+// Deliberately scoped to mount-time so #127's CRUD edits to the row
+// renderer below stay disjoint. Edit-mode is never auto-entered — a
+// long-press from Now Playing must not accidentally open the editor.
+const FOCUS_FLASH_MS = 1600;
+
+function applyFocus(body, focusId) {
+  if (!body || typeof focusId !== 'string' || !focusId) return false;
+  const rows = body.querySelectorAll('.favorites-row');
+  for (const row of rows) {
+    const sid = row.dataset && row.dataset.sid;
+    if (sid !== focusId) continue;
+    row.classList.add('is-focused');
+    if (typeof row.scrollIntoView === 'function') {
+      try { row.scrollIntoView({ block: 'center', behavior: 'smooth' }); }
+      catch (_err) { /* JSDOM / xmldom — no-op */ }
+    }
+    setTimeout(() => row.classList.remove('is-focused'), FOCUS_FLASH_MS);
+    return true;
+  }
+  return false;
+}
+
 export default defineView({
-  mount(root, store, _ctx, env) {
+  mount(root, store, ctx, env) {
     mount(root, html`
       <section class="favorites" data-view="favorites">
         <header class="favorites-header">
@@ -66,6 +93,13 @@ export default defineView({
       </section>
     `);
     const body = root.querySelector('.favorites-body');
+
+    // Deep-link target id, taken from `?focus=<id>` and honoured once
+    // after the first render that contains a matching row. Cleared after
+    // a successful match so subsequent re-renders don't keep re-flashing.
+    let pendingFocusId = ctx && ctx.query && typeof ctx.query.focus === 'string'
+      ? ctx.query.focus
+      : '';
 
     function render() {
       const list = (store.state.speaker && store.state.speaker.favorites) || null;
@@ -78,6 +112,9 @@ export default defineView({
         body.replaceChildren(buildEmptyState());
       } else {
         body.replaceChildren(buildList(entries));
+        if (pendingFocusId && applyFocus(body, pendingFocusId)) {
+          pendingFocusId = '';
+        }
       }
     }
 

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -1,24 +1,38 @@
 // favorites — #/favorites top-level tab.
 //
-// Tracer-slice rendering: plain row list, no CRUD affordances.
-// - row primitives come from `components.stationRow` so the visual
-//   matches search results / browse drill rows.
-// - the heart on each row (#126) and the pencil/trash/drag affordances
-//   (#127/#128/#129) are deliberately NOT here — this slice only proves
-//   the loop end-to-end.
+// CRUD management surface. Each row carries always-on affordances:
 //
-// The empty-state banner mirrors the search empty state's tone: a short
-// hint pointing the user at the station-detail heart, which is where
-// the only writer in this slice lives.
+//   [drag-handle stub]  [body — tap to play]  [pencil]  [trash]
+//
+// The drag-handle is a visual stub in this slice (issue #127); the
+// behaviour wiring lands in #128. Pencil expands the row vertically
+// in place, exposing inputs for name / art / note plus Save & Cancel.
+// Trash optimistically removes the row, fires POST immediately, and
+// shows a 5-second toast with Undo; tapping Undo re-inserts the entry
+// at its previous index and POSTs the restored list.
+//
+// Validation failures from the CGI surface as toasts; local state
+// reverts to match the last-known-good response (via replaceFavorites
+// snapshot rollback).
 //
 // Visibility refetch: the favourites array is fetched on app boot via
 // reconcile() and again on every `visibilitychange → 'visible'` so a
 // second tab that mutated the list flows back into this one.
 
 import { html, mount, defineView } from '../dom.js';
-import { stationRow } from '../components.js';
+import { stationArt } from '../components.js';
 import { reconcileField } from '../speaker-state.js';
-import { parseSid } from '../tunein-sid.js';
+import { isPlayableSid } from '../tunein-sid.js';
+import { icon } from '../icons.js';
+import { playSid } from '../play-button.js';
+import { showToast, showActionToast } from '../toast.js';
+import {
+  indexOfFavorite,
+  withFavoriteRemoved,
+  replaceFavorites,
+} from '../favorites.js';
+
+const UNDO_DWELL_MS = 5000;
 
 function buildEmptyState() {
   const wrap = document.createElement('section');
@@ -32,25 +46,277 @@ function buildEmptyState() {
   return wrap;
 }
 
-function buildList(entries) {
+// Build the row body — the tappable play target. Mirrors the stationRow
+// visual contract (art + name + optional note) without the chev or
+// auto-attached Play icon, because here the row body itself is the
+// play affordance and the pencil/trash own the right gutter.
+function buildBody({ entry, onPlay }) {
+  const body = document.createElement('button');
+  body.type = 'button';
+  body.className = 'favorites-row__body';
+  body.setAttribute('aria-label', `Play ${entry.name || entry.id} on Bo`);
+
+  body.appendChild(stationArt({ url: entry.art || '', name: entry.name || entry.id, size: 40 }));
+
+  const text = document.createElement('span');
+  text.className = 'favorites-row__text';
+
+  const name = document.createElement('span');
+  name.className = 'favorites-row__name';
+  name.textContent = entry.name || entry.id;
+  text.appendChild(name);
+
+  if (entry.note) {
+    const note = document.createElement('span');
+    note.className = 'favorites-row__note';
+    note.textContent = entry.note;
+    text.appendChild(note);
+  }
+
+  body.appendChild(text);
+
+  if (isPlayableSid(entry.id)) {
+    body.addEventListener('click', (evt) => {
+      if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+      if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+      onPlay();
+    });
+  } else {
+    // Non-playable ids (shouldn't appear in favourites, but keep the
+    // affordance honest) — render the body but disable the play action.
+    body.disabled = true;
+    body.classList.add('is-disabled');
+  }
+
+  return body;
+}
+
+// Build the inline edit form revealed under the row when the pencil
+// is tapped. `seed` is the current entry; `onSave` receives a new
+// entry object built from the form fields (id is preserved); `onCancel`
+// tears the form down without writing.
+function buildEditForm({ seed, onSave, onCancel }) {
+  const form = document.createElement('form');
+  form.className = 'favorites-row__edit';
+  // Prevent the browser's default form submission — we own the save.
+  form.addEventListener('submit', (evt) => {
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+  });
+
+  function fieldRow(labelText, inputType, value) {
+    const wrap = document.createElement('label');
+    wrap.className = 'favorites-edit__field';
+    const lbl = document.createElement('span');
+    lbl.className = 'favorites-edit__label';
+    lbl.textContent = labelText;
+    const input = document.createElement('input');
+    input.type = inputType;
+    input.className = 'favorites-edit__input';
+    input.value = value || '';
+    wrap.appendChild(lbl);
+    wrap.appendChild(input);
+    return { wrap, input };
+  }
+
+  const nameField = fieldRow('Name', 'text', seed.name);
+  const artField  = fieldRow('Art URL', 'url',  seed.art);
+  const noteField = fieldRow('Note', 'text', seed.note);
+
+  form.appendChild(nameField.wrap);
+  form.appendChild(artField.wrap);
+  form.appendChild(noteField.wrap);
+
+  const actions = document.createElement('div');
+  actions.className = 'favorites-edit__actions';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'favorites-edit__btn favorites-edit__btn--cancel';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', (evt) => {
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+    onCancel();
+  });
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.className = 'favorites-edit__btn favorites-edit__btn--save';
+  saveBtn.textContent = 'Save';
+  saveBtn.addEventListener('click', (evt) => {
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+    const nextName = String(nameField.input.value || '').trim();
+    // Client-side validation: name is required. Falling back to the id
+    // would silently swallow a "user cleared the name" edit; surface a
+    // toast instead so the user can correct it.
+    if (!nextName) {
+      showToast('Name cannot be empty');
+      return;
+    }
+    onSave({
+      id:   seed.id,
+      name: nextName,
+      art:  String(artField.input.value  || '').trim(),
+      note: String(noteField.input.value || '').trim(),
+    });
+  });
+
+  actions.appendChild(cancelBtn);
+  actions.appendChild(saveBtn);
+  form.appendChild(actions);
+
+  return form;
+}
+
+function buildIconButton({ glyph, label, className, onClick }) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = className;
+  btn.setAttribute('aria-label', label);
+  btn.setAttribute('title', label);
+  btn.appendChild(icon(glyph, 18));
+  btn.addEventListener('click', (evt) => {
+    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+    onClick();
+  });
+  return btn;
+}
+
+// buildRow — one favourite entry rendered as the full management row.
+// Returns the row element; the caller hangs it on the list.
+function buildRow({ entry, store, onActivity }) {
+  const row = document.createElement('div');
+  row.className = 'favorites-row';
+  row.setAttribute('role', 'listitem');
+  row.dataset.favId = entry.id;
+
+  // [drag-handle]
+  const handle = document.createElement('span');
+  handle.className = 'favorites-row__drag';
+  handle.setAttribute('aria-hidden', 'true');
+  // Stub only — no drag wiring in #127; #128 will add the behaviour.
+  handle.appendChild(icon('drag-handle', 16));
+  row.appendChild(handle);
+
+  // [body — tap to play]
+  const body = buildBody({
+    entry,
+    onPlay: () => {
+      onActivity();
+      playSid({ sid: entry.id, label: entry.name || entry.id });
+    },
+  });
+  row.appendChild(body);
+
+  // [pencil]
+  let editForm = null;
+  const pencil = buildIconButton({
+    glyph: 'pencil',
+    label: `Edit ${entry.name || entry.id}`,
+    className: 'favorites-row__edit-btn',
+    onClick: () => {
+      onActivity();
+      if (editForm) {
+        // Toggle closes if pencil is tapped twice. Symmetric with
+        // Cancel; either path lands on "no expanded row".
+        editForm.remove();
+        editForm = null;
+        row.classList.remove('is-expanded');
+        return;
+      }
+      editForm = buildEditForm({
+        seed: entry,
+        onSave: (next) => {
+          const list = (store.state.speaker && store.state.speaker.favorites) || [];
+          const idx = indexOfFavorite(list, entry.id);
+          if (idx < 0) {
+            // Edit raced with an external mutation that dropped the
+            // entry. Tear the form down rather than silently re-adding.
+            if (editForm) editForm.remove();
+            editForm = null;
+            row.classList.remove('is-expanded');
+            return;
+          }
+          const prev = list.slice();
+          const nextList = prev.slice();
+          nextList[idx] = {
+            id:   next.id,
+            name: next.name,
+            art:  next.art,
+            note: next.note,
+          };
+          // Collapse optimistically — the optimistic state already
+          // shows the new values on the visible row via the store
+          // subscription.
+          if (editForm) editForm.remove();
+          editForm = null;
+          row.classList.remove('is-expanded');
+          replaceFavorites(store, nextList, prev, "Couldn't save favourite");
+        },
+        onCancel: () => {
+          if (editForm) editForm.remove();
+          editForm = null;
+          row.classList.remove('is-expanded');
+        },
+      });
+      row.classList.add('is-expanded');
+      row.appendChild(editForm);
+    },
+  });
+  row.appendChild(pencil);
+
+  // [trash]
+  const trash = buildIconButton({
+    glyph: 'trash',
+    label: `Delete ${entry.name || entry.id}`,
+    className: 'favorites-row__delete-btn',
+    onClick: () => {
+      onActivity();
+      const list = (store.state.speaker && store.state.speaker.favorites) || [];
+      const idx = indexOfFavorite(list, entry.id);
+      if (idx < 0) return;
+      const prev = list.slice();
+      // Drop the entry locally + POST immediately. The toast offers
+      // Undo for 5 s; on timeout the deletion is permanent.
+      const afterRemove = withFavoriteRemoved(prev, entry.id);
+      replaceFavorites(store, afterRemove, prev, "Couldn't delete favourite");
+
+      const undoToast = showActionToast({
+        message: `Removed ${entry.name || entry.id}`,
+        actionLabel: 'Undo',
+        dwellMs: UNDO_DWELL_MS,
+        onAction: () => {
+          // Re-insert at the previous index; POST the restored list.
+          const cur = (store.state.speaker && store.state.speaker.favorites) || [];
+          const restoredPrev = cur.slice();
+          // Defensive: if the entry got re-added in the meantime, skip.
+          if (indexOfFavorite(cur, entry.id) >= 0) return;
+          const restored = cur.slice();
+          const insertAt = Math.min(idx, restored.length);
+          restored.splice(insertAt, 0, prev[idx]);
+          replaceFavorites(store, restored, restoredPrev, "Couldn't restore favourite");
+        },
+      });
+      // Track the in-flight toast so any other user action collapses
+      // it early (the contract per #127). The mount-level activity
+      // hook does the dismissal.
+      onActivity.registerToast(undoToast);
+    },
+  });
+  row.appendChild(trash);
+
+  return row;
+}
+
+function buildList({ entries, store, onActivity }) {
   const list = document.createElement('div');
-  list.className = 'favorites-list station-list';
+  list.className = 'favorites-list';
   list.setAttribute('role', 'list');
   for (const entry of entries) {
     if (!entry || typeof entry.id !== 'string') continue;
-    // Drill href is computed by stationRow via parseSid; we feed it
-    // the bare id and let the row primitive route the click.
-    const row = stationRow({
-      sid:  entry.id,
-      name: entry.name || entry.id,
-      art:  entry.art || '',
-    });
-    row.classList.add('favorites-row');
-    // Annotate the row with the detail-href explicitly so it's easy to
-    // assert on in tests without re-deriving it.
-    const dest = parseSid(entry.id).detailHref;
-    if (dest) row.setAttribute('data-detail-href', dest);
-    list.appendChild(row);
+    list.appendChild(buildRow({ entry, store, onActivity }));
   }
   return list;
 }
@@ -67,6 +333,17 @@ export default defineView({
     `);
     const body = root.querySelector('.favorites-body');
 
+    // Activity hook: tracks the most recent action-toast so any other
+    // user-initiated action collapses it early. The contract per #127:
+    // an in-flight Undo toast survives only until the next interaction.
+    let inflightToast = null;
+    function onActivity() {
+      const t = inflightToast;
+      inflightToast = null;
+      if (t && typeof t.dismiss === 'function') t.dismiss('early');
+    }
+    onActivity.registerToast = (toast) => { inflightToast = toast; };
+
     function render() {
       const list = (store.state.speaker && store.state.speaker.favorites) || null;
       // null = unfetched. Show the empty state immediately so a slow
@@ -77,7 +354,7 @@ export default defineView({
       if (entries.length === 0) {
         body.replaceChildren(buildEmptyState());
       } else {
-        body.replaceChildren(buildList(entries));
+        body.replaceChildren(buildList({ entries, store, onActivity }));
       }
     }
 

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -31,6 +31,7 @@ import {
   withFavoriteRemoved,
   replaceFavorites,
 } from '../favorites.js';
+import { installFavoriteDrag } from './favorites-drag.js';
 
 const UNDO_DWELL_MS = 5000;
 
@@ -185,18 +186,21 @@ function buildIconButton({ glyph, label, className, onClick }) {
 }
 
 // buildRow — one favourite entry rendered as the full management row.
-// Returns the row element; the caller hangs it on the list.
+// Returns { row, handle }; the caller hangs the row on the list and
+// wires drag on the handle (drag plumbing needs the listEl + live
+// store, both of which are owned at the buildList level).
 function buildRow({ entry, store, onActivity }) {
   const row = document.createElement('div');
   row.className = 'favorites-row';
   row.setAttribute('role', 'listitem');
   row.dataset.favId = entry.id;
 
-  // [drag-handle]
+  // [drag-handle] — wiring lives in views/favorites-drag.js and is
+  // attached after the row joins the DOM (the controller needs the
+  // list container as its parent).
   const handle = document.createElement('span');
   handle.className = 'favorites-row__drag';
   handle.setAttribute('aria-hidden', 'true');
-  // Stub only — no drag wiring in #127; #128 will add the behaviour.
   handle.appendChild(icon('drag-handle', 16));
   row.appendChild(handle);
 
@@ -307,16 +311,44 @@ function buildRow({ entry, store, onActivity }) {
   });
   row.appendChild(trash);
 
-  return row;
+  return { row, handle };
 }
 
-function buildList({ entries, store, onActivity }) {
+function buildList({ entries, store, onActivity, onCleanup }) {
   const list = document.createElement('div');
   list.className = 'favorites-list';
   list.setAttribute('role', 'list');
+  const built = [];
   for (const entry of entries) {
     if (!entry || typeof entry.id !== 'string') continue;
-    list.appendChild(buildRow({ entry, store, onActivity }));
+    const { row, handle } = buildRow({ entry, store, onActivity });
+    list.appendChild(row);
+    built.push({ entry, row, handle });
+  }
+
+  // Drag wiring (#128). Hung on each handle after the row joins the
+  // list so the controller can re-parent its ghost / indicator inside
+  // the live container. `getFromIdx` resolves the source index on
+  // pointerdown so a between-renders mutation doesn't desync.
+  for (const item of built) {
+    installFavoriteDrag({
+      handle: item.handle,
+      row: item.row,
+      listEl: list,
+      getList: () => {
+        const cur = store.state.speaker && store.state.speaker.favorites;
+        return Array.isArray(cur) ? cur : [];
+      },
+      getFromIdx: () => {
+        const cur = store.state.speaker && store.state.speaker.favorites;
+        return indexOfFavorite(Array.isArray(cur) ? cur : [], item.entry.id);
+      },
+      onDrop: (next, prev) => {
+        onActivity();
+        replaceFavorites(store, next, prev, "Couldn't reorder favourite");
+      },
+      onCleanup,
+    });
   }
   return list;
 }
@@ -388,7 +420,10 @@ export default defineView({
       if (entries.length === 0) {
         body.replaceChildren(buildEmptyState());
       } else {
-        body.replaceChildren(buildList({ entries, store, onActivity }));
+        body.replaceChildren(buildList({
+          entries, store, onActivity,
+          onCleanup: env.onCleanup,
+        }));
         if (pendingFocusId && applyFocus(body, pendingFocusId)) {
           pendingFocusId = '';
         }

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -1,0 +1,109 @@
+// favorites — #/favorites top-level tab.
+//
+// Tracer-slice rendering: plain row list, no CRUD affordances.
+// - row primitives come from `components.stationRow` so the visual
+//   matches search results / browse drill rows.
+// - the heart on each row (#126) and the pencil/trash/drag affordances
+//   (#127/#128/#129) are deliberately NOT here — this slice only proves
+//   the loop end-to-end.
+//
+// The empty-state banner mirrors the search empty state's tone: a short
+// hint pointing the user at the station-detail heart, which is where
+// the only writer in this slice lives.
+//
+// Visibility refetch: the favourites array is fetched on app boot via
+// reconcile() and again on every `visibilitychange → 'visible'` so a
+// second tab that mutated the list flows back into this one.
+
+import { html, mount, defineView } from '../dom.js';
+import { stationRow } from '../components.js';
+import { reconcileField } from '../speaker-state.js';
+import { parseSid } from '../tunein-sid.js';
+
+function buildEmptyState() {
+  const wrap = document.createElement('section');
+  wrap.className = 'favorites-empty';
+  const head = document.createElement('h2');
+  head.textContent = 'No favourites yet';
+  const body = document.createElement('p');
+  body.textContent = 'Tap the heart on a station to add it here.';
+  wrap.appendChild(head);
+  wrap.appendChild(body);
+  return wrap;
+}
+
+function buildList(entries) {
+  const list = document.createElement('div');
+  list.className = 'favorites-list station-list';
+  list.setAttribute('role', 'list');
+  for (const entry of entries) {
+    if (!entry || typeof entry.id !== 'string') continue;
+    // Drill href is computed by stationRow via parseSid; we feed it
+    // the bare id and let the row primitive route the click.
+    const row = stationRow({
+      sid:  entry.id,
+      name: entry.name || entry.id,
+      art:  entry.art || '',
+    });
+    row.classList.add('favorites-row');
+    // Annotate the row with the detail-href explicitly so it's easy to
+    // assert on in tests without re-deriving it.
+    const dest = parseSid(entry.id).detailHref;
+    if (dest) row.setAttribute('data-detail-href', dest);
+    list.appendChild(row);
+  }
+  return list;
+}
+
+export default defineView({
+  mount(root, store, _ctx, env) {
+    mount(root, html`
+      <section class="favorites" data-view="favorites">
+        <header class="favorites-header">
+          <h1>Favourites</h1>
+        </header>
+        <div class="favorites-body"></div>
+      </section>
+    `);
+    const body = root.querySelector('.favorites-body');
+
+    function render() {
+      const list = (store.state.speaker && store.state.speaker.favorites) || null;
+      // null = unfetched. Show the empty state immediately so a slow
+      // GET doesn't leave the body blank; reconcile-on-mount will land
+      // shortly and re-render with the real list.
+      const entries = Array.isArray(list) ? list : [];
+      if (!body) return;
+      if (entries.length === 0) {
+        body.replaceChildren(buildEmptyState());
+      } else {
+        body.replaceChildren(buildList(entries));
+      }
+    }
+
+    render();
+
+    // Fetch on mount if we haven't yet (speaker-state's reconcile fires
+    // at boot, but a deep-link to #/favorites before reconcile lands
+    // shouldn't show a phantom empty state any longer than necessary).
+    if (!Array.isArray(store.state.speaker.favorites)) {
+      reconcileField(store, 'favorites').catch(() => { /* surfaced via store subscription */ });
+    }
+
+    // Visibility refetch — mirrors the now-playing pattern. Detaches
+    // via env.onCleanup so we don't leak across route transitions.
+    function onVisibilityChange() {
+      if (typeof document === 'undefined') return;
+      if (document.hidden) return;
+      reconcileField(store, 'favorites').catch(() => {});
+    }
+    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      env.onCleanup(() => document.removeEventListener('visibilitychange', onVisibilityChange));
+    }
+
+    return {
+      speaker() { render(); },
+    };
+  },
+});

--- a/admin/app/views/now-playing.js
+++ b/admin/app/views/now-playing.js
@@ -30,6 +30,12 @@ import { cache } from '../tunein-cache.js';
 import { showToast } from '../toast.js';
 import { pickTrackLine, pickMetaLine, humaniseSourceKey } from '../np-derive.js';
 import { labelForTopic, lazyFetchTopicsList } from './now-playing-data.js';
+import { favoriteHeart } from '../favorites.js';
+
+// Sources where a heart on the Now-Playing card makes no sense — the
+// playing content has no TuneIn id to favourite. Mirrors the AUX /
+// BLUETOOTH / STANDBY rule in the #126 spec.
+const HEART_HIDDEN_SOURCES = new Set(['AUX', 'BLUETOOTH', 'STANDBY']);
 
 const POLL_MS = 2000;
 const PRESET_SLOTS = 6;
@@ -70,7 +76,10 @@ export default defineView({
                   <span class="np-eq-slot" aria-hidden="true"></span>
                   <span class="np-meta" hidden></span>
                 </div>
-                <h1 class="np-name"></h1>
+                <div class="np-name-row">
+                  <h1 class="np-name"></h1>
+                  <span class="np-heart-slot" aria-hidden="true"></span>
+                </div>
                 <p class="np-track" aria-live="polite" hidden></p>
               </div>
               <div class="np-transport">
@@ -110,6 +119,7 @@ export default defineView({
     const cardEl     = root.querySelector('.np-card');
     const artEl      = root.querySelector('.np-art');
     const nameEl     = root.querySelector('.np-name');
+    const heartSlot  = root.querySelector('.np-heart-slot');
     const trackEl    = root.querySelector('.np-track');
     const metaEl     = root.querySelector('.np-meta');
     const sourcesEl  = root.querySelector('.np-sources');
@@ -133,6 +143,35 @@ export default defineView({
     btnPlay.appendChild(playIconRef.node);
     const muteIconRef = { node: icon('vol', 14) };
     muteEl.appendChild(muteIconRef.node);
+
+    // Heart on the Now-Playing card (#126). Visibility is two-layered:
+    // favoriteHeart's own gate keeps it hidden unless the resolved
+    // guide_id matches `^[sp]\d+$`; the source-class gate below hides
+    // it on AUX / BLUETOOTH / STANDBY where no TuneIn id ever applies.
+    // The entry is resolved at click time from the live nowPlaying so
+    // the captured name/art track WS updates.
+    const heartEl = favoriteHeart({
+      store,
+      getEntry: () => {
+        const np = store.state.speaker.nowPlaying;
+        if (!np) return null;
+        // Explicit suppression for sources where no TuneIn id ever
+        // applies. AUX / BLUETOOTH / STANDBY can briefly carry a
+        // stale TuneIn-style location during a transition; gating on
+        // source.first is the safe answer.
+        if (HEART_HIDDEN_SOURCES.has(np.source)) return null;
+        const item = np.item;
+        const id = extractGuideIdFromLocation(item && item.location);
+        if (!id) return null;
+        const name = (item && (item.itemName || item.name)) || '';
+        const art  = (np && typeof np.art === 'string' && np.art.startsWith('http'))
+          ? np.art : '';
+        return { id, name, art, note: '' };
+      },
+      onCleanup: env.onCleanup,
+    });
+    heartEl.classList.add('np-heart');
+    if (heartSlot) heartSlot.appendChild(heartEl);
 
     // Long-press state — closure-local.
     let longPressTimer    = null;
@@ -227,6 +266,11 @@ export default defineView({
       // keyboard tabs through a hidden card don't reach a live button.
       syncPlayBtn(np);
       syncPrevNext(np);
+      // Heart repaint defensively — favoriteHeart's own 'speaker'
+      // subscription handles store-driven updates, but a polling tick
+      // that flips the source class (e.g. STANDBY → TUNEIN) needs the
+      // visibility gate to re-evaluate before the user sees the card.
+      if (heartEl && typeof heartEl.repaint === 'function') heartEl.repaint();
 
       if (standby) return;
 

--- a/admin/app/views/now-playing.js
+++ b/admin/app/views/now-playing.js
@@ -26,13 +26,15 @@ import {
   parentKey,
   topicsKey,
 } from '../transport-state.js';
-import { cache } from '../tunein-cache.js';
+import { cache, TTL_STREAM } from '../tunein-cache.js';
 import { showToast } from '../toast.js';
+import { cgiErrorMessage } from '../error-messages.js';
 import { pickTrackLine, pickMetaLine, humaniseSourceKey } from '../np-derive.js';
 import { labelForTopic, lazyFetchTopicsList } from './now-playing-data.js';
 
 const POLL_MS = 2000;
 const PRESET_SLOTS = 6;
+const FAVORITE_SLOTS = 9;
 const LONG_PRESS_MS = 600;
 
 // Thin shim so the existing renderName callsites stay one-arg. The
@@ -100,6 +102,13 @@ export default defineView({
           </div>
           <div class="np-presets-grid" role="toolbar" aria-label="Presets"></div>
         </div>
+        <div class="np-favorites" hidden>
+          <div class="np-section-h">
+            <span>Favourites</span>
+            <span class="np-section-h__hint">tap to play · long-press to focus</span>
+          </div>
+          <div class="np-favorites-grid" role="toolbar" aria-label="Favourites"></div>
+        </div>
         <div class="np-asleep" hidden>
           <p>Speaker is asleep</p>
           <p class="np-asleep-hint">Press Play to wake it up.</p>
@@ -115,6 +124,8 @@ export default defineView({
     const sourcesEl  = root.querySelector('.np-sources');
     const sourceCurEl = root.querySelector('.np-source-current');
     const presetsEl  = root.querySelector('.np-presets-grid');
+    const favoritesSectionEl = root.querySelector('.np-favorites');
+    const favoritesEl = root.querySelector('.np-favorites-grid');
     const asleepEl   = root.querySelector('.np-asleep');
     const volumeRowEl = root.querySelector('.np-volume');
     const muteEl     = root.querySelector('.np-mute');
@@ -389,6 +400,148 @@ export default defineView({
       presetBtns.push(btn);
     }
 
+    // --- favourites grid (#129) ------------------------------------
+    //
+    // 3×3 preview of the user's favourites list. Mirrors the preset
+    // card visuals (hashHue tint, name overlay) but with three distinct
+    // rules:
+    //   - the whole section hides at zero favourites (no empty
+    //     placeholder, no heading);
+    //   - partial fills render only the cards that exist — favourites
+    //     have no concept of empty slots;
+    //   - 9+ favourites render the first nine; the tab is the overflow
+    //     surface.
+    //
+    // Gestures match the preset row: tap → /play via playGuideId, long-
+    // press / contextmenu → `#/favorites?focus=<id>` so the favourites
+    // tab can scroll the matching row into view and flash it.
+
+    let favoriteLongPressTimer = null;
+    let favoriteLongPressCancelled = false;
+
+    function clearFavoriteLongPress() {
+      if (favoriteLongPressTimer != null) {
+        clearTimeout(favoriteLongPressTimer);
+        favoriteLongPressTimer = null;
+      }
+    }
+    env.onCleanup(clearFavoriteLongPress);
+
+    async function onFavoriteClick(evt) {
+      const btn = evt.currentTarget;
+      if (favoriteLongPressCancelled) {
+        favoriteLongPressCancelled = false;
+        return;
+      }
+      const id = btn.dataset.favId;
+      const name = btn.dataset.favName || id;
+      if (!id) return;
+      if (btn.disabled) return;
+      btn.disabled = true;
+      btn.classList.add('is-loading');
+      const cacheKey = `tunein.stream.${id}`;
+      const cached = cache.get(cacheKey);
+      try {
+        const result = await playGuideId(id, name, cached || undefined);
+        if (result && result.ok) {
+          if (typeof result.url === 'string' && result.url) {
+            cache.set(cacheKey, result.url, TTL_STREAM);
+          }
+          showToast(`Playing on Bo: ${name}`);
+        } else {
+          cache.invalidate(cacheKey);
+          showToast(cgiErrorMessage(result));
+        }
+      } catch (_err) {
+        cache.invalidate(cacheKey);
+        showToast('Could not reach Bo');
+      } finally {
+        btn.disabled = false;
+        btn.classList.remove('is-loading');
+      }
+    }
+
+    function focusFavorite(id) {
+      if (!id) return;
+      location.hash = `#/favorites?focus=${encodeURIComponent(id)}`;
+    }
+
+    function onFavoritePointerDown(evt) {
+      if (evt.button !== undefined && evt.button !== 0) return;
+      const btn = evt.currentTarget;
+      const id = btn.dataset.favId;
+      if (!id || btn.disabled) return;
+      clearFavoriteLongPress();
+      favoriteLongPressCancelled = false;
+      favoriteLongPressTimer = setTimeout(() => {
+        favoriteLongPressTimer = null;
+        favoriteLongPressCancelled = true;
+        focusFavorite(id);
+      }, LONG_PRESS_MS);
+    }
+
+    function onFavoritePointerUp()     { clearFavoriteLongPress(); }
+    function onFavoritePointerCancel() { clearFavoriteLongPress(); }
+
+    function onFavoriteContextMenu(evt) {
+      evt.preventDefault();
+      const btn = evt.currentTarget;
+      const id = btn.dataset.favId;
+      if (!id || btn.disabled) return;
+      clearFavoriteLongPress();
+      favoriteLongPressCancelled = false;
+      focusFavorite(id);
+    }
+
+    function applyFavorites(favorites) {
+      const list = Array.isArray(favorites) ? favorites : [];
+      const visible = list.slice(0, FAVORITE_SLOTS);
+
+      // Hide the entire section at zero — no heading, no placeholder.
+      if (visible.length === 0) {
+        favoritesSectionEl.hidden = true;
+        favoritesEl.replaceChildren();
+        return;
+      }
+      favoritesSectionEl.hidden = false;
+
+      // Cheap signature so re-renders skip the rebuild when the visible
+      // slice hasn't changed. Mirrors the preset path's per-slot dataset
+      // diff but applies it to the whole grid because favourites are
+      // ordered and have no slot ids.
+      const sig = visible.map((e) => `${e.id}|${e.name || ''}|${e.art || ''}`).join('\n');
+      if (favoritesEl.dataset.renderedSig === sig) return;
+      favoritesEl.dataset.renderedSig = sig;
+
+      favoritesEl.replaceChildren();
+      for (const entry of visible) {
+        if (!entry || typeof entry.id !== 'string') continue;
+        const name = entry.name && entry.name.trim() ? entry.name : entry.id;
+
+        const btn = document.createElement('button');
+        btn.className = 'np-fav';
+        btn.type = 'button';
+        btn.dataset.favId = entry.id;
+        btn.dataset.favName = name;
+        btn.style.setProperty('--np-fav-hue', String(hashHue(name)));
+        btn.setAttribute('aria-label', `Play ${name}`);
+        btn.setAttribute('title', name);
+
+        const labelSpan = document.createElement('span');
+        labelSpan.className = 'np-fav-name';
+        labelSpan.textContent = name;
+        btn.appendChild(labelSpan);
+
+        btn.addEventListener('click',         onFavoriteClick);
+        btn.addEventListener('pointerdown',   onFavoritePointerDown);
+        btn.addEventListener('pointerup',     onFavoritePointerUp);
+        btn.addEventListener('pointercancel', onFavoritePointerCancel);
+        btn.addEventListener('contextmenu',   onFavoriteContextMenu);
+
+        favoritesEl.appendChild(btn);
+      }
+    }
+
     function applySourcePills(sources, activeSource) {
       const ready = (Array.isArray(sources) ? sources : [])
         .filter((s) => s && s.status === 'READY');
@@ -601,6 +754,7 @@ export default defineView({
     applyVolume(sp.volume);
     applySourcePills(sp.sources, sp.nowPlaying && sp.nowPlaying.source);
     applyPresets(sp.presets, sp.nowPlaying && sp.nowPlaying.item);
+    applyFavorites(sp.favorites);
 
     if (typeof document === 'undefined' || !document.hidden) startPolling();
     if (!store.state.speaker.presets) fetchPresetsOnce();
@@ -612,6 +766,7 @@ export default defineView({
         const activeSource = state.speaker.nowPlaying && state.speaker.nowPlaying.source;
         applySourcePills(state.speaker.sources, activeSource);
         applyPresets(state.speaker.presets, state.speaker.nowPlaying && state.speaker.nowPlaying.item);
+        applyFavorites(state.speaker.favorites);
       },
     };
   },

--- a/admin/app/views/search.js
+++ b/admin/app/views/search.js
@@ -36,6 +36,7 @@ import { icon } from '../icons.js';
 import { classifyOutline, normaliseRow } from '../tunein-outline.js';
 import { canonicaliseBrowseUrl, extractDrillKey } from '../tunein-url.js';
 import { cache, TTL_LABEL } from '../tunein-cache.js';
+import { store as appStore } from '../state.js';
 import {
   DEBOUNCE_MS,
   SEARCH_PLACEHOLDER,
@@ -179,6 +180,18 @@ export function searchRow(entry) {
       tertiary: norm.tertiary,
       badges:   norm.badges,
       chips:    norm.chips,
+      // Heart on s / p sids; topics keep the chevron (favoriteHeart's
+      // visibility gate rejects t-prefix). Capture rule per #126:
+      // {id, name, art, note: ''} from search-row data.
+      favorite: {
+        store: appStore,
+        getEntry: () => ({
+          id:   sid,
+          name: norm.primary || '',
+          art:  norm.image || '',
+          note: '',
+        }),
+      },
     });
     if (kind === 'show') {
       const drillHash = drillHashForUrl(entry && entry.URL)
@@ -584,6 +597,17 @@ export default defineView({
         sid:  entry.sid,
         name: entry.name || entry.sid,
         art:  entry.art,
+        // Recently-viewed rows capture {id, name, art, note: ''} from
+        // the row's own data — same shape as the search-result rows.
+        favorite: {
+          store: appStore,
+          getEntry: () => ({
+            id:   entry.sid,
+            name: entry.name || entry.sid,
+            art:  entry.art || '',
+            note: '',
+          }),
+        },
       })));
     }
 
@@ -604,6 +628,16 @@ export default defineView({
         location: e.subtext,
         bitrate:  e.bitrate,
         codec:    e.formats,
+        // Popular rows capture from the Browse.ashx?c=local row data.
+        favorite: {
+          store: appStore,
+          getEntry: () => ({
+            id:   e.guide_id || '',
+            name: e.text || '',
+            art:  e.image || '',
+            note: '',
+          }),
+        },
       })));
     }
 

--- a/admin/app/views/station.js
+++ b/admin/app/views/station.js
@@ -30,6 +30,7 @@ import { probe, assignToPreset, buildBosePayload } from '../probe.js';
 import { previewStream } from '../actions/index.js';
 import { cgiErrorMessage } from '../error-messages.js';
 import { pickArt, bestStream, buildMetaText, fmtCodec, fmtReliability } from '../station-verdict.js';
+import { favoriteHeart } from '../favorites.js';
 
 const ASSIGN_SLOTS = 6;
 
@@ -147,7 +148,9 @@ function renderSkeleton(root, sid) {
       <header class="station-header">
         <div class="station-art" hidden></div>
         <div class="station-header__body">
-          <h1 class="station-name">${sid}</h1>
+          <div class="station-name-row">
+            <h1 class="station-name">${sid}</h1>
+          </div>
           <p class="station-slogan"></p>
           <p class="station-meta">Loading metadata...</p>
         </div>
@@ -256,6 +259,19 @@ export default defineView({
     let stationArt = '';
     const getName = () => stationName;
     const getArt  = () => stationArt;
+
+    // Heart toggle next to the station name. `getEntry` reads the live
+    // name + art at click time so we don't lock in the placeholder
+    // before Describe.ashx lands. The component owns its own
+    // subscription to state.speaker.favorites; we hand it env.onCleanup
+    // so the unsub fires on route transition.
+    const heart = favoriteHeart({
+      getEntry: () => ({ id: sid, name: stationName, art: stationArt }),
+      store,
+      onCleanup: env.onCleanup,
+    });
+    const nameRow = root.querySelector('.station-name-row');
+    if (nameRow) nameRow.appendChild(heart);
 
     async function auditionStream(url, actx) {
       if (!actx || !actx.getProbe || !actx.getName) return;

--- a/admin/cgi-bin/api/v1/favorites
+++ b/admin/cgi-bin/api/v1/favorites
@@ -1,0 +1,335 @@
+#!/bin/sh
+#
+# favorites — admin-owned favourites list, persisted on the speaker.
+#
+# GET  /cgi-bin/api/v1/favorites   → { ok:true, data:[ {id,name,art,note}, ... ] }
+# PUT  /cgi-bin/api/v1/favorites   body = full JSON array → atomic replace
+#
+# The favourites list is the admin's persistent record of stations and
+# shows the user has hearted. It is DISJOINT from the firmware-owned
+# six hardware presets (those live in <preset> XML and reach the speaker
+# through /presets + /storePreset). The same TuneIn id may appear as a
+# favourite, a preset, both, or neither.
+#
+# Storage: /mnt/nv/resolver/admin-data/favorites.json
+# Shape:   JSON array; array index = position. No explicit `position` field.
+# Entry:   { "id": "sNNN" | "pNNN",
+#            "name": "<non-empty>",
+#            "art":  "" | "http(s)://...",
+#            "note": "<any string>" }
+#
+# PUT validation (envelope codes):
+#   INVALID_ID    — id missing or does not match ^[sp][0-9]+$
+#   INVALID_NAME  — name missing or empty
+#   INVALID_ART   — art is non-empty and not http(s)://...
+#   DUPLICATE_ID  — same id appears twice in the array
+#   INVALID_JSON  — body is not parseable as a JSON array
+#
+# Envelope + CSRF guard + CORS preflight come from the shared
+# admin/cgi-bin/lib/playback.sh / cgi-common.sh helpers, mirroring the
+# /presets and /preview CGIs.
+#
+# busybox-shell only — no bash-isms, no jq. Must pass shellcheck under
+# --severity=warning.
+
+set -u
+
+# shellcheck source=../../lib/playback.sh
+. "$(dirname "$0")/../../lib/playback.sh"
+
+# Where favourites live on the speaker. Distinct from
+# PLAYBACK_RESOLVER_DIR (which holds per-station Bose JSON for the
+# firmware to fetch) — favourites are admin-only metadata that the
+# firmware never sees.
+# Storage path. The literal lives in production; tests override via
+# FAV_DIR_OVERRIDE so the shell harness can exercise GET / PUT without
+# touching /mnt/nv. The override is intentionally NOT a CGI knob — busybox
+# httpd doesn't forward arbitrary env into CGI processes, so a request
+# from the network never reaches this branch.
+FAV_DIR="${FAV_DIR_OVERRIDE:-/mnt/nv/resolver/admin-data}"
+FAV_FILE="$FAV_DIR/favorites.json"
+
+# --- JSON array parser ---------------------------------------------
+#
+# parse_fav_entries — read a JSON array from stdin, emit one entry per
+# line to stdout in the format `<id>\t<name>\t<art>\t<note>`. Echoes
+# `INVALID_JSON` to stderr and returns non-zero if the top-level value
+# is not an array. Fields with embedded tabs are unlikely in practice
+# (the resolver-side validation prevents the entries we accept), but
+# we still defensively reject any control char inside a value.
+#
+# This is a minimal hand-rolled parser scoped to the favourites shape:
+# it handles the four expected string fields, the standard JSON string
+# escapes (\" \\ \/ \b \f \n \r \t) and \uXXXX, and the
+# array-of-objects-of-strings structure. Anything more exotic falls
+# through to INVALID_JSON, which is the right answer — the SPA never
+# generates anything more exotic.
+parse_fav_entries() {
+    awk '
+        BEGIN {
+            # Hex digit lookup for \uXXXX.
+            for (i = 0; i <= 9; i++) hex[i] = i
+            hex["a"] = 10; hex["b"] = 11; hex["c"] = 12
+            hex["d"] = 13; hex["e"] = 14; hex["f"] = 15
+            hex["A"] = 10; hex["B"] = 11; hex["C"] = 12
+            hex["D"] = 13; hex["E"] = 14; hex["F"] = 15
+        }
+        # Append the whole stdin to buf so we can walk it as one stream.
+        { buf = buf $0 "\n" }
+        END {
+            n = length(buf)
+            i = 1
+            # Skip leading whitespace.
+            while (i <= n && index(" \t\r\n", substr(buf, i, 1)) > 0) i++
+            if (substr(buf, i, 1) != "[") {
+                print "INVALID_JSON" > "/dev/stderr"
+                exit 2
+            }
+            i++
+            # Loop over array elements.
+            first = 1
+            while (1) {
+                while (i <= n && index(" \t\r\n,", substr(buf, i, 1)) > 0) i++
+                if (i > n) { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                c = substr(buf, i, 1)
+                if (c == "]") { i++; break }
+                if (c != "{") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                i++
+                id = ""; name = ""; art = ""; note = ""
+                seen_id = 0; seen_name = 0; seen_art = 0; seen_note = 0
+                # Loop over object members.
+                while (1) {
+                    while (i <= n && index(" \t\r\n,", substr(buf, i, 1)) > 0) i++
+                    if (i > n) { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    cc = substr(buf, i, 1)
+                    if (cc == "}") { i++; break }
+                    if (cc != "\"") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    key = parse_str()
+                    if (key == "__ERR__") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    while (i <= n && index(" \t\r\n", substr(buf, i, 1)) > 0) i++
+                    if (substr(buf, i, 1) != ":") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    i++
+                    while (i <= n && index(" \t\r\n", substr(buf, i, 1)) > 0) i++
+                    if (substr(buf, i, 1) != "\"") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    val = parse_str()
+                    if (val == "__ERR__") { print "INVALID_JSON" > "/dev/stderr"; exit 2 }
+                    if      (key == "id")   { id = val;   seen_id = 1 }
+                    else if (key == "name") { name = val; seen_name = 1 }
+                    else if (key == "art")  { art = val;  seen_art = 1 }
+                    else if (key == "note") { note = val; seen_note = 1 }
+                    # Unknown keys are silently dropped — we control
+                    # both ends, but staying tolerant means a future
+                    # client that adds a field can still talk to an
+                    # older speaker without erroring out.
+                }
+                # Defaults for missing fields: empty strings. The id is
+                # validated separately below; missing-id falls through
+                # to INVALID_ID rather than INVALID_JSON.
+                if (!first) printf "\n"
+                first = 0
+                printf "%s\t%s\t%s\t%s", id, name, art, note
+            }
+            if (!first) printf "\n"
+        }
+        function parse_str(    out, c, esc, u, j, hi, lo, cp) {
+            # Caller has positioned i at the opening ".
+            i++
+            out = ""
+            while (i <= n) {
+                c = substr(buf, i, 1)
+                if (c == "\"") { i++; return out }
+                if (c == "\\") {
+                    if (i + 1 > n) return "__ERR__"
+                    esc = substr(buf, i + 1, 1)
+                    if      (esc == "\"") { out = out "\""; i += 2 }
+                    else if (esc == "\\") { out = out "\\"; i += 2 }
+                    else if (esc == "/")  { out = out "/";  i += 2 }
+                    else if (esc == "b")  { out = out " ";  i += 2 }
+                    else if (esc == "f")  { out = out " ";  i += 2 }
+                    else if (esc == "n")  { out = out " ";  i += 2 }
+                    else if (esc == "r")  { out = out " ";  i += 2 }
+                    else if (esc == "t")  { out = out " ";  i += 2 }
+                    else if (esc == "u") {
+                        if (i + 5 > n) return "__ERR__"
+                        u = substr(buf, i + 2, 4)
+                        cp = 0
+                        for (j = 1; j <= 4; j++) {
+                            ch = substr(u, j, 1)
+                            if (!(ch in hex)) return "__ERR__"
+                            cp = cp * 16 + hex[ch]
+                        }
+                        # Only encode ASCII payloads here; non-ASCII
+                        # round-trips as a placeholder. The SPA only
+                        # emits ASCII for ids; names/notes that need
+                        # non-ASCII reach the speaker via the user
+                        # typing them, not via \u escapes.
+                        if (cp < 128) out = out sprintf("%c", cp)
+                        else          out = out "?"
+                        i += 6
+                    }
+                    else return "__ERR__"
+                }
+                else if (c == "\t" || c == "\n" || c == "\r") {
+                    # JSON forbids literal control chars in strings.
+                    return "__ERR__"
+                }
+                else {
+                    out = out c
+                    i++
+                }
+            }
+            return "__ERR__"
+        }
+    '
+}
+
+# --- Field validators ----------------------------------------------
+
+# is_valid_fav_id — accept ^s[0-9]+$ or ^p[0-9]+$.
+is_valid_fav_id() {
+    case "$1" in
+        s|p) return 1 ;;
+        s*|p*)
+            tail=${1#?}
+            case "$tail" in
+                ''|*[!0-9]*) return 1 ;;
+                *) return 0 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# is_valid_fav_art — accept the empty string or an http(s):// URL.
+is_valid_fav_art() {
+    case "$1" in
+        '')         return 0 ;;
+        http://*)   return 0 ;;
+        https://*)  return 0 ;;
+        *)          return 1 ;;
+    esac
+}
+
+# --- GET / PUT handlers --------------------------------------------
+
+handle_get() {
+    emit_ok_headers 'GET, PUT, OPTIONS'
+    if [ -s "$FAV_FILE" ]; then
+        cat "$FAV_FILE"
+        # Make sure the response ends in a newline even when the on-disk
+        # file doesn't.
+        last=$(tail -c 1 "$FAV_FILE" 2>/dev/null || true)
+        if [ "$last" != '' ] && [ "$last" != '
+' ]; then
+            printf '\n'
+        fi
+    else
+        # Absent file → empty list. No envelope wrapping needed since the
+        # GET body is the same shape the PUT consumes.
+        printf '{"ok":true,"data":[]}\n'
+    fi
+}
+
+handle_put() {
+    csrf_guard || return 0
+
+    body_file="$PLAYBACK_TMPDIR/favorites.$$.body"
+    parsed_file="$PLAYBACK_TMPDIR/favorites.$$.parsed"
+    # shellcheck disable=SC2064
+    trap "rm -f '$body_file' '$parsed_file' '$FAV_FILE.tmp'" EXIT INT TERM
+    slurp_body "$body_file"
+
+    if ! parse_fav_entries <"$body_file" >"$parsed_file" 2>/dev/null; then
+        emit_error '400 Bad Request' INVALID_JSON \
+            'body must be a JSON array of {id,name,art,note} objects'
+        return 0
+    fi
+
+    # Walk the parsed entries line by line, validating each. We collect
+    # seen ids in a small file so we can detect duplicates without
+    # relying on bash arrays (busybox shell is POSIX).
+    seen_file="$PLAYBACK_TMPDIR/favorites.$$.seen"
+    : >"$seen_file"
+    # shellcheck disable=SC2064
+    trap "rm -f '$body_file' '$parsed_file' '$seen_file' '$FAV_FILE.tmp'" \
+        EXIT INT TERM
+
+    has_entries=0
+    while IFS="$(printf '\t')" read -r fid fname fart _fnote; do
+        # Skip the trailing blank line from parse_fav_entries.
+        if [ -z "$fid" ] && [ -z "$fname" ] && [ -z "$fart" ]; then
+            continue
+        fi
+        has_entries=1
+        if ! is_valid_fav_id "$fid"; then
+            emit_error '400 Bad Request' INVALID_ID \
+                "id must match ^[sp][0-9]+\$"
+            return 0
+        fi
+        if [ -z "$fname" ]; then
+            emit_error '400 Bad Request' INVALID_NAME \
+                'name must be a non-empty string'
+            return 0
+        fi
+        if ! is_valid_fav_art "$fart"; then
+            emit_error '400 Bad Request' INVALID_ART \
+                'art must be empty or an http(s):// URL'
+            return 0
+        fi
+        if grep -Fxq "$fid" "$seen_file" 2>/dev/null; then
+            emit_error '400 Bad Request' DUPLICATE_ID \
+                "duplicate id in favourites list: $fid"
+            return 0
+        fi
+        printf '%s\n' "$fid" >>"$seen_file"
+    done <"$parsed_file"
+
+    # Empty array is legitimate (user cleared the list). has_entries
+    # disambiguates "no rows" from "every row was the blank trailer".
+    if [ "$has_entries" = 0 ] && [ -s "$parsed_file" ]; then
+        # Defensive: parse succeeded but no usable lines came through.
+        emit_error '400 Bad Request' INVALID_JSON \
+            'body parsed but produced no entries'
+        return 0
+    fi
+
+    # Atomic write: tmp + mv on the same filesystem. We persist the
+    # exact request body (not the parsed reshape) so any future fields
+    # the SPA adds round-trip until the parser learns to read them.
+    mkdir -p "$FAV_DIR" 2>/dev/null || true
+    # We store the envelope-shaped payload so GET can `cat` the file
+    # verbatim. The body the client PUT was just the bare array, so
+    # we re-emit it inside `{"ok":true,"data":...}`.
+    {
+        printf '{"ok":true,"data":'
+        cat "$body_file"
+        printf '}\n'
+    } >"$FAV_FILE.tmp" 2>/dev/null
+
+    if [ ! -s "$FAV_FILE.tmp" ]; then
+        emit_error '500 Internal Server Error' WRITE_FAILED \
+            "couldn't write favourites tmp file"
+        return 0
+    fi
+    if ! mv "$FAV_FILE.tmp" "$FAV_FILE" 2>/dev/null; then
+        rm -f "$FAV_FILE.tmp"
+        emit_error '500 Internal Server Error' RENAME_FAILED \
+            "couldn't move favourites file into place"
+        return 0
+    fi
+
+    emit_ok_headers 'GET, PUT, OPTIONS'
+    cat "$FAV_FILE"
+}
+
+# CORS preflight: respond and exit before doing any work.
+if handle_cors_preflight 'GET, PUT, OPTIONS'; then exit 0; fi
+
+case "${REQUEST_METHOD:-GET}" in
+    GET) handle_get ;;
+    PUT) handle_put ;;
+    *)
+        emit_error '405 Method Not Allowed' METHOD_NOT_ALLOWED \
+            'favorites accepts GET and PUT only'
+        ;;
+esac

--- a/admin/cgi-bin/api/v1/favorites
+++ b/admin/cgi-bin/api/v1/favorites
@@ -3,7 +3,11 @@
 # favorites — admin-owned favourites list, persisted on the speaker.
 #
 # GET  /cgi-bin/api/v1/favorites   → { ok:true, data:[ {id,name,art,note}, ... ] }
-# PUT  /cgi-bin/api/v1/favorites   body = full JSON array → atomic replace
+# POST /cgi-bin/api/v1/favorites   body = full JSON array → atomic replace
+#
+# busybox httpd on the speaker firmware (v1.19.4, 2017) returns 501 for
+# PUT before the CGI sees the request. POST is the only mutating method
+# that reaches the script. The presets CGI uses the same convention.
 #
 # The favourites list is the admin's persistent record of stations and
 # shows the user has hearted. It is DISJOINT from the firmware-owned
@@ -18,7 +22,7 @@
 #            "art":  "" | "http(s)://...",
 #            "note": "<any string>" }
 #
-# PUT validation (envelope codes):
+# POST validation (envelope codes):
 #   INVALID_ID    — id missing or does not match ^[sp][0-9]+$
 #   INVALID_NAME  — name missing or empty
 #   INVALID_ART   — art is non-empty and not http(s)://...
@@ -42,7 +46,7 @@ set -u
 # firmware to fetch) — favourites are admin-only metadata that the
 # firmware never sees.
 # Storage path. The literal lives in production; tests override via
-# FAV_DIR_OVERRIDE so the shell harness can exercise GET / PUT without
+# FAV_DIR_OVERRIDE so the shell harness can exercise GET / POST without
 # touching /mnt/nv. The override is intentionally NOT a CGI knob — busybox
 # httpd doesn't forward arbitrary env into CGI processes, so a request
 # from the network never reaches this branch.
@@ -210,10 +214,10 @@ is_valid_fav_art() {
     esac
 }
 
-# --- GET / PUT handlers --------------------------------------------
+# --- GET / POST handlers -------------------------------------------
 
 handle_get() {
-    emit_ok_headers 'GET, PUT, OPTIONS'
+    emit_ok_headers 'GET, POST, OPTIONS'
     if [ -s "$FAV_FILE" ]; then
         cat "$FAV_FILE"
         # Make sure the response ends in a newline even when the on-disk
@@ -225,12 +229,12 @@ handle_get() {
         fi
     else
         # Absent file → empty list. No envelope wrapping needed since the
-        # GET body is the same shape the PUT consumes.
+        # GET body is the same shape the POST consumes.
         printf '{"ok":true,"data":[]}\n'
     fi
 }
 
-handle_put() {
+handle_post() {
     csrf_guard || return 0
 
     body_file="$PLAYBACK_TMPDIR/favorites.$$.body"
@@ -298,7 +302,7 @@ handle_put() {
     # the SPA adds round-trip until the parser learns to read them.
     mkdir -p "$FAV_DIR" 2>/dev/null || true
     # We store the envelope-shaped payload so GET can `cat` the file
-    # verbatim. The body the client PUT was just the bare array, so
+    # verbatim. The body the client POST'd was just the bare array, so
     # we re-emit it inside `{"ok":true,"data":...}`.
     {
         printf '{"ok":true,"data":'
@@ -318,18 +322,18 @@ handle_put() {
         return 0
     fi
 
-    emit_ok_headers 'GET, PUT, OPTIONS'
+    emit_ok_headers 'GET, POST, OPTIONS'
     cat "$FAV_FILE"
 }
 
 # CORS preflight: respond and exit before doing any work.
-if handle_cors_preflight 'GET, PUT, OPTIONS'; then exit 0; fi
+if handle_cors_preflight 'GET, POST, OPTIONS'; then exit 0; fi
 
 case "${REQUEST_METHOD:-GET}" in
     GET) handle_get ;;
-    PUT) handle_put ;;
+    POST) handle_post ;;
     *)
         emit_error '405 Method Not Allowed' METHOD_NOT_ALLOWED \
-            'favorites accepts GET and PUT only'
+            'favorites accepts GET and POST only'
         ;;
 esac

--- a/admin/style.css
+++ b/admin/style.css
@@ -1310,9 +1310,46 @@ main {
   justify-content: center;
   width: 24px;
   color: var(--muted);
-  /* Visual stub only in #127; cursor hints the future affordance. */
   cursor: grab;
   opacity: 0.6;
+  /* The handle owns the pointer; suppress scroll/zoom gestures that
+   * would otherwise hijack the drag on touch. */
+  touch-action: none;
+  user-select: none;
+}
+.favorites-row__drag:active { cursor: grabbing; }
+
+/* Source row while a drag is in flight — fade it so the ghost reads
+ * as "this is where the row currently lives". */
+.favorites-row.is-dragging {
+  opacity: 0.4;
+}
+
+/* Drop indicator: a 2 px accent line that slides between rows as the
+ * pointer moves. Rendered inside the .favorites-list grid; takes up
+ * its own list slot so neighbouring rows nudge apart visually. */
+.favorites-drag-indicator {
+  height: 2px;
+  background: var(--accent, #4a90e2);
+  border-radius: 1px;
+  margin: 2px 4px;
+  pointer-events: none;
+}
+
+/* Floating ghost — semi-transparent clone that follows the pointer. */
+.favorites-drag-ghost {
+  position: fixed;
+  pointer-events: none;
+  opacity: 0.75;
+  z-index: 9999;
+  transform: translate(-12px, -50%);
+  background: var(--surface-hi, #2a2a2a);
+  border: 1px solid var(--border, #444);
+  border-radius: 6px;
+  padding: 4px 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  max-width: 320px;
+  overflow: hidden;
 }
 
 .favorites-row__body {

--- a/admin/style.css
+++ b/admin/style.css
@@ -466,6 +466,24 @@ main {
   white-space: nowrap;
 }
 
+/* Now-Playing name + heart row (#126). The heart sits next to the
+   station name; the name span keeps its ellipsis behaviour while the
+   heart anchors to the right of the row. */
+.np-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.np-name-row .np-name {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.np-heart-slot {
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+
 .np-track {
   margin: 0;
   font-size: 14px;
@@ -2635,6 +2653,19 @@ select.settings-input {
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+}
+
+/* showHero name + inline heart (#126). The heart toggle sits next to
+   the show title inside the body column. The name keeps ellipsis;
+   the heart anchors at the end of the row. */
+.station-row__name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.station-row__name-row .station-row__name {
+  flex: 1 1 auto;
 }
 
 .station-row__meta {

--- a/admin/style.css
+++ b/admin/style.css
@@ -1100,6 +1100,83 @@ main {
   margin: 0 0 0.25rem;
 }
 
+/* Station name + favourites heart sit on one row so the heart hugs the
+ * name on the left and never bumps the rest of the metadata below. */
+.station-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.station-name-row .station-name {
+  margin-bottom: 0;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+/* Favourites heart — toggle button. Outline (.is-empty) and filled
+ * (.is-filled) variants share the same path; the filled state paints
+ * the heart in --accent. The button is borderless on purpose so it
+ * reads as a glyph rather than an action chip; the focus ring keeps
+ * it keyboard-reachable. Hidden via [hidden] when the row's id isn't
+ * `^[sp]\d+$` (favoriteHeart() sets the attribute). */
+.fav-heart {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color 100ms ease;
+}
+.fav-heart:hover { color: var(--text); }
+.fav-heart:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.fav-heart.is-filled {
+  color: var(--accent, #e0245e);
+}
+.fav-heart.is-filled svg {
+  fill: currentColor;
+  stroke: currentColor;
+}
+.fav-heart.is-busy {
+  opacity: 0.6;
+  cursor: progress;
+}
+.fav-heart[hidden] { display: none; }
+
+/* Favourites tab body — plain list. The empty state mirrors the
+ * search-empty hint style: a faint header + one-line tip. */
+.favorites {
+  padding: 1rem;
+}
+.favorites-header h1 {
+  font-size: 1.5rem;
+  margin: 0 0 1rem;
+}
+.favorites-empty {
+  color: var(--muted);
+  padding: 2rem 0;
+  text-align: center;
+}
+.favorites-empty h2 {
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+.favorites-empty p {
+  margin: 0;
+}
+.favorites-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .station-slogan {
   margin: 0 0 0.25rem;
   font-style: italic;

--- a/admin/style.css
+++ b/admin/style.css
@@ -749,6 +749,90 @@ main {
   white-space: nowrap;
 }
 
+/* Favourites grid (#129) — 3×3 preview of the user's favourites,
+   mirroring the preset card visuals. Hidden entirely at zero favourites
+   (the section element carries `hidden`). Cards take a deterministic
+   per-station tint via `--np-fav-hue` set inline. */
+.np-favorites {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.np-favorites-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.np-fav {
+  font: inherit;
+  text-align: left;
+  display: block;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: #ffffff;
+  cursor: pointer;
+  position: relative;
+  min-height: 92px;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg,
+      hsl(var(--np-fav-hue, 220), 60%, 55%),
+      color-mix(in srgb, hsl(var(--np-fav-hue, 220), 60%, 30%) 60%, #000));
+  transition: border-color 120ms, transform 120ms;
+}
+
+.np-fav:not(:disabled):hover {
+  border-color: var(--accent);
+}
+
+.np-fav:not(:disabled):active {
+  transform: scale(0.985);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .np-fav { transition: none; }
+  .np-fav:not(:disabled):active { transform: none; }
+}
+
+.np-fav.is-loading {
+  opacity: 0.75;
+}
+
+.np-fav-name {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  right: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #ffffff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Brief flash on the Favourites tab when arriving via
+   `#/favorites?focus=<id>` (long-press from the Now-Playing grid). */
+.favorites-row.is-focused {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  animation: favorites-focus-flash 1400ms ease-out;
+}
+
+@keyframes favorites-focus-flash {
+  0%   { background: color-mix(in srgb, var(--accent) 30%, transparent); }
+  100% { background: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .favorites-row.is-focused { animation: none; }
+}
+
 /* STANDBY / asleep state */
 .np-asleep {
   border: 1px solid var(--border);

--- a/admin/style.css
+++ b/admin/style.css
@@ -1177,6 +1177,173 @@ main {
   gap: 0.25rem;
 }
 
+/* Favourites row — [drag-handle stub] [body] [pencil] [trash]. The
+ * body is a flex-1 button so the row can be tapped to play without
+ * stealing pencil/trash click targets. Pencil expands the row in
+ * place: the form is appended as a sibling under the row controls and
+ * `.is-expanded` lifts the row's background so the form reads as
+ * "part of this entry". */
+.favorites-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: transparent;
+  transition: background 120ms ease;
+}
+.favorites-row.is-expanded {
+  background: var(--surface-hi);
+  /* Make the form span the full row when expanded. */
+  grid-template-columns: auto 1fr auto auto;
+}
+.favorites-row.is-expanded .favorites-row__edit {
+  grid-column: 1 / -1;
+}
+
+.favorites-row__drag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  color: var(--muted);
+  /* Visual stub only in #127; cursor hints the future affordance. */
+  cursor: grab;
+  opacity: 0.6;
+}
+
+.favorites-row__body {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  min-width: 0;
+  border-radius: 4px;
+  transition: background 120ms ease;
+}
+.favorites-row__body:hover,
+.favorites-row__body:focus-visible {
+  background: var(--surface-hi);
+}
+.favorites-row__body:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.favorites-row__body.is-disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.favorites-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.favorites-row__name {
+  font-weight: 500;
+  font-size: 13.5px;
+  line-height: 1.2;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.favorites-row__note {
+  font-size: 11.5px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.favorites-row__edit-btn,
+.favorites-row__delete-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 120ms ease, background 120ms ease;
+}
+.favorites-row__edit-btn:hover,
+.favorites-row__edit-btn:focus-visible,
+.favorites-row__delete-btn:hover,
+.favorites-row__delete-btn:focus-visible {
+  color: var(--fg);
+  background: var(--surface-hi);
+}
+.favorites-row__delete-btn:hover,
+.favorites-row__delete-btn:focus-visible {
+  color: var(--danger, #c0392b);
+}
+
+/* Inline edit form. Three single-line inputs + Save / Cancel. */
+.favorites-row__edit {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-top: 6px;
+  border-top: 1px solid var(--border);
+}
+.favorites-edit__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.favorites-edit__label {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.favorites-edit__input {
+  font: inherit;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--fg);
+}
+.favorites-edit__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.favorites-edit__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+.favorites-edit__btn {
+  font: inherit;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+}
+.favorites-edit__btn--save {
+  background: var(--accent);
+  color: var(--accent-fg, white);
+  border-color: var(--accent);
+}
+
 .station-slogan {
   margin: 0 0 0.25rem;
   font-style: italic;
@@ -1331,6 +1498,33 @@ main {
 .toast.is-shown {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* Action toast — text + inline button (e.g. "Undo" after a favourite
+ * is deleted). pointer-events restored on the toast itself so the
+ * button is tappable; the container above keeps pointer-events:none. */
+.toast--action {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  pointer-events: auto;
+}
+.toast--action .toast__text {
+  flex: 1 1 auto;
+}
+.toast--action .toast__action {
+  font: inherit;
+  font-weight: 600;
+  padding: 4px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--accent, #e0245e);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.toast--action .toast__action:hover,
+.toast--action .toast__action:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* --- preset modal (#/preset/N) ------------------------------------ */

--- a/admin/test/test_browse.js
+++ b/admin/test/test_browse.js
@@ -57,7 +57,7 @@ function hasClass(el, cls) {
 
 // --- audio-leaf rendering -------------------------------------------
 
-test('renderEntry: audio leaf renders a station-row with art + name + meta + chevron', () => {
+test('renderEntry: audio leaf renders a station-row with art + name + meta + heart (#126)', () => {
   const node = renderEntry({
     type:       'audio',
     guide_id:   's12345',
@@ -85,8 +85,12 @@ test('renderEntry: audio leaf renders a station-row with art + name + meta + che
   const fmt = findFirstByClass(node, 'station-row__fmt');
   assert.equal(fmt.textContent, '192k MP3');
 
+  // Per #126 the heart replaces the chevron on favouritable
+  // (`^[sp]\d+$`) rows.
+  const heart = findFirstByClass(node, 'fav-heart');
+  assert.ok(heart, 'heart slot present on s-prefix row');
   const chev = findFirstByClass(node, 'station-row__chev');
-  assert.ok(chev, 'chevron slot present');
+  assert.equal(chev, null, 'chevron is gone on favouritable rows');
 });
 
 test('renderEntry: long station name keeps the truncating .station-row__name class', () => {

--- a/admin/test/test_browse.js
+++ b/admin/test/test_browse.js
@@ -264,24 +264,10 @@ test('renderOutline: paginated page (flat list) renders one section card with cu
   assert.equal(sections[0].getAttribute('data-section'), 'flat');
 });
 
-test('renderOutline: tombstone response renders an empty-state message', async () => {
-  const fs = await import('node:fs');
-  const path = await import('node:path');
-  const tomb = JSON.parse(
-    fs.readFileSync(path.resolve('admin/test/fixtures/api/c424724-l117-tombstone.tunein.json'), 'utf8'),
-  );
-
-  const body = doc.createElement('div');
-  const total = renderOutline(body, tomb);
-
-  assert.equal(total, 0);
-  const empty = findFirstByClass(body, 'browse-empty');
-  assert.ok(empty, 'tombstone produces a .browse-empty message node');
-  assert.equal(empty.textContent, 'No stations or shows available');
-  // No section cards.
-  const sections = findAllBy(body, (el) => el.getAttribute('data-section') != null);
-  assert.equal(sections.length, 0);
-});
+// renderOutline's top-level tombstone / body:[] branches have moved
+// upstream into tunein-drill.resolveBrowseDrill (#122). The fixture-
+// driven equivalent of this test lives in test_tunein_drill.js — see
+// "resolveBrowseDrill on the captured Welsh tombstone fixture".
 
 // --- segmented control: CSS contract -------------------------------
 

--- a/admin/test/test_browse_outline.js
+++ b/admin/test/test_browse_outline.js
@@ -259,13 +259,11 @@ test('renderOutline returns the total visible row count, skipping cursors / pivo
   assert.equal(total, 3);
 });
 
-test('renderOutline emits an empty-state for an entirely empty body', () => {
-  const body = doc.createElement('div');
-  const total = renderOutline(body, { head: { status: '200' }, body: [] });
-  assert.equal(total, 0);
-  const empty = findFirstByClass(body, 'browse-empty');
-  assert.ok(empty);
-});
+// renderOutline's top-level body:[] branch has moved upstream into
+// tunein-drill.resolveBrowseDrill (#122). The seam now returns
+// kind:'empty' for an empty body; the renderer paints emptyNode
+// directly without renderOutline being involved. The equivalent
+// fixture-driven test lives in test_tunein_drill.js.
 
 // --- primeTuneinSkipCaches preserves the #102 episode-name write ----
 

--- a/admin/test/test_browse_show_landing.js
+++ b/admin/test/test_browse_show_landing.js
@@ -14,6 +14,7 @@ void ev;
 
 const {
   _renderShowLandingForTest,
+  loadShowLanding,
   renderLiveShowCard,
   renderTopicsCard,
   renderTopicRow,
@@ -308,4 +309,73 @@ test('renderLiveShowCard primes tunein.label.<p-sid> from the airing show entry 
   ]);
   assert.equal(tc.cache.get('tunein.label.p105'), 'Fresh Air');
   tc.cache.invalidate('tunein.label.p105');
+});
+
+// --- loadShowLanding: Browse-half routed through resolveBrowseDrill (#123) ---
+//
+// The migration moves `tuneinBrowse(showId).catch(() => null)` onto the
+// structured drill seam. Behavioural parity for valid drills and for
+// rejected ones is unchanged; the gain is that empty / error / tombstone
+// classification is explicit. This unit drives loadShowLanding end-to-end
+// with a stubbed globalThis.fetch: Describe resolves with a show body so
+// the card mounts, and Browse rejects (network down) so resolveBrowseDrill
+// classifies it as kind:'error'. The expected outcome is parity with the
+// pre-migration swallowed-rejection behaviour: show card present, no
+// related-sections cards.
+
+test('#123 loadShowLanding: kind:error from resolveBrowseDrill still mounts the show card with no related-sections card', async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = typeof url === 'string' ? url : String(url);
+    if (u.includes('/tunein/describe')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          head: { status: '200' },
+          body: [{
+            element: 'show',
+            guide_id: 'p17',
+            title: 'Fresh Air',
+            hosts: 'Terry Gross',
+            description: 'A Peabody Award winner.',
+            genre_id: 'g168',
+          }],
+        }),
+      };
+    }
+    if (u.includes('/tunein/browse')) {
+      // Network-down-style throw — the resolver classifies this as
+      // kind:'error' with code 'ERROR'.
+      throw new Error('failed to fetch');
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+
+  try {
+    const body = doc.createElement('div');
+    const headerCount = doc.createElement('span');
+    loadShowLanding(body, 'p17', headerCount, null);
+
+    // Let the Describe + drill-seam promises settle. The chain is:
+    //   fetch → res.json() → tuneinDescribe/Browse → resolveBrowseDrill
+    //     → Promise.all → renderShowLandingBody
+    // each `await` advances one microtask turn; a macrotask boundary
+    // (setTimeout 0) flushes the whole chain reliably.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Show card mounted from the Describe response.
+    const landings = findAllBy(body, (el) => el.getAttribute('data-section') === 'showLanding');
+    assert.equal(landings.length, 1, 'show-landing card renders despite Browse-half error');
+
+    // No other sections — kind:'error' collapses to "no related sections",
+    // matching the pre-migration swallowed-rejection behaviour.
+    const sections = findAllBy(body, (el) => el.getAttribute('data-section') != null);
+    assert.equal(sections.length, 1, 'no related-sections card mounts when Browse errored');
+
+    // Header count is blank — relatedCount stays 0 when no related sections render.
+    assert.equal(headerCount.textContent, '');
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });

--- a/admin/test/test_crumb_parts.js
+++ b/admin/test/test_crumb_parts.js
@@ -1,0 +1,267 @@
+// Tests for the pure half of the Crumb stack module —
+// admin/app/views/browse/crumb-parts.js. Covers the value type
+// (parseCrumbs / stringifyCrumbs, crumbTokenFor / partsFromCrumb),
+// the URL composer (backHrefFor), and the cache-driven label
+// readers (crumbLabelFor + the lcode catalogue join).
+//
+// crumb-parts.js is pure: no DOM imports, no api.js, no fetch. This
+// test file therefore avoids the @xmldom/xmldom-backed dom-shim and
+// brings in only the sessionStorage stub that tunein-cache.js needs.
+//
+// Run: node --test admin/test
+
+import { test, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// sessionStorage stub — tunein-cache.js reads sessionStorage at import
+// time to back its label cache. Mirrors the in-memory Map shim the
+// dom-shim installs (kept in scope so beforeEach can clear it
+// between tests).
+const ssStore = new Map();
+globalThis.sessionStorage = {
+  getItem(k)         { return ssStore.has(k) ? ssStore.get(k) : null; },
+  setItem(k, v)      { ssStore.set(k, String(v)); },
+  removeItem(k)      { ssStore.delete(k); },
+  clear()            { ssStore.clear(); },
+};
+
+const {
+  parseCrumbs,
+  stringifyCrumbs,
+  crumbTokenFor,
+  partsFromCrumb,
+  backHrefFor,
+  crumbLabelFor,
+} = await import('../app/views/browse/crumb-parts.js');
+
+beforeEach(() => {
+  ssStore.clear();
+});
+
+// --- parseCrumbs / stringifyCrumbs ----------------------------------
+
+test('parseCrumbs splits a comma-separated string into trimmed tokens', () => {
+  assert.deepEqual(parseCrumbs('c100000948,g79,music'), ['c100000948', 'g79', 'music']);
+});
+
+test('parseCrumbs returns [] for empty / non-string input', () => {
+  assert.deepEqual(parseCrumbs(''), []);
+  assert.deepEqual(parseCrumbs(null), []);
+  assert.deepEqual(parseCrumbs(undefined), []);
+});
+
+test('parseCrumbs drops empty segments', () => {
+  assert.deepEqual(parseCrumbs('a,,b,'), ['a', 'b']);
+});
+
+test('parseCrumbs caps the stack at 8 entries, keeping the tail', () => {
+  const raw = 'a,b,c,d,e,f,g,h,i,j';
+  const parsed = parseCrumbs(raw);
+  assert.equal(parsed.length, 8, 'cap to MAX_CRUMBS');
+  // The last crumb is the most recent — preserved.
+  assert.equal(parsed[parsed.length - 1], 'j');
+  // The first two are dropped (the oldest).
+  assert.equal(parsed[0], 'c');
+});
+
+test('stringifyCrumbs joins with comma and returns empty for empty', () => {
+  assert.equal(stringifyCrumbs(['a', 'b', 'c']), 'a,b,c');
+  assert.equal(stringifyCrumbs([]), '');
+  assert.equal(stringifyCrumbs(null), '');
+  assert.equal(stringifyCrumbs(undefined), '');
+});
+
+test('stringifyCrumbs then parseCrumbs round-trip preserves token order', () => {
+  const original = ['c100000948', 'g79', 'music'];
+  assert.deepEqual(parseCrumbs(stringifyCrumbs(original)), original);
+});
+
+// --- crumbTokenFor / partsFromCrumb ---------------------------------
+
+test('crumbTokenFor prefers id over c', () => {
+  assert.equal(crumbTokenFor({ id: 'g79' }), 'g79');
+  assert.equal(crumbTokenFor({ c: 'music' }), 'music');
+  assert.equal(crumbTokenFor({ id: 'g79', c: 'music' }), 'g79');
+});
+
+test('crumbTokenFor returns null when neither anchor is set', () => {
+  assert.equal(crumbTokenFor({}), null);
+  assert.equal(crumbTokenFor({ filter: 'l109' }), null);
+  assert.equal(crumbTokenFor(null), null);
+});
+
+test('partsFromCrumb maps lowercase-letter-then-digit tokens to id', () => {
+  assert.deepEqual(partsFromCrumb('g79'),       { id: 'g79' });
+  assert.deepEqual(partsFromCrumb('c100000948'), { id: 'c100000948' });
+  assert.deepEqual(partsFromCrumb('p38913'),     { id: 'p38913' });
+  assert.deepEqual(partsFromCrumb('s12345'),     { id: 's12345' });
+});
+
+test('partsFromCrumb maps letters-only tokens to c=', () => {
+  assert.deepEqual(partsFromCrumb('music'),  { c: 'music' });
+  assert.deepEqual(partsFromCrumb('talk'),   { c: 'talk' });
+  assert.deepEqual(partsFromCrumb('sports'), { c: 'sports' });
+  assert.deepEqual(partsFromCrumb('lang'),   { c: 'lang' });
+});
+
+test('partsFromCrumb returns null for empty / non-string', () => {
+  assert.equal(partsFromCrumb(''), null);
+  assert.equal(partsFromCrumb(null), null);
+  assert.equal(partsFromCrumb(123), null);
+});
+
+// --- filter-aware crumb encoding (#89) ------------------------------
+
+test('crumbTokenFor encodes a filter as <anchor>:<filter> so language-tree drills produce distinct tokens', () => {
+  assert.equal(crumbTokenFor({ c: 'lang',  filter: 'l109' }), 'lang:l109');
+  assert.equal(crumbTokenFor({ c: 'music', filter: 'l109' }), 'music:l109');
+  assert.equal(crumbTokenFor({ id: 'c100000948', filter: 'l109' }), 'c100000948:l109');
+});
+
+test('crumbTokenFor omits the filter suffix when no filter is set', () => {
+  assert.equal(crumbTokenFor({ c: 'lang' }), 'lang');
+  assert.equal(crumbTokenFor({ id: 'g79' }), 'g79');
+});
+
+test('partsFromCrumb round-trips the <anchor>:<filter> form back to drill parts', () => {
+  // #106: parts carry `filters: string[]` plus a back-compat `filter`
+  // alias (the comma-joined wire value). Single-filter tokens land as
+  // single-element arrays.
+  assert.deepEqual(partsFromCrumb('lang:l109'),       { c: 'lang',  filters: ['l109'],       filter: 'l109' });
+  assert.deepEqual(partsFromCrumb('music:l109'),      { c: 'music', filters: ['l109'],       filter: 'l109' });
+  assert.deepEqual(partsFromCrumb('c100000948:l109'), { id: 'c100000948', filters: ['l109'], filter: 'l109' });
+});
+
+test('crumbTokenFor → partsFromCrumb round-trip for the language-tree path emits distinct tokens', () => {
+  // The bug from issue #89: drilling root → Language → German → Music
+  // in German used to collapse every step's token to "lang", giving a
+  // breadcrumb of "By Language › By Language › By Language". After the
+  // filter-aware fix each step produces its own token.
+  const lang   = crumbTokenFor({ c: 'lang' });
+  const german = crumbTokenFor({ c: 'lang', filter: 'l109' });
+  const music  = crumbTokenFor({ c: 'music', filter: 'l109' });
+  assert.equal(lang,   'lang');
+  assert.equal(german, 'lang:l109');
+  assert.equal(music,  'music:l109');
+  assert.notEqual(lang, german);
+  assert.notEqual(german, music);
+  // Round-trip back to drill parts (now carrying the `filters` array
+  // plus the back-compat `filter` alias — #106).
+  assert.deepEqual(partsFromCrumb(german), { c: 'lang',  filters: ['l109'], filter: 'l109' });
+  assert.deepEqual(partsFromCrumb(music),  { c: 'music', filters: ['l109'], filter: 'l109' });
+});
+
+// --- backHrefFor: pop the rightmost crumb --------------------------
+
+test('backHrefFor with empty stack lands at the root tabs view', () => {
+  assert.equal(backHrefFor([]), '#/browse');
+  assert.equal(backHrefFor(null), '#/browse');
+  assert.equal(backHrefFor(undefined), '#/browse');
+});
+
+test('backHrefFor with one crumb lands at that crumb with no further from=', () => {
+  // Stack [music] → pop → land on c=music with empty from=.
+  assert.equal(backHrefFor(['music']), '#/browse?c=music');
+});
+
+test('backHrefFor with multiple crumbs pops the rightmost and carries the rest as from=', () => {
+  // Stack [music, g79] → pop → land on id=g79 with from=music.
+  assert.equal(backHrefFor(['music', 'g79']), '#/browse?id=g79&from=music');
+  // Stack [c100000948, g79, music] → pop → land on c=music with from=c100000948,g79.
+  // URLSearchParams encodes commas as %2C.
+  assert.equal(
+    backHrefFor(['c100000948', 'g79', 'music']),
+    '#/browse?c=music&from=c100000948%2Cg79',
+  );
+});
+
+// --- crumbLabelFor surfaces the resolved language name (#90) --------
+
+test('crumbLabelFor appends the resolved language name when filter is a known lcode', async () => {
+  const { cacheLcodes } = await import('../app/tunein-url.js');
+  cacheLcodes([{ id: 'l109', name: 'German' }]);
+  assert.equal(
+    crumbLabelFor({ c: 'music', filter: 'l109' }),
+    'c=music · filter=l109 (German)',
+  );
+});
+
+test('crumbLabelFor leaves the badge unchanged when the lcode catalogue does not know the filter', () => {
+  // No cacheLcodes — lcodeLabel returns undefined → no "(name)" suffix.
+  assert.equal(
+    crumbLabelFor({ c: 'music', filter: 'l9999' }),
+    'c=music · filter=l9999',
+  );
+});
+
+test('crumbLabelFor leaves non-lcode filters unchanged', async () => {
+  const { cacheLcodes } = await import('../app/tunein-url.js');
+  cacheLcodes([{ id: 'l109', name: 'German' }]);
+  // A non-l filter shape — even if a cached catalogue exists.
+  assert.equal(
+    crumbLabelFor({ id: 'g79', filter: 'top' }),
+    'g79 · filter=top',
+  );
+});
+
+// --- #106 — multi-filter support: parts.filters: string[] -----------
+//
+// TuneIn upstream accepts comma-separated values inside a single
+// `filter=` query param (e.g. `filter=l109,g22` for "rock stations in
+// German-speaking countries"). The SPA's state shape is
+// `parts.filters: string[]`; the crumb-token form is
+// `<anchor>:<f1>+<f2>+…` (plus sign separates filters inside one
+// crumb so the comma-separated `from=` stack is unambiguous).
+
+test('crumbTokenFor encodes parts.filters: string[] as <anchor>:<f1>+<f2>+… — #106', () => {
+  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26', 'l170'] }),       'r101821:g26+l170');
+  assert.equal(crumbTokenFor({ c: 'music',    filters: ['l109', 'g22'] }),       'music:l109+g22');
+  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26', 'l170', 'm:5'] }), 'r101821:g26+l170+m:5');
+});
+
+test('crumbTokenFor with a single filter emits the legacy <anchor>:<filter> shape — #106', () => {
+  // Single-filter case must produce the same token as the old single-
+  // string callers so bookmarks / pasted URLs from before #106 keep
+  // resolving against the same cache keys.
+  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26'] }), 'r101821:g26');
+  assert.equal(crumbTokenFor({ c: 'lang',     filters: ['l109'] }), 'lang:l109');
+});
+
+test('crumbTokenFor with an empty filters array drops to the bare anchor — #106', () => {
+  assert.equal(crumbTokenFor({ id: 'r101821', filters: [] }), 'r101821');
+  assert.equal(crumbTokenFor({ c: 'music',    filters: [] }), 'music');
+});
+
+test('partsFromCrumb splits a <anchor>:<f1>+<f2> token back to filters: [f1, f2] — #106', () => {
+  assert.deepEqual(
+    partsFromCrumb('r101821:g26+l170'),
+    { id: 'r101821', filters: ['g26', 'l170'], filter: 'g26,l170' },
+  );
+  assert.deepEqual(
+    partsFromCrumb('music:l109+g22'),
+    { c: 'music', filters: ['l109', 'g22'], filter: 'l109,g22' },
+  );
+});
+
+test('partsFromCrumb round-trips three stacked filters — #106', () => {
+  const tok = 'r101821:g26+l170+m:5';
+  const parts = partsFromCrumb(tok);
+  assert.deepEqual(parts.filters, ['g26', 'l170', 'm:5']);
+  assert.equal(crumbTokenFor(parts), tok, 'token round-trips');
+});
+
+test('crumbTokenFor → partsFromCrumb round-trips zero / one / two / three filters — #106', () => {
+  for (const filters of [[], ['g26'], ['g26', 'l170'], ['g26', 'l170', 's:popular']]) {
+    const parts = { id: 'r101821' };
+    if (filters.length > 0) parts.filters = filters;
+    const token = crumbTokenFor(parts);
+    const round = partsFromCrumb(token);
+    if (filters.length === 0) {
+      assert.equal(token, 'r101821');
+      assert.deepEqual(round, { id: 'r101821' });
+    } else {
+      assert.deepEqual(round.filters, filters, `${filters.length}-filter round-trip`);
+      assert.equal(round.id, 'r101821');
+    }
+  }
+});

--- a/admin/test/test_crumb_renderer.js
+++ b/admin/test/test_crumb_renderer.js
@@ -1,8 +1,12 @@
-// Tests for the URL crumb stack helpers and the pill-bar / trail
-// renderer in admin/app/views/browse.js. The mounted-view paths
-// (renderDrill / renderRoot) need a real DOM; tests focus on the
-// pure helpers that own URL composition and on the cache-driven
-// trail render.
+// Tests for the DOM half of the Crumb stack module —
+// admin/app/views/browse/crumb-renderer.js. Covers the pill-bar
+// builder (renderPillBar, renderCrumbTrail), the filter-badge
+// renderers (renderFilterBadge / renderFilterBadges) and the
+// renderEntry → child-stack composition seam.
+//
+// The pure value type lives in crumb-parts.js (test_crumb_parts.js
+// covers it without the xmldom shim); this file exercises the
+// DOM-bound surface that hydrateCrumbLabels and the pill-bar mount.
 //
 // Run: node --test admin/test
 
@@ -14,17 +18,15 @@ import { doc, installSessionStorage } from './fixtures/dom-shim.js';
 const ssStore = installSessionStorage();
 
 const {
-  parseCrumbs,
-  stringifyCrumbs,
-  crumbTokenFor,
-  partsFromCrumb,
   renderCrumbTrail,
   renderPillBar,
   renderFilterBadge,
   renderFilterBadges,
+} = await import('../app/views/browse/crumb-renderer.js');
+
+const {
   backHrefFor,
-  crumbLabelFor,
-} = await import('../app/views/browse/crumbs.js');
+} = await import('../app/views/browse/crumb-parts.js');
 
 const {
   renderEntry,
@@ -35,119 +37,6 @@ const { cache, TTL_LABEL } = await import('../app/tunein-cache.js');
 
 beforeEach(() => {
   ssStore.clear();
-});
-
-// --- parseCrumbs / stringifyCrumbs ----------------------------------
-
-test('parseCrumbs splits a comma-separated string into trimmed tokens', () => {
-  assert.deepEqual(parseCrumbs('c100000948,g79,music'), ['c100000948', 'g79', 'music']);
-});
-
-test('parseCrumbs returns [] for empty / non-string input', () => {
-  assert.deepEqual(parseCrumbs(''), []);
-  assert.deepEqual(parseCrumbs(null), []);
-  assert.deepEqual(parseCrumbs(undefined), []);
-});
-
-test('parseCrumbs drops empty segments', () => {
-  assert.deepEqual(parseCrumbs('a,,b,'), ['a', 'b']);
-});
-
-test('parseCrumbs caps the stack at 8 entries, keeping the tail', () => {
-  const raw = 'a,b,c,d,e,f,g,h,i,j';
-  const parsed = parseCrumbs(raw);
-  assert.equal(parsed.length, 8, 'cap to MAX_CRUMBS');
-  // The last crumb is the most recent — preserved.
-  assert.equal(parsed[parsed.length - 1], 'j');
-  // The first two are dropped (the oldest).
-  assert.equal(parsed[0], 'c');
-});
-
-test('stringifyCrumbs joins with comma and returns empty for empty', () => {
-  assert.equal(stringifyCrumbs(['a', 'b', 'c']), 'a,b,c');
-  assert.equal(stringifyCrumbs([]), '');
-  assert.equal(stringifyCrumbs(null), '');
-  assert.equal(stringifyCrumbs(undefined), '');
-});
-
-test('stringifyCrumbs then parseCrumbs round-trip preserves token order', () => {
-  const original = ['c100000948', 'g79', 'music'];
-  assert.deepEqual(parseCrumbs(stringifyCrumbs(original)), original);
-});
-
-// --- crumbTokenFor / partsFromCrumb ---------------------------------
-
-test('crumbTokenFor prefers id over c', () => {
-  assert.equal(crumbTokenFor({ id: 'g79' }), 'g79');
-  assert.equal(crumbTokenFor({ c: 'music' }), 'music');
-  assert.equal(crumbTokenFor({ id: 'g79', c: 'music' }), 'g79');
-});
-
-test('crumbTokenFor returns null when neither anchor is set', () => {
-  assert.equal(crumbTokenFor({}), null);
-  assert.equal(crumbTokenFor({ filter: 'l109' }), null);
-  assert.equal(crumbTokenFor(null), null);
-});
-
-test('partsFromCrumb maps lowercase-letter-then-digit tokens to id', () => {
-  assert.deepEqual(partsFromCrumb('g79'),       { id: 'g79' });
-  assert.deepEqual(partsFromCrumb('c100000948'), { id: 'c100000948' });
-  assert.deepEqual(partsFromCrumb('p38913'),     { id: 'p38913' });
-  assert.deepEqual(partsFromCrumb('s12345'),     { id: 's12345' });
-});
-
-test('partsFromCrumb maps letters-only tokens to c=', () => {
-  assert.deepEqual(partsFromCrumb('music'),  { c: 'music' });
-  assert.deepEqual(partsFromCrumb('talk'),   { c: 'talk' });
-  assert.deepEqual(partsFromCrumb('sports'), { c: 'sports' });
-  assert.deepEqual(partsFromCrumb('lang'),   { c: 'lang' });
-});
-
-test('partsFromCrumb returns null for empty / non-string', () => {
-  assert.equal(partsFromCrumb(''), null);
-  assert.equal(partsFromCrumb(null), null);
-  assert.equal(partsFromCrumb(123), null);
-});
-
-// --- filter-aware crumb encoding (#89) ------------------------------
-
-test('crumbTokenFor encodes a filter as <anchor>:<filter> so language-tree drills produce distinct tokens', () => {
-  assert.equal(crumbTokenFor({ c: 'lang',  filter: 'l109' }), 'lang:l109');
-  assert.equal(crumbTokenFor({ c: 'music', filter: 'l109' }), 'music:l109');
-  assert.equal(crumbTokenFor({ id: 'c100000948', filter: 'l109' }), 'c100000948:l109');
-});
-
-test('crumbTokenFor omits the filter suffix when no filter is set', () => {
-  assert.equal(crumbTokenFor({ c: 'lang' }), 'lang');
-  assert.equal(crumbTokenFor({ id: 'g79' }), 'g79');
-});
-
-test('partsFromCrumb round-trips the <anchor>:<filter> form back to drill parts', () => {
-  // #106: parts carry `filters: string[]` plus a back-compat `filter`
-  // alias (the comma-joined wire value). Single-filter tokens land as
-  // single-element arrays.
-  assert.deepEqual(partsFromCrumb('lang:l109'),       { c: 'lang',  filters: ['l109'],       filter: 'l109' });
-  assert.deepEqual(partsFromCrumb('music:l109'),      { c: 'music', filters: ['l109'],       filter: 'l109' });
-  assert.deepEqual(partsFromCrumb('c100000948:l109'), { id: 'c100000948', filters: ['l109'], filter: 'l109' });
-});
-
-test('crumbTokenFor → partsFromCrumb round-trip for the language-tree path emits distinct tokens', () => {
-  // The bug from issue #89: drilling root → Language → German → Music
-  // in German used to collapse every step's token to "lang", giving a
-  // breadcrumb of "By Language › By Language › By Language". After the
-  // filter-aware fix each step produces its own token.
-  const lang   = crumbTokenFor({ c: 'lang' });
-  const german = crumbTokenFor({ c: 'lang', filter: 'l109' });
-  const music  = crumbTokenFor({ c: 'music', filter: 'l109' });
-  assert.equal(lang,   'lang');
-  assert.equal(german, 'lang:l109');
-  assert.equal(music,  'music:l109');
-  assert.notEqual(lang, german);
-  assert.notEqual(german, music);
-  // Round-trip back to drill parts (now carrying the `filters` array
-  // plus the back-compat `filter` alias — #106).
-  assert.deepEqual(partsFromCrumb(german), { c: 'lang',  filters: ['l109'], filter: 'l109' });
-  assert.deepEqual(partsFromCrumb(music),  { c: 'music', filters: ['l109'], filter: 'l109' });
 });
 
 // --- renderCrumbTrail (legacy ancestor-only shape) ------------------
@@ -392,59 +281,6 @@ test('renderEntry: with empty child crumb stack, href has no from= param', () =>
   assert.equal(href, '#/browse?id=g22', `no from= for root-level child: ${href}`);
 });
 
-// --- backHrefFor: pop the rightmost crumb --------------------------
-
-test('backHrefFor with empty stack lands at the root tabs view', () => {
-  assert.equal(backHrefFor([]), '#/browse');
-  assert.equal(backHrefFor(null), '#/browse');
-  assert.equal(backHrefFor(undefined), '#/browse');
-});
-
-test('backHrefFor with one crumb lands at that crumb with no further from=', () => {
-  // Stack [music] → pop → land on c=music with empty from=.
-  assert.equal(backHrefFor(['music']), '#/browse?c=music');
-});
-
-test('backHrefFor with multiple crumbs pops the rightmost and carries the rest as from=', () => {
-  // Stack [music, g79] → pop → land on id=g79 with from=music.
-  assert.equal(backHrefFor(['music', 'g79']), '#/browse?id=g79&from=music');
-  // Stack [c100000948, g79, music] → pop → land on c=music with from=c100000948,g79.
-  // URLSearchParams encodes commas as %2C.
-  assert.equal(
-    backHrefFor(['c100000948', 'g79', 'music']),
-    '#/browse?c=music&from=c100000948%2Cg79',
-  );
-});
-
-// --- crumbLabelFor surfaces the resolved language name (#90) --------
-
-test('crumbLabelFor appends the resolved language name when filter is a known lcode', async () => {
-  const { cacheLcodes } = await import('../app/tunein-url.js');
-  cacheLcodes([{ id: 'l109', name: 'German' }]);
-  assert.equal(
-    crumbLabelFor({ c: 'music', filter: 'l109' }),
-    'c=music · filter=l109 (German)',
-  );
-});
-
-test('crumbLabelFor leaves the badge unchanged when the lcode catalogue does not know the filter', () => {
-  // No cacheLcodes — lcodeLabel returns undefined → no "(name)" suffix.
-  assert.equal(
-    crumbLabelFor({ c: 'music', filter: 'l9999' }),
-    'c=music · filter=l9999',
-  );
-});
-
-test('crumbLabelFor leaves non-lcode filters unchanged', async () => {
-  const { cacheLcodes } = await import('../app/tunein-url.js');
-  cacheLcodes([{ id: 'l109', name: 'German' }]);
-  // A non-l filter shape — even if a cached catalogue exists.
-  assert.equal(
-    crumbLabelFor({ id: 'g79', filter: 'top' }),
-    'g79 · filter=top',
-  );
-});
-
 // --- #104 — dedupe trail tail when current parts match last stack ---
 //
 // When the user clicks an end-of-page filter chip, the link appends
@@ -646,68 +482,6 @@ test('renderPillBar + filter chip click shape produces a clean trail + badge —
   const badge = bar.querySelector('.browse-bar__filter');
   assert.ok(badge);
   assert.equal(badge.querySelector('.browse-bar__filter-label').textContent, 'Country');
-});
-
-// --- #106 — multi-filter support: parts.filters: string[] -----------
-//
-// TuneIn upstream accepts comma-separated values inside a single
-// `filter=` query param (e.g. `filter=l109,g22` for "rock stations in
-// German-speaking countries"). The SPA's state shape is
-// `parts.filters: string[]`; the crumb-token form is
-// `<anchor>:<f1>+<f2>+…` (plus sign separates filters inside one
-// crumb so the comma-separated `from=` stack is unambiguous).
-
-test('crumbTokenFor encodes parts.filters: string[] as <anchor>:<f1>+<f2>+… — #106', () => {
-  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26', 'l170'] }),       'r101821:g26+l170');
-  assert.equal(crumbTokenFor({ c: 'music',    filters: ['l109', 'g22'] }),       'music:l109+g22');
-  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26', 'l170', 'm:5'] }), 'r101821:g26+l170+m:5');
-});
-
-test('crumbTokenFor with a single filter emits the legacy <anchor>:<filter> shape — #106', () => {
-  // Single-filter case must produce the same token as the old single-
-  // string callers so bookmarks / pasted URLs from before #106 keep
-  // resolving against the same cache keys.
-  assert.equal(crumbTokenFor({ id: 'r101821', filters: ['g26'] }), 'r101821:g26');
-  assert.equal(crumbTokenFor({ c: 'lang',     filters: ['l109'] }), 'lang:l109');
-});
-
-test('crumbTokenFor with an empty filters array drops to the bare anchor — #106', () => {
-  assert.equal(crumbTokenFor({ id: 'r101821', filters: [] }), 'r101821');
-  assert.equal(crumbTokenFor({ c: 'music',    filters: [] }), 'music');
-});
-
-test('partsFromCrumb splits a <anchor>:<f1>+<f2> token back to filters: [f1, f2] — #106', () => {
-  assert.deepEqual(
-    partsFromCrumb('r101821:g26+l170'),
-    { id: 'r101821', filters: ['g26', 'l170'], filter: 'g26,l170' },
-  );
-  assert.deepEqual(
-    partsFromCrumb('music:l109+g22'),
-    { c: 'music', filters: ['l109', 'g22'], filter: 'l109,g22' },
-  );
-});
-
-test('partsFromCrumb round-trips three stacked filters — #106', () => {
-  const tok = 'r101821:g26+l170+m:5';
-  const parts = partsFromCrumb(tok);
-  assert.deepEqual(parts.filters, ['g26', 'l170', 'm:5']);
-  assert.equal(crumbTokenFor(parts), tok, 'token round-trips');
-});
-
-test('crumbTokenFor → partsFromCrumb round-trips zero / one / two / three filters — #106', () => {
-  for (const filters of [[], ['g26'], ['g26', 'l170'], ['g26', 'l170', 's:popular']]) {
-    const parts = { id: 'r101821' };
-    if (filters.length > 0) parts.filters = filters;
-    const token = crumbTokenFor(parts);
-    const round = partsFromCrumb(token);
-    if (filters.length === 0) {
-      assert.equal(token, 'r101821');
-      assert.deepEqual(round, { id: 'r101821' });
-    } else {
-      assert.deepEqual(round.filters, filters, `${filters.length}-filter round-trip`);
-      assert.equal(round.id, 'r101821');
-    }
-  }
 });
 
 // --- #106 — trail-tail dedupe still fires with multi-filter ---------

--- a/admin/test/test_favorites.js
+++ b/admin/test/test_favorites.js
@@ -96,7 +96,7 @@ function installFetchStub(handler) {
   return () => { globalThis.fetch = original; };
 }
 
-test('toggleFavorite: PUT success → state stays at optimistic value', async () => {
+test('toggleFavorite: POST success → state stays at optimistic value', async () => {
   store.state.speaker.favorites = [];
   let captured = null;
   const restore = installFetchStub(async (url, opts) => {
@@ -109,8 +109,8 @@ test('toggleFavorite: PUT success → state stays at optimistic value', async ()
   try {
     const env = await toggleFavorite(store, { id: 's12345', name: 'R1' });
     assert.equal(env.ok, true);
-    assert.ok(captured, 'PUT issued');
-    assert.equal(captured.opts.method, 'PUT');
+    assert.ok(captured, 'POST issued');
+    assert.equal(captured.opts.method, 'POST');
     assert.match(captured.url, /\/favorites$/);
     const sent = JSON.parse(captured.opts.body);
     assert.equal(sent.length, 1);
@@ -121,7 +121,7 @@ test('toggleFavorite: PUT success → state stays at optimistic value', async ()
   }
 });
 
-test('toggleFavorite: PUT structured-error → state rolls back, no leak', async () => {
+test('toggleFavorite: POST structured-error → state rolls back, no leak', async () => {
   store.state.speaker.favorites = [];
   const restore = installFetchStub(async () => ({
     ok: true, status: 400,
@@ -137,7 +137,7 @@ test('toggleFavorite: PUT structured-error → state rolls back, no leak', async
   }
 });
 
-test('toggleFavorite: PUT transport throw → state rolls back, synthetic envelope returned', async () => {
+test('toggleFavorite: POST transport throw → state rolls back, synthetic envelope returned', async () => {
   store.state.speaker.favorites = [{ id: 's1', name: 'A', art: '', note: '' }];
   const restore = installFetchStub(async () => { throw new Error('boom'); });
   try {
@@ -161,14 +161,14 @@ test('toggleFavorite: remove path — present id flips to absent on success', as
   try {
     const env = await toggleFavorite(store, { id: 's7', name: 'Seven' });
     assert.equal(env.ok, true);
-    assert.deepEqual(body, [], 'PUT body is the post-remove array');
+    assert.deepEqual(body, [], 'POST body is the post-remove array');
     assert.deepEqual(store.state.speaker.favorites, [], 'state is empty after the remove');
   } finally {
     restore();
   }
 });
 
-test('toggleFavorite: id that doesn\'t match ^[sp]\\d+$ short-circuits without a PUT', async () => {
+test('toggleFavorite: id that doesn\'t match ^[sp]\\d+$ short-circuits without a POST', async () => {
   store.state.speaker.favorites = [];
   let calls = 0;
   const restore = installFetchStub(async () => { calls++; return { ok: true, json: async () => ({}) }; });
@@ -176,7 +176,7 @@ test('toggleFavorite: id that doesn\'t match ^[sp]\\d+$ short-circuits without a
     const env = await toggleFavorite(store, { id: 'g22', name: 'genre' });
     assert.equal(env.ok, false);
     assert.equal(env.error.code, 'INVALID_ID');
-    assert.equal(calls, 0, 'no PUT is fired for an invalid id');
+    assert.equal(calls, 0, 'no POST is fired for an invalid id');
     assert.equal(store.state.speaker.favorites.length, 0);
   } finally {
     restore();
@@ -222,7 +222,7 @@ test('favoriteHeart: outlines on miss, fills on hit, re-paints on store change',
   btn.unsubscribe();
 });
 
-test('favoriteHeart: click fires the PUT, optimistic add lands immediately', async () => {
+test('favoriteHeart: click fires the POST, optimistic add lands immediately', async () => {
   store.state.speaker.favorites = [];
   const calls = [];
   const restore = installFetchStub(async (url, opts) => {
@@ -241,8 +241,8 @@ test('favoriteHeart: click fires the PUT, optimistic add lands immediately', asy
     // Allow the toggle's microtask + the await to settle.
     await new Promise((r) => setTimeout(r, 5));
     const putCall = calls.find((c) => /\/favorites$/.test(c.url));
-    assert.ok(putCall, 'PUT /favorites issued');
-    assert.equal(putCall.opts.method, 'PUT');
+    assert.ok(putCall, 'POST /favorites issued');
+    assert.equal(putCall.opts.method, 'POST');
     assert.equal(store.state.speaker.favorites.length, 1);
     assert.equal(store.state.speaker.favorites[0].id, 's12345');
     assert.equal(btn.classList.contains('is-filled'), true, 'heart paints filled after toggle');
@@ -311,11 +311,11 @@ test('station-detail: heart click toggles the favourite optimistically', async (
     assert.ok(heart, 'heart mounted');
     // Click — fires the optimistic toggle.
     heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
-    // Optimistic mutation lands before the PUT resolves.
+    // Optimistic mutation lands before the POST resolves.
     assert.equal(store.state.speaker.favorites.length, 1, 'optimistic add');
     await new Promise((r) => setTimeout(r, 5));
-    const putCall = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'PUT');
-    assert.ok(putCall, 'PUT /favorites issued');
+    const putCall = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(putCall, 'POST /favorites issued');
     destroy();
   } finally {
     restore();

--- a/admin/test/test_favorites.js
+++ b/admin/test/test_favorites.js
@@ -321,3 +321,122 @@ test('station-detail: heart click toggles the favourite optimistically', async (
     restore();
   }
 });
+
+// --- favourites tab `?focus=<id>` mount handler (#129) --------------
+
+const { default: favoritesView } = await import('../app/views/favorites.js');
+
+test('favourites view: ?focus=<id> flashes the matching row on mount', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One',   art: '', note: '' },
+    { id: 's2', name: 'Two',   art: '', note: '' },
+    { id: 'p3', name: 'Three', art: '', note: '' },
+  ];
+  const root = makeRoot();
+  const destroy = favoritesView.init(root, store, { query: { focus: 's2' } });
+  try {
+    const rows = root.querySelectorAll('.favorites-row');
+    assert.equal(rows.length, 3, 'three rows rendered');
+    const target = rows.find((r) => r.dataset.sid === 's2');
+    assert.ok(target, 'row for s2 present');
+    assert.equal(target.classList.contains('is-focused'), true,
+      'matching row gets the is-focused flash class on mount');
+    // The two siblings stay un-flashed.
+    for (const r of rows) {
+      if (r === target) continue;
+      assert.equal(r.classList.contains('is-focused'), false,
+        `non-target row ${r.dataset.sid} must not flash`);
+    }
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites view: ?focus with no match → nothing flashes, no throw', () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+  ];
+  const root = makeRoot();
+  const destroy = favoritesView.init(root, store, { query: { focus: 'sNope' } });
+  try {
+    const rows = root.querySelectorAll('.favorites-row');
+    for (const r of rows) {
+      assert.equal(r.classList.contains('is-focused'), false,
+        'no row should flash when ?focus does not match');
+    }
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites view: mount without ?focus → no row flashes', () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+  ];
+  const root = makeRoot();
+  const destroy = favoritesView.init(root, store, {});
+  try {
+    const rows = root.querySelectorAll('.favorites-row');
+    for (const r of rows) {
+      assert.equal(r.classList.contains('is-focused'), false,
+        'mount without focus must leave rows untouched');
+    }
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites view: ?focus on unfetched list applies after the list lands', () => {
+  // Empty state first — the favourite to focus hasn't loaded yet.
+  store.state.speaker.favorites = [];
+  const root = makeRoot();
+  const destroy = favoritesView.init(root, store, { query: { focus: 's42' } });
+  try {
+    assert.equal(root.querySelectorAll('.favorites-row').length, 0,
+      'empty state — no rows to flash yet');
+    // Now the reconcile lands.
+    store.update('speaker', (s) => {
+      s.speaker.favorites = [
+        { id: 's7',  name: 'Seven',   art: '', note: '' },
+        { id: 's42', name: 'Magic',   art: '', note: '' },
+      ];
+    });
+    const rows = root.querySelectorAll('.favorites-row');
+    assert.equal(rows.length, 2, 'rows rendered after the update');
+    const target = rows.find((r) => r.dataset.sid === 's42');
+    assert.ok(target, 'row for s42 present');
+    assert.equal(target.classList.contains('is-focused'), true,
+      'pending focus applies once the matching row lands');
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites view: ?focus applies once — re-render after flash does not re-flash', () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+  ];
+  const root = makeRoot();
+  const destroy = favoritesView.init(root, store, { query: { focus: 's1' } });
+  try {
+    const initialRow = root.querySelector('.favorites-row');
+    assert.equal(initialRow.classList.contains('is-focused'), true,
+      'first paint flashes the target row');
+    // Manually drop the flash class to simulate the post-timeout state,
+    // then trigger another render via a benign store change.
+    initialRow.classList.remove('is-focused');
+    store.update('speaker', (s) => {
+      s.speaker.favorites = [
+        { id: 's1', name: 'One',   art: '', note: '' },
+        { id: 's2', name: 'Two',   art: '', note: '' },
+      ];
+    });
+    const rows = root.querySelectorAll('.favorites-row');
+    for (const r of rows) {
+      assert.equal(r.classList.contains('is-focused'), false,
+        `subsequent renders must not re-apply the flash (${r.dataset.sid})`);
+    }
+  } finally {
+    destroy();
+  }
+});

--- a/admin/test/test_favorites.js
+++ b/admin/test/test_favorites.js
@@ -1,0 +1,323 @@
+// Tests for the favourites tracer slice (issue #125):
+//
+//   - app/favorites.js — list helpers (indexOfFavorite, withFavoriteAdded,
+//     withFavoriteRemoved), the optimistic toggleFavorite action, and the
+//     favoriteHeart() DOM primitive (visibility rule + click round-trip).
+//   - station-detail integration — the heart renders next to the station
+//     name on `^[sp]\d+$` ids and is hidden otherwise.
+//
+// Strategy: the dom-shim gives us a working Element/document, fetch is
+// the never-resolving default which we override per test with a callable
+// stub. We stand up a fresh in-process state with the production store
+// (it's a module singleton like the other view tests).
+//
+// Run: node --test admin/test
+
+import { test, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { doc, installFetchNeverResolving } from './fixtures/dom-shim.js';
+
+installFetchNeverResolving();
+
+const {
+  isFavoriteId,
+  indexOfFavorite,
+  withFavoriteAdded,
+  withFavoriteRemoved,
+  toggleFavorite,
+  favoriteHeart,
+} = await import('../app/favorites.js');
+
+const { store } = await import('../app/state.js');
+const { default: stationView } = await import('../app/views/station.js');
+const { _setDeps } = await import('../app/probe.js');
+
+function makeRoot() { return doc.createElement('div'); }
+
+beforeEach(() => {
+  store.state.speaker.favorites = null;
+  store.state.speaker.presets   = null;
+  store.state.caches.probe.clear();
+  _setDeps({
+    tuneinProbe:   async () => { throw new Error('tuneinProbe not stubbed'); },
+    presetsAssign: async () => { throw new Error('presetsAssign not stubbed'); },
+    setPresets:    () => {},
+  });
+});
+
+// --- pure helpers ---------------------------------------------------
+
+test('isFavoriteId: accepts s/p + digits, rejects bare prefix, garbage, non-s/p', () => {
+  assert.equal(isFavoriteId('s12345'), true,  's12345 is a valid favourite id');
+  assert.equal(isFavoriteId('p99'),    true,  'p99 is a valid favourite id');
+  assert.equal(isFavoriteId('s'),      false, 'bare s is rejected');
+  assert.equal(isFavoriteId('p'),      false, 'bare p is rejected');
+  assert.equal(isFavoriteId('t1'),     false, 't-prefix is rejected (favourites are stations + shows only)');
+  assert.equal(isFavoriteId('g22'),    false, 'g-prefix is rejected');
+  assert.equal(isFavoriteId(''),       false, 'empty string is rejected');
+  assert.equal(isFavoriteId(null),     false, 'null is rejected');
+  assert.equal(isFavoriteId('s1a'),    false, 'trailing letters are rejected');
+});
+
+test('indexOfFavorite: returns -1 on miss / null list, otherwise the array index', () => {
+  assert.equal(indexOfFavorite(null, 's1'), -1);
+  assert.equal(indexOfFavorite([], 's1'), -1);
+  const list = [{ id: 's1', name: 'A' }, { id: 'p9', name: 'B' }];
+  assert.equal(indexOfFavorite(list, 'p9'), 1);
+  assert.equal(indexOfFavorite(list, 's2'), -1);
+});
+
+test('withFavoriteAdded: appends when missing, no-op when present (returns same reference)', () => {
+  const base = [{ id: 's1', name: 'A', art: '', note: '' }];
+  const added = withFavoriteAdded(base, { id: 'p9', name: 'B' });
+  assert.equal(added.length, 2);
+  assert.deepEqual(added[1], { id: 'p9', name: 'B', art: '', note: '' });
+  assert.notEqual(added, base, 'returns a new array');
+
+  const same = withFavoriteAdded(base, { id: 's1', name: 'A' });
+  assert.equal(same, base, 'no-op returns the original reference for callers');
+});
+
+test('withFavoriteRemoved: drops the first match; no-op when missing', () => {
+  const base = [{ id: 's1' }, { id: 'p9' }, { id: 's2' }];
+  const out = withFavoriteRemoved(base, 'p9');
+  assert.deepEqual(out.map((e) => e.id), ['s1', 's2']);
+
+  const same = withFavoriteRemoved(base, 'sNope');
+  assert.equal(same, base, 'miss returns the original reference');
+});
+
+// --- toggleFavorite optimistic round-trip ---------------------------
+
+function installFetchStub(handler) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler;
+  return () => { globalThis.fetch = original; };
+}
+
+test('toggleFavorite: PUT success → state stays at optimistic value', async () => {
+  store.state.speaker.favorites = [];
+  let captured = null;
+  const restore = installFetchStub(async (url, opts) => {
+    captured = { url: String(url), opts };
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's12345', name: 'R1', art: '', note: '' }] }),
+    };
+  });
+  try {
+    const env = await toggleFavorite(store, { id: 's12345', name: 'R1' });
+    assert.equal(env.ok, true);
+    assert.ok(captured, 'PUT issued');
+    assert.equal(captured.opts.method, 'PUT');
+    assert.match(captured.url, /\/favorites$/);
+    const sent = JSON.parse(captured.opts.body);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].id, 's12345');
+    assert.equal(store.state.speaker.favorites.length, 1, 'optimistic add persists');
+  } finally {
+    restore();
+  }
+});
+
+test('toggleFavorite: PUT structured-error → state rolls back, no leak', async () => {
+  store.state.speaker.favorites = [];
+  const restore = installFetchStub(async () => ({
+    ok: true, status: 400,
+    json: async () => ({ ok: false, error: { code: 'INVALID_ID', message: 'bad' } }),
+  }));
+  try {
+    const env = await toggleFavorite(store, { id: 's12345', name: 'R1' });
+    assert.equal(env.ok, false);
+    assert.equal(env.error.code, 'INVALID_ID');
+    assert.deepEqual(store.state.speaker.favorites, [], 'rolled back to the snapshot');
+  } finally {
+    restore();
+  }
+});
+
+test('toggleFavorite: PUT transport throw → state rolls back, synthetic envelope returned', async () => {
+  store.state.speaker.favorites = [{ id: 's1', name: 'A', art: '', note: '' }];
+  const restore = installFetchStub(async () => { throw new Error('boom'); });
+  try {
+    const env = await toggleFavorite(store, { id: 's1', name: 'A' });
+    assert.equal(env.ok, false);
+    assert.equal(env.error.code, 'TRANSPORT');
+    assert.equal(store.state.speaker.favorites.length, 1, 'rollback restores the prior entry');
+    assert.equal(store.state.speaker.favorites[0].id, 's1');
+  } finally {
+    restore();
+  }
+});
+
+test('toggleFavorite: remove path — present id flips to absent on success', async () => {
+  store.state.speaker.favorites = [{ id: 's7', name: 'Seven', art: '', note: '' }];
+  let body = null;
+  const restore = installFetchStub(async (_url, opts) => {
+    body = JSON.parse(opts.body);
+    return { ok: true, status: 200, json: async () => ({ ok: true, data: [] }) };
+  });
+  try {
+    const env = await toggleFavorite(store, { id: 's7', name: 'Seven' });
+    assert.equal(env.ok, true);
+    assert.deepEqual(body, [], 'PUT body is the post-remove array');
+    assert.deepEqual(store.state.speaker.favorites, [], 'state is empty after the remove');
+  } finally {
+    restore();
+  }
+});
+
+test('toggleFavorite: id that doesn\'t match ^[sp]\\d+$ short-circuits without a PUT', async () => {
+  store.state.speaker.favorites = [];
+  let calls = 0;
+  const restore = installFetchStub(async () => { calls++; return { ok: true, json: async () => ({}) }; });
+  try {
+    const env = await toggleFavorite(store, { id: 'g22', name: 'genre' });
+    assert.equal(env.ok, false);
+    assert.equal(env.error.code, 'INVALID_ID');
+    assert.equal(calls, 0, 'no PUT is fired for an invalid id');
+    assert.equal(store.state.speaker.favorites.length, 0);
+  } finally {
+    restore();
+  }
+});
+
+// --- favoriteHeart visibility + click ------------------------------
+
+test('favoriteHeart: hidden when getEntry().id is missing or non-station/show', () => {
+  store.state.speaker.favorites = [];
+  let id = 'g42';
+  const btn = favoriteHeart({
+    getEntry: () => ({ id, name: 'genre' }),
+    store,
+  });
+  assert.equal(btn.hidden, true, 'genre id → heart hidden');
+  // Switch to a station id and repaint — the heart should appear.
+  id = 's12345';
+  btn.repaint();
+  assert.equal(btn.hidden, false, 'station id → heart shown');
+  // And back to absent.
+  id = '';
+  btn.repaint();
+  assert.equal(btn.hidden, true, 'empty id → heart hidden');
+  btn.unsubscribe();
+});
+
+test('favoriteHeart: outlines on miss, fills on hit, re-paints on store change', () => {
+  store.state.speaker.favorites = [];
+  const btn = favoriteHeart({
+    getEntry: () => ({ id: 's12345', name: 'R1' }),
+    store,
+  });
+  assert.equal(btn.classList.contains('is-empty'), true,  'not a favourite → is-empty');
+  assert.equal(btn.classList.contains('is-filled'), false);
+
+  store.state.speaker.favorites = [{ id: 's12345', name: 'R1', art: '', note: '' }];
+  store.touch('speaker');
+
+  assert.equal(btn.classList.contains('is-filled'), true,  'after add → is-filled');
+  assert.equal(btn.classList.contains('is-empty'),  false);
+  assert.equal(btn.getAttribute('aria-pressed'), 'true');
+  btn.unsubscribe();
+});
+
+test('favoriteHeart: click fires the PUT, optimistic add lands immediately', async () => {
+  store.state.speaker.favorites = [];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's12345', name: 'R1', art: '', note: '' }] }),
+    };
+  });
+  try {
+    const btn = favoriteHeart({
+      getEntry: () => ({ id: 's12345', name: 'R1' }),
+      store,
+    });
+    btn.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    // Allow the toggle's microtask + the await to settle.
+    await new Promise((r) => setTimeout(r, 5));
+    const putCall = calls.find((c) => /\/favorites$/.test(c.url));
+    assert.ok(putCall, 'PUT /favorites issued');
+    assert.equal(putCall.opts.method, 'PUT');
+    assert.equal(store.state.speaker.favorites.length, 1);
+    assert.equal(store.state.speaker.favorites[0].id, 's12345');
+    assert.equal(btn.classList.contains('is-filled'), true, 'heart paints filled after toggle');
+    btn.unsubscribe();
+  } finally {
+    restore();
+  }
+});
+
+// --- station-detail integration ------------------------------------
+
+async function mountStation(root, sid) {
+  // Seed the probe cache so the view's mount doesn't hang on
+  // tuneinProbe. The heart visibility rule fires synchronously off the
+  // sid, so we don't need probe to land before asserting.
+  store.state.caches.probe.set(sid, {
+    sid,
+    verdict: { kind: 'playable', streams: [] },
+    tuneinJson: {},
+    expires: Date.now() + 600000,
+  });
+  const destroy = stationView.init(root, store, { params: { id: sid } });
+  await new Promise((r) => setTimeout(r, 5));
+  return destroy;
+}
+
+test('station-detail: heart mounts next to the station name on s-ids', async () => {
+  store.state.speaker.favorites = [];
+  const root = makeRoot();
+  const destroy = await mountStation(root, 's12345');
+  try {
+    const heart = root.querySelector('.fav-heart');
+    assert.ok(heart, 'heart present on s-id station-detail');
+    assert.equal(heart.hidden, false, 'heart visible on s-id');
+    // Must be inside the name row, not somewhere arbitrary.
+    const nameRow = root.querySelector('.station-name-row');
+    assert.ok(nameRow, 'name row wrapper present');
+    let inside = false;
+    for (const child of nameRow.childNodes || []) {
+      if (child === heart) { inside = true; break; }
+    }
+    assert.equal(inside, true, 'heart is a child of the name row');
+  } finally {
+    destroy();
+  }
+});
+
+test('station-detail: heart click toggles the favourite optimistically', async () => {
+  store.state.speaker.favorites = [];
+  const root = makeRoot();
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    if (/\/favorites$/.test(String(url))) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ ok: true, data: [{ id: 's12345', name: 's12345', art: '', note: '' }] }),
+      };
+    }
+    // Anything else (tuneinStation describe etc.) — never resolves.
+    return new Promise(() => {});
+  });
+  try {
+    const destroy = await mountStation(root, 's12345');
+    const heart = root.querySelector('.fav-heart');
+    assert.ok(heart, 'heart mounted');
+    // Click — fires the optimistic toggle.
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    // Optimistic mutation lands before the PUT resolves.
+    assert.equal(store.state.speaker.favorites.length, 1, 'optimistic add');
+    await new Promise((r) => setTimeout(r, 5));
+    const putCall = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'PUT');
+    assert.ok(putCall, 'PUT /favorites issued');
+    destroy();
+  } finally {
+    restore();
+  }
+});

--- a/admin/test/test_favorites_cgi/test_favorites_cgi.sh
+++ b/admin/test/test_favorites_cgi/test_favorites_cgi.sh
@@ -98,108 +98,108 @@ assert_contains 'GET emits 200 OK status line' 'Status: 200 OK' "$out"
 assert_contains 'GET body has ok:true' '"ok":true' "$body"
 assert_contains 'GET body has empty data array' '"data":[]' "$body"
 
-# --- PUT: empty array writes and round-trips ----------------------
+# --- POST: empty array writes and round-trips ----------------------
 
-printf '\n=== PUT: empty array → writes envelope, GET returns it ===\n'
+printf '\n=== POST: empty array → writes envelope, GET returns it ===\n'
 empty_body="$WORK/empty.json"
 printf '[]' >"$empty_body"
-out=$(call_cgi PUT "$empty_body" 2>/dev/null)
+out=$(call_cgi POST "$empty_body" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
-assert_contains 'empty PUT returns 200 OK' 'Status: 200 OK' "$out"
-assert_contains 'empty PUT body has ok:true' '"ok":true' "$body"
+assert_contains 'empty POST returns 200 OK' 'Status: 200 OK' "$out"
+assert_contains 'empty POST body has ok:true' '"ok":true' "$body"
 if [ ! -f "$FAV_DIR/favorites.json" ]; then
     printf '  [FAIL] favorites.json was not written\n'
     fail=$((fail + 1))
 else
-    printf '  [ OK ] favorites.json present on disk after empty PUT\n'
+    printf '  [ OK ] favorites.json present on disk after empty POST\n'
     ok=$((ok + 1))
 fi
 
-# --- PUT: valid one-entry list ------------------------------------
+# --- POST: valid one-entry list ------------------------------------
 
-printf '\n=== PUT: valid one-entry list ===\n'
+printf '\n=== POST: valid one-entry list ===\n'
 one_body="$WORK/one.json"
 printf '%s' '[{"id":"s12345","name":"R1","art":"http://x.png","note":"hi"}]' >"$one_body"
-out=$(call_cgi PUT "$one_body" 2>/dev/null)
+out=$(call_cgi POST "$one_body" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
-assert_contains 'one-entry PUT returns 200 OK' 'Status: 200 OK' "$out"
+assert_contains 'one-entry POST returns 200 OK' 'Status: 200 OK' "$out"
 assert_contains 'response carries the entry id' '"id":"s12345"' "$body"
 assert_contains 'response carries the entry name' '"name":"R1"' "$body"
-# GET after PUT echoes back the same envelope.
+# GET after POST echoes back the same envelope.
 get_out=$(call_cgi GET '' 2>/dev/null)
 get_body=$(printf '%s\n' "$get_out" | strip_headers)
 assert_contains 'subsequent GET returns the persisted entry' '"id":"s12345"' "$get_body"
 
-# --- PUT: INVALID_ID -----------------------------------------------
+# --- POST: INVALID_ID -----------------------------------------------
 
-printf '\n=== PUT: invalid id (g-prefix) → INVALID_ID ===\n'
+printf '\n=== POST: invalid id (g-prefix) → INVALID_ID ===\n'
 bad_id="$WORK/bad_id.json"
 printf '%s' '[{"id":"g22","name":"genre","art":"","note":""}]' >"$bad_id"
-out=$(call_cgi PUT "$bad_id" 2>/dev/null)
+out=$(call_cgi POST "$bad_id" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'INVALID_ID returns 400' 'Status: 400 Bad Request' "$out"
 assert_contains 'INVALID_ID envelope code' '"code":"INVALID_ID"' "$body"
 assert_contains 'error envelope is an object, not a bare string' '"error":{' "$body"
 
-printf '\n=== PUT: invalid id (bare s) → INVALID_ID ===\n'
+printf '\n=== POST: invalid id (bare s) → INVALID_ID ===\n'
 bare="$WORK/bare.json"
 printf '%s' '[{"id":"s","name":"x","art":"","note":""}]' >"$bare"
-out=$(call_cgi PUT "$bare" 2>/dev/null)
+out=$(call_cgi POST "$bare" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'bare-prefix is rejected' '"code":"INVALID_ID"' "$body"
 
-# --- PUT: INVALID_NAME ---------------------------------------------
+# --- POST: INVALID_NAME ---------------------------------------------
 
-printf '\n=== PUT: empty name → INVALID_NAME ===\n'
+printf '\n=== POST: empty name → INVALID_NAME ===\n'
 no_name="$WORK/no_name.json"
 printf '%s' '[{"id":"s12345","name":"","art":"","note":""}]' >"$no_name"
-out=$(call_cgi PUT "$no_name" 2>/dev/null)
+out=$(call_cgi POST "$no_name" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'empty name returns 400' 'Status: 400 Bad Request' "$out"
 assert_contains 'INVALID_NAME envelope code' '"code":"INVALID_NAME"' "$body"
 
-# --- PUT: INVALID_ART ----------------------------------------------
+# --- POST: INVALID_ART ----------------------------------------------
 
-printf '\n=== PUT: bad art (not http/https) → INVALID_ART ===\n'
+printf '\n=== POST: bad art (not http/https) → INVALID_ART ===\n'
 bad_art="$WORK/bad_art.json"
 printf '%s' '[{"id":"s12345","name":"R1","art":"data:image/png;base64,XX","note":""}]' >"$bad_art"
-out=$(call_cgi PUT "$bad_art" 2>/dev/null)
+out=$(call_cgi POST "$bad_art" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'bad-art returns 400' 'Status: 400 Bad Request' "$out"
 assert_contains 'INVALID_ART envelope code' '"code":"INVALID_ART"' "$body"
 
-# --- PUT: DUPLICATE_ID ---------------------------------------------
+# --- POST: DUPLICATE_ID ---------------------------------------------
 
-printf '\n=== PUT: duplicate id → DUPLICATE_ID ===\n'
+printf '\n=== POST: duplicate id → DUPLICATE_ID ===\n'
 dup="$WORK/dup.json"
 printf '%s' '[{"id":"s1","name":"A","art":"","note":""},{"id":"s1","name":"B","art":"","note":""}]' >"$dup"
-out=$(call_cgi PUT "$dup" 2>/dev/null)
+out=$(call_cgi POST "$dup" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'duplicate-id returns 400' 'Status: 400 Bad Request' "$out"
 assert_contains 'DUPLICATE_ID envelope code' '"code":"DUPLICATE_ID"' "$body"
 
-# --- PUT: INVALID_JSON ---------------------------------------------
+# --- POST: INVALID_JSON ---------------------------------------------
 
-printf '\n=== PUT: non-array body → INVALID_JSON ===\n'
+printf '\n=== POST: non-array body → INVALID_JSON ===\n'
 bad_json="$WORK/bad_json.json"
 printf '%s' '{"id":"s1"}' >"$bad_json"
-out=$(call_cgi PUT "$bad_json" 2>/dev/null)
+out=$(call_cgi POST "$bad_json" 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
 assert_contains 'object-shaped body returns 400' 'Status: 400 Bad Request' "$out"
 assert_contains 'INVALID_JSON envelope code' '"code":"INVALID_JSON"' "$body"
 
-# --- failed-PUT preserves the prior file ---------------------------
+# --- failed-POST preserves the prior file ---------------------------
 
-printf '\n=== PUT failure leaves the previous file in place ===\n'
+printf '\n=== POST failure leaves the previous file in place ===\n'
 # Re-prime with a known-good entry.
 ok_body="$WORK/ok.json"
 printf '%s' '[{"id":"s2","name":"Keeper","art":"","note":""}]' >"$ok_body"
-call_cgi PUT "$ok_body" >/dev/null 2>&1
-# Now PUT a broken payload.
-call_cgi PUT "$bad_id" >/dev/null 2>&1
+call_cgi POST "$ok_body" >/dev/null 2>&1
+# Now POST a broken payload.
+call_cgi POST "$bad_id" >/dev/null 2>&1
 disk=$(cat "$FAV_DIR/favorites.json")
-assert_contains 'prior good entry still on disk after a failed PUT' '"id":"s2"' "$disk"
-assert_not_contains 'failed-PUT id never reached disk' '"id":"g22"' "$disk"
+assert_contains 'prior good entry still on disk after a failed POST' '"id":"s2"' "$disk"
+assert_not_contains 'failed-POST id never reached disk' '"id":"g22"' "$disk"
 
 # --- atomic-replace tmp file cleaned up ----------------------------
 
@@ -213,10 +213,10 @@ fi
 
 # --- METHOD_NOT_ALLOWED --------------------------------------------
 
-printf '\n=== POST: method rejected ===\n'
-out=$(call_cgi POST '' 2>/dev/null)
+printf '\n=== DELETE: method rejected ===\n'
+out=$(call_cgi DELETE '' 2>/dev/null)
 body=$(printf '%s\n' "$out" | strip_headers)
-assert_contains 'POST returns 405' 'Status: 405 Method Not Allowed' "$out"
+assert_contains 'DELETE returns 405' 'Status: 405 Method Not Allowed' "$out"
 assert_contains 'METHOD_NOT_ALLOWED envelope code' '"code":"METHOD_NOT_ALLOWED"' "$body"
 
 # --- OPTIONS preflight ---------------------------------------------
@@ -224,7 +224,7 @@ assert_contains 'METHOD_NOT_ALLOWED envelope code' '"code":"METHOD_NOT_ALLOWED"'
 printf '\n=== OPTIONS: CORS preflight ===\n'
 out=$(call_cgi OPTIONS '' 2>/dev/null)
 assert_contains 'OPTIONS returns 204' 'Status: 204 No Content' "$out"
-assert_contains 'preflight advertises PUT in Allow-Methods' 'PUT' "$out"
+assert_contains 'preflight advertises POST in Allow-Methods' 'POST' "$out"
 assert_contains 'preflight advertises GET in Allow-Methods' 'GET' "$out"
 
 printf '\n=== Summary: %d ok, %d failed ===\n' "$ok" "$fail"

--- a/admin/test/test_favorites_cgi/test_favorites_cgi.sh
+++ b/admin/test/test_favorites_cgi/test_favorites_cgi.sh
@@ -1,0 +1,234 @@
+#!/bin/sh
+#
+# test_favorites_cgi — unit tests for admin/cgi-bin/api/v1/favorites.
+#
+# Drives the CGI as a subprocess with CGI env vars set in-line, and
+# overrides FAV_DIR via the FAV_DIR_OVERRIDE escape hatch so we don't
+# need /mnt/nv to exist locally. No live speaker required.
+#
+# Run with: sh admin/test/test_favorites_cgi/test_favorites_cgi.sh
+# Exits non-zero on any failure.
+
+set -u
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$THIS_DIR/../../.." && pwd)
+CGI="$REPO/admin/cgi-bin/api/v1/favorites"
+
+if [ ! -x "$CGI" ]; then
+    chmod +x "$CGI"
+fi
+
+WORK=$(mktemp -d 2>/dev/null || echo "/tmp/test_favorites_cgi.$$")
+mkdir -p "$WORK"
+FAV_DIR="$WORK/admin-data"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+ok=0
+fail=0
+
+assert_contains() {
+    label=$1; needle=$2; haystack=$3
+    case "$haystack" in
+        *"$needle"*)
+            printf '  [ OK ] %s\n' "$label"
+            ok=$((ok + 1)) ;;
+        *)
+            printf '  [FAIL] %s\n    needle: %s\n    body:   %s\n' \
+                "$label" "$needle" "$haystack"
+            fail=$((fail + 1)) ;;
+    esac
+}
+
+assert_not_contains() {
+    label=$1; needle=$2; haystack=$3
+    case "$haystack" in
+        *"$needle"*)
+            printf '  [FAIL] %s\n    forbidden needle present: %s\n' \
+                "$label" "$needle"
+            fail=$((fail + 1)) ;;
+        *)
+            printf '  [ OK ] %s\n' "$label"
+            ok=$((ok + 1)) ;;
+    esac
+}
+
+# call_cgi <method> <body-file-or-empty> → emits CGI response on stdout.
+# Sets HTTP_HOST so the CSRF guard's empty-Origin path passes (same as
+# curl with no Origin/Referer).
+call_cgi() {
+    method=$1
+    body=$2
+    cl=0
+    if [ -n "$body" ] && [ -f "$body" ]; then
+        cl=$(wc -c <"$body" | tr -d ' ')
+    fi
+    if [ "$cl" -gt 0 ]; then
+        FAV_DIR_OVERRIDE="$FAV_DIR" \
+        REQUEST_METHOD="$method" \
+        HTTP_HOST="localhost" \
+        HTTP_ORIGIN="" \
+        HTTP_REFERER="" \
+        CONTENT_LENGTH="$cl" \
+        sh "$CGI" <"$body"
+    else
+        FAV_DIR_OVERRIDE="$FAV_DIR" \
+        REQUEST_METHOD="$method" \
+        HTTP_HOST="localhost" \
+        HTTP_ORIGIN="" \
+        HTTP_REFERER="" \
+        CONTENT_LENGTH="0" \
+        sh "$CGI" </dev/null
+    fi
+}
+
+# Extract just the JSON body (drop Status/Content-Type/etc. headers).
+# Reads stdin via the awk default; no positional args needed.
+strip_headers() {
+    awk 'BEGIN { body = 0 } { if (body) { print } else if ($0 == "" || $0 == "\r") body = 1 }'
+}
+
+# --- GET: empty store → empty data array --------------------------
+
+printf '\n=== GET: absent file → ok:true, data:[] ===\n'
+rm -rf "$FAV_DIR"
+out=$(call_cgi GET '' 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'GET emits 200 OK status line' 'Status: 200 OK' "$out"
+assert_contains 'GET body has ok:true' '"ok":true' "$body"
+assert_contains 'GET body has empty data array' '"data":[]' "$body"
+
+# --- PUT: empty array writes and round-trips ----------------------
+
+printf '\n=== PUT: empty array → writes envelope, GET returns it ===\n'
+empty_body="$WORK/empty.json"
+printf '[]' >"$empty_body"
+out=$(call_cgi PUT "$empty_body" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'empty PUT returns 200 OK' 'Status: 200 OK' "$out"
+assert_contains 'empty PUT body has ok:true' '"ok":true' "$body"
+if [ ! -f "$FAV_DIR/favorites.json" ]; then
+    printf '  [FAIL] favorites.json was not written\n'
+    fail=$((fail + 1))
+else
+    printf '  [ OK ] favorites.json present on disk after empty PUT\n'
+    ok=$((ok + 1))
+fi
+
+# --- PUT: valid one-entry list ------------------------------------
+
+printf '\n=== PUT: valid one-entry list ===\n'
+one_body="$WORK/one.json"
+printf '%s' '[{"id":"s12345","name":"R1","art":"http://x.png","note":"hi"}]' >"$one_body"
+out=$(call_cgi PUT "$one_body" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'one-entry PUT returns 200 OK' 'Status: 200 OK' "$out"
+assert_contains 'response carries the entry id' '"id":"s12345"' "$body"
+assert_contains 'response carries the entry name' '"name":"R1"' "$body"
+# GET after PUT echoes back the same envelope.
+get_out=$(call_cgi GET '' 2>/dev/null)
+get_body=$(printf '%s\n' "$get_out" | strip_headers)
+assert_contains 'subsequent GET returns the persisted entry' '"id":"s12345"' "$get_body"
+
+# --- PUT: INVALID_ID -----------------------------------------------
+
+printf '\n=== PUT: invalid id (g-prefix) → INVALID_ID ===\n'
+bad_id="$WORK/bad_id.json"
+printf '%s' '[{"id":"g22","name":"genre","art":"","note":""}]' >"$bad_id"
+out=$(call_cgi PUT "$bad_id" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'INVALID_ID returns 400' 'Status: 400 Bad Request' "$out"
+assert_contains 'INVALID_ID envelope code' '"code":"INVALID_ID"' "$body"
+assert_contains 'error envelope is an object, not a bare string' '"error":{' "$body"
+
+printf '\n=== PUT: invalid id (bare s) → INVALID_ID ===\n'
+bare="$WORK/bare.json"
+printf '%s' '[{"id":"s","name":"x","art":"","note":""}]' >"$bare"
+out=$(call_cgi PUT "$bare" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'bare-prefix is rejected' '"code":"INVALID_ID"' "$body"
+
+# --- PUT: INVALID_NAME ---------------------------------------------
+
+printf '\n=== PUT: empty name → INVALID_NAME ===\n'
+no_name="$WORK/no_name.json"
+printf '%s' '[{"id":"s12345","name":"","art":"","note":""}]' >"$no_name"
+out=$(call_cgi PUT "$no_name" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'empty name returns 400' 'Status: 400 Bad Request' "$out"
+assert_contains 'INVALID_NAME envelope code' '"code":"INVALID_NAME"' "$body"
+
+# --- PUT: INVALID_ART ----------------------------------------------
+
+printf '\n=== PUT: bad art (not http/https) → INVALID_ART ===\n'
+bad_art="$WORK/bad_art.json"
+printf '%s' '[{"id":"s12345","name":"R1","art":"data:image/png;base64,XX","note":""}]' >"$bad_art"
+out=$(call_cgi PUT "$bad_art" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'bad-art returns 400' 'Status: 400 Bad Request' "$out"
+assert_contains 'INVALID_ART envelope code' '"code":"INVALID_ART"' "$body"
+
+# --- PUT: DUPLICATE_ID ---------------------------------------------
+
+printf '\n=== PUT: duplicate id → DUPLICATE_ID ===\n'
+dup="$WORK/dup.json"
+printf '%s' '[{"id":"s1","name":"A","art":"","note":""},{"id":"s1","name":"B","art":"","note":""}]' >"$dup"
+out=$(call_cgi PUT "$dup" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'duplicate-id returns 400' 'Status: 400 Bad Request' "$out"
+assert_contains 'DUPLICATE_ID envelope code' '"code":"DUPLICATE_ID"' "$body"
+
+# --- PUT: INVALID_JSON ---------------------------------------------
+
+printf '\n=== PUT: non-array body → INVALID_JSON ===\n'
+bad_json="$WORK/bad_json.json"
+printf '%s' '{"id":"s1"}' >"$bad_json"
+out=$(call_cgi PUT "$bad_json" 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'object-shaped body returns 400' 'Status: 400 Bad Request' "$out"
+assert_contains 'INVALID_JSON envelope code' '"code":"INVALID_JSON"' "$body"
+
+# --- failed-PUT preserves the prior file ---------------------------
+
+printf '\n=== PUT failure leaves the previous file in place ===\n'
+# Re-prime with a known-good entry.
+ok_body="$WORK/ok.json"
+printf '%s' '[{"id":"s2","name":"Keeper","art":"","note":""}]' >"$ok_body"
+call_cgi PUT "$ok_body" >/dev/null 2>&1
+# Now PUT a broken payload.
+call_cgi PUT "$bad_id" >/dev/null 2>&1
+disk=$(cat "$FAV_DIR/favorites.json")
+assert_contains 'prior good entry still on disk after a failed PUT' '"id":"s2"' "$disk"
+assert_not_contains 'failed-PUT id never reached disk' '"id":"g22"' "$disk"
+
+# --- atomic-replace tmp file cleaned up ----------------------------
+
+if [ -f "$FAV_DIR/favorites.json.tmp" ]; then
+    printf '  [FAIL] tmp file leaked: %s\n' "$FAV_DIR/favorites.json.tmp"
+    fail=$((fail + 1))
+else
+    printf '  [ OK ] no tmp file leaked\n'
+    ok=$((ok + 1))
+fi
+
+# --- METHOD_NOT_ALLOWED --------------------------------------------
+
+printf '\n=== POST: method rejected ===\n'
+out=$(call_cgi POST '' 2>/dev/null)
+body=$(printf '%s\n' "$out" | strip_headers)
+assert_contains 'POST returns 405' 'Status: 405 Method Not Allowed' "$out"
+assert_contains 'METHOD_NOT_ALLOWED envelope code' '"code":"METHOD_NOT_ALLOWED"' "$body"
+
+# --- OPTIONS preflight ---------------------------------------------
+
+printf '\n=== OPTIONS: CORS preflight ===\n'
+out=$(call_cgi OPTIONS '' 2>/dev/null)
+assert_contains 'OPTIONS returns 204' 'Status: 204 No Content' "$out"
+assert_contains 'preflight advertises PUT in Allow-Methods' 'PUT' "$out"
+assert_contains 'preflight advertises GET in Allow-Methods' 'GET' "$out"
+
+printf '\n=== Summary: %d ok, %d failed ===\n' "$ok" "$fail"
+
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi

--- a/admin/test/test_favorites_drag.js
+++ b/admin/test/test_favorites_drag.js
@@ -1,0 +1,439 @@
+// Tests for the favourites-tab drag reorder (issue #128):
+//
+//   - splice math: a pure function lifts the "remove from i, insert at
+//     gap g" math out of the DOM so we can hammer the edge cases
+//     (no-op drops, end-of-list, cross-source) without instrumenting
+//     pointer events.
+//   - POST-on-drop: a synthetic pointer drag from one row to another's
+//     gap fires exactly one POST with the reordered list.
+//   - abort-no-POST: pointercancel and Escape both tear the drag down
+//     without writing.
+//
+// The DOM shim doesn't ship a real document.addEventListener, so the
+// drag controller's document-scoped listeners (pointermove / pointerup
+// / pointercancel / keydown) wouldn't fire under the default no-op. We
+// install a tiny dispatching shim per-test so the synthetic pointer
+// events route through to the controller. Rows get a stubbed
+// getBoundingClientRect so the "gap from pointer Y" math has something
+// to chew on — the production code uses the real rect from layout.
+//
+// Run: node --test admin/test
+
+import { test, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { doc, installFetchNeverResolving } from './fixtures/dom-shim.js';
+
+installFetchNeverResolving();
+
+const { spliceReorder } = await import('../app/favorites.js');
+const { default: favoritesView } = await import('../app/views/favorites.js');
+const { store } = await import('../app/state.js');
+
+function makeRoot() { return doc.createElement('div'); }
+
+function installFetchStub(handler) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler;
+  return () => { globalThis.fetch = original; };
+}
+
+function mountFavorites(root) {
+  return favoritesView.init(root, store, { params: {} });
+}
+
+// Install a dispatching doc.addEventListener for the duration of one
+// test. The default shim is a no-op; the drag controller needs the
+// document-scoped pointermove / pointerup / pointercancel / keydown
+// listeners to actually fire. Returns { fireDoc, restore }.
+function installDocEventDispatch() {
+  const listeners = new Map();
+  const originalAdd    = doc.addEventListener;
+  const originalRemove = doc.removeEventListener;
+  doc.addEventListener = function (type, fn) {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type).add(fn);
+  };
+  doc.removeEventListener = function (type, fn) {
+    if (listeners.has(type)) listeners.get(type).delete(fn);
+  };
+  function fireDoc(type, init) {
+    const evt = Object.assign({
+      type,
+      defaultPrevented: false,
+      preventDefault() { this.defaultPrevented = true; },
+      stopPropagation() {},
+    }, init);
+    const set = listeners.get(type);
+    if (!set) return evt;
+    for (const fn of set) {
+      try { fn.call(doc, evt); } catch (_e) { /* swallow */ }
+    }
+    return evt;
+  }
+  function restore() {
+    doc.addEventListener    = originalAdd;
+    doc.removeEventListener = originalRemove;
+  }
+  return { fireDoc, restore };
+}
+
+// Stub rect: each row claims a 40 px tall band starting at its index.
+// Row 0 → y 0..40, row 1 → y 40..80, etc. The midline of row i is
+// i * 40 + 20, which lets us pick "before row N" with `pointerY <
+// N * 40 + 20` and "after the last row" with any y past length * 40.
+function stubRowRects(rows) {
+  for (let i = 0; i < rows.length; i++) {
+    const top = i * 40;
+    const height = 40;
+    rows[i].getBoundingClientRect = () => ({
+      top, left: 0, right: 100, bottom: top + height, width: 100, height,
+      x: 0, y: top,
+    });
+  }
+}
+
+function findRows(root) { return root.querySelectorAll('.favorites-row'); }
+function findDragHandle(row) { return row.querySelector('.favorites-row__drag'); }
+
+function dispatch(el, type, init) {
+  const evt = Object.assign({
+    type,
+    defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+    stopPropagation() {},
+  }, init);
+  el.dispatchEvent(evt);
+  return evt;
+}
+
+beforeEach(() => {
+  store.state.speaker.favorites = null;
+});
+
+// --- splice math ----------------------------------------------------
+
+test('spliceReorder: move down past one neighbour', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+  // from 0, drop after index 2 (gap 3) → b, c, a, d.
+  const next = spliceReorder(list, 0, 3);
+  assert.deepEqual(next.map((e) => e.id), ['b', 'c', 'a', 'd']);
+  // Returns a new array (no in-place mutation).
+  assert.notEqual(next, list);
+  assert.deepEqual(list.map((e) => e.id), ['a', 'b', 'c', 'd']);
+});
+
+test('spliceReorder: move up past one neighbour', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+  // from 2 → gap 0: c, a, b, d.
+  const next = spliceReorder(list, 2, 0);
+  assert.deepEqual(next.map((e) => e.id), ['c', 'a', 'b', 'd']);
+});
+
+test('spliceReorder: move from start to end', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  // from 0 → gap 3 (past the last row): b, c, a.
+  const next = spliceReorder(list, 0, 3);
+  assert.deepEqual(next.map((e) => e.id), ['b', 'c', 'a']);
+});
+
+test('spliceReorder: move from end to start', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  // from 2 → gap 0: c, a, b.
+  const next = spliceReorder(list, 2, 0);
+  assert.deepEqual(next.map((e) => e.id), ['c', 'a', 'b']);
+});
+
+test('spliceReorder: drop at source gap is a no-op (same reference)', () => {
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  assert.equal(spliceReorder(list, 1, 1), list, 'drop at own gap = no-op');
+  assert.equal(spliceReorder(list, 1, 2), list, 'drop just past self = no-op');
+});
+
+test('spliceReorder: invalid args return the original list', () => {
+  const list = [{ id: 'a' }, { id: 'b' }];
+  assert.equal(spliceReorder(list, -1, 0), list);
+  assert.equal(spliceReorder(list,  0, -1), list);
+  assert.equal(spliceReorder(list,  5,  0), list);
+  assert.equal(spliceReorder(list,  0,  9), list);
+  assert.equal(spliceReorder(null, 0, 0).length, 0, 'null list → []');
+});
+
+test('spliceReorder: empty / single-element lists never reorder', () => {
+  assert.deepEqual(spliceReorder([], 0, 0), []);
+  const single = [{ id: 'a' }];
+  assert.equal(spliceReorder(single, 0, 0), single);
+  assert.equal(spliceReorder(single, 0, 1), single);
+});
+
+// --- pointer-driven drag → POST -------------------------------------
+
+test('drag drop: pointer drag fires one POST with the reordered list', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+    { id: 's2', name: 'Two', art: '', note: '' },
+    { id: 's3', name: 'Three', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      const body = JSON.parse(opts.body);
+      posts.push(body);
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: body }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    assert.equal(rows.length, 3, 'three rows rendered');
+    stubRowRects(rows);
+
+    // Pick up row 0 from its drag handle.
+    const handle0 = findDragHandle(rows[0]);
+    dispatch(handle0, 'pointerdown', {
+      button: 0, pointerId: 1, clientX: 0, clientY: 20,
+    });
+
+    // Drag down past row 2's midline (row 2 mid = 100). pointerY = 110
+    // sits past every row's midline → gap 3 (after the last row).
+    fireDoc('pointermove', { pointerId: 1, clientX: 0, clientY: 110 });
+
+    // Release → splice 0 into gap 3 → ['s2','s3','s1'].
+    fireDoc('pointerup', { pointerId: 1, clientX: 0, clientY: 110 });
+
+    // Optimistic state lands synchronously.
+    const optimistic = store.state.speaker.favorites.map((e) => e.id);
+    assert.deepEqual(optimistic, ['s2', 's3', 's1']);
+
+    // POST fires asynchronously through replaceFavorites.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 1, 'exactly one POST per successful drop');
+    assert.deepEqual(posts[0].map((e) => e.id), ['s2', 's3', 's1']);
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});
+
+test('drag drop: drop into the middle splices correctly', async () => {
+  store.state.speaker.favorites = [
+    { id: 'a', name: 'A', art: '', note: '' },
+    { id: 'b', name: 'B', art: '', note: '' },
+    { id: 'c', name: 'C', art: '', note: '' },
+    { id: 'd', name: 'D', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts.push(JSON.parse(opts.body));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    stubRowRects(rows);
+
+    // Pick up row 3 (d), drop between row 0 (a) and row 1 (b).
+    // Row 1's midline is at y=60, so pointerY=50 sits "before row 1"
+    // → gap 1. Splice 3→1 yields ['a','d','b','c'].
+    const handle3 = findDragHandle(rows[3]);
+    dispatch(handle3, 'pointerdown', {
+      button: 0, pointerId: 2, clientX: 0, clientY: 140,
+    });
+    fireDoc('pointermove', { pointerId: 2, clientX: 0, clientY: 50 });
+    fireDoc('pointerup',   { pointerId: 2, clientX: 0, clientY: 50 });
+
+    assert.deepEqual(
+      store.state.speaker.favorites.map((e) => e.id),
+      ['a', 'd', 'b', 'c'],
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 1);
+    assert.deepEqual(posts[0].map((e) => e.id), ['a', 'd', 'b', 'c']);
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});
+
+// --- abort: no POST --------------------------------------------------
+
+test('drag abort: pointercancel mid-drag fires no POST', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+    { id: 's2', name: 'Two', art: '', note: '' },
+    { id: 's3', name: 'Three', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts.push(JSON.parse(opts.body));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    stubRowRects(rows);
+
+    const handle0 = findDragHandle(rows[0]);
+    dispatch(handle0, 'pointerdown', {
+      button: 0, pointerId: 3, clientX: 0, clientY: 20,
+    });
+    fireDoc('pointermove',   { pointerId: 3, clientX: 0, clientY: 110 });
+    fireDoc('pointercancel', { pointerId: 3, clientX: 0, clientY: 110 });
+
+    // State preserved — pointercancel must not rewrite.
+    assert.deepEqual(
+      store.state.speaker.favorites.map((e) => e.id),
+      ['s1', 's2', 's3'],
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 0, 'no POST fires on pointercancel');
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});
+
+test('drag abort: Escape mid-drag fires no POST', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+    { id: 's2', name: 'Two', art: '', note: '' },
+    { id: 's3', name: 'Three', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts.push(JSON.parse(opts.body));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    stubRowRects(rows);
+
+    const handle0 = findDragHandle(rows[0]);
+    dispatch(handle0, 'pointerdown', {
+      button: 0, pointerId: 4, clientX: 0, clientY: 20,
+    });
+    fireDoc('pointermove', { pointerId: 4, clientX: 0, clientY: 110 });
+    fireDoc('keydown',     { key: 'Escape' });
+
+    assert.deepEqual(
+      store.state.speaker.favorites.map((e) => e.id),
+      ['s1', 's2', 's3'],
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 0, 'no POST fires on Escape');
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});
+
+// --- mid-drag has no POST -------------------------------------------
+
+test('drag in flight: pointermove without pointerup fires no POST', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+    { id: 's2', name: 'Two', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts.push(JSON.parse(opts.body));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    stubRowRects(rows);
+
+    const handle0 = findDragHandle(rows[0]);
+    dispatch(handle0, 'pointerdown', {
+      button: 0, pointerId: 5, clientX: 0, clientY: 20,
+    });
+    for (let y = 30; y < 80; y += 10) {
+      fireDoc('pointermove', { pointerId: 5, clientX: 0, clientY: y });
+    }
+    // No pointerup. The state is still the original list.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.deepEqual(
+      store.state.speaker.favorites.map((e) => e.id),
+      ['s1', 's2'],
+    );
+    assert.equal(posts.length, 0, 'no POST until release');
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});
+
+// --- no-op drop ------------------------------------------------------
+
+test('drag drop at source: no POST fires', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'One', art: '', note: '' },
+    { id: 's2', name: 'Two', art: '', note: '' },
+    { id: 's3', name: 'Three', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts.push(JSON.parse(opts.body));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    return new Promise(() => {});
+  });
+  const { fireDoc, restore: restoreDoc } = installDocEventDispatch();
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    stubRowRects(rows);
+
+    // Pick up row 1, release at its own midline → gap 1 = source's own
+    // gap. spliceReorder returns the original list reference; no POST.
+    const handle1 = findDragHandle(rows[1]);
+    dispatch(handle1, 'pointerdown', {
+      button: 0, pointerId: 6, clientX: 0, clientY: 60,
+    });
+    fireDoc('pointermove', { pointerId: 6, clientX: 0, clientY: 50 });
+    fireDoc('pointerup',   { pointerId: 6, clientX: 0, clientY: 50 });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 0, 'drop at source gap is a no-op');
+    assert.deepEqual(
+      store.state.speaker.favorites.map((e) => e.id),
+      ['s1', 's2', 's3'],
+    );
+  } finally {
+    destroy();
+    restore();
+    restoreDoc();
+  }
+});

--- a/admin/test/test_favorites_inline_hearts.js
+++ b/admin/test/test_favorites_inline_hearts.js
@@ -1,0 +1,492 @@
+// Tests for inline favourite hearts on every playable row + the
+// Now-Playing card (issue #126).
+//
+// Surfaces under test:
+//   - search rows (s/p/t/m mix) — heart visibility + capture rule
+//   - browse rows via renderEntry — heart on station/show rows
+//   - show-landing hero (via _renderShowLandingForTest) — heart on the
+//     show subject, capture rule uses Describe-resolved title + logo
+//   - recently-viewed / popular row builders — heart wired in
+//   - Now-Playing card — heart visibility per source + toggle round-trip
+//
+// Strategy: import the production row builders directly. The
+// dom-shim's xmldom shim gives us a working Element + addEventListener
+// + dispatchEvent. fetch is stubbed per-test for the toggle paths.
+//
+// Run: node --test admin/test
+
+import { test, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { doc, installFetchNeverResolving } from './fixtures/dom-shim.js';
+
+installFetchNeverResolving();
+
+const { store } = await import('../app/state.js');
+const { searchRow } = await import('../app/views/search.js');
+const { renderEntry } = await import('../app/views/browse/outline-render.js');
+const {
+  _renderShowLandingForTest,
+  renderLiveShowCard,
+  renderTopicsCard,
+} = await import('../app/views/browse/show-landing.js');
+const { stationRow } = await import('../app/components.js');
+
+function classOf(el) { return el.getAttribute('class') || ''; }
+function hasClass(el, cls) {
+  return classOf(el).split(/\s+/).includes(cls);
+}
+function findFirstByClass(root, cls) {
+  if (!root) return null;
+  if (root.nodeType === 1 && hasClass(root, cls)) return root;
+  for (const c of root.childNodes || []) {
+    if (c && c.nodeType === 1) {
+      const found = findFirstByClass(c, cls);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function installFetchStub(handler) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler;
+  return () => { globalThis.fetch = original; };
+}
+
+beforeEach(() => {
+  store.state.speaker.favorites = [];
+});
+
+// --- search rows -----------------------------------------------------
+
+test('search row: s-prefix renders heart in place of chevron', () => {
+  const row = searchRow({
+    type: 'audio', guide_id: 's11111', text: 'Folk Alley',
+    subtext: 'Kent, OH', image: 'http://example/art.png',
+    item: 'station',
+  });
+  const heart = findFirstByClass(row, 'fav-heart');
+  assert.ok(heart, 's-prefix row has a heart');
+  assert.equal(heart.hidden, false, 'heart is visible on a favouritable id');
+  assert.equal(findFirstByClass(row, 'station-row__chev'), null,
+    'chevron is gone on favouritable rows');
+});
+
+test('search row: p-prefix show renders heart in place of chevron', () => {
+  const row = searchRow({
+    type: 'link', guide_id: 'p38913', text: 'Folk Alley Sessions',
+    URL: 'http://opml.radiotime.com/Browse.ashx?id=p38913',
+    item: 'show', image: 'http://example/show.png',
+  });
+  const heart = findFirstByClass(row, 'fav-heart');
+  assert.ok(heart, 'p-prefix show row has a heart');
+  assert.equal(heart.hidden, false);
+  assert.equal(findFirstByClass(row, 'station-row__chev'), null);
+});
+
+test('search row: t-prefix topic keeps the chevron (not favouritable)', () => {
+  const row = searchRow({
+    type: 'link', guide_id: 't22222', text: 'Topic',
+    URL: 'http://opml.radiotime.com/Browse.ashx?id=t22222',
+    item: 'topic',
+  });
+  // The heart is wired but its visibility gate hides it on a t-prefix.
+  // The chevron stays as the trailing affordance.
+  const heart = findFirstByClass(row, 'fav-heart');
+  if (heart) {
+    assert.equal(heart.hidden, true, 'heart hidden on t-prefix');
+  }
+  // Note: when the heart is mounted but hidden, the chevron may not
+  // exist (the heart took the slot). The contract is that the user
+  // sees no heart — the gate hides it.
+});
+
+test('search row: m-prefix artist keeps the chevron, no heart', () => {
+  const row = searchRow({
+    type: 'link', guide_id: 'm33333', text: 'Joan Baez',
+    URL: 'http://opml.radiotime.com/Browse.ashx?id=m33333',
+  });
+  assert.equal(findFirstByClass(row, 'fav-heart'), null,
+    'artist row has no heart at all (drillSearchRow path)');
+  const chev = findFirstByClass(row, 'station-row__chev');
+  assert.ok(chev, 'artist row still carries a chevron');
+});
+
+test('search row: heart toggle round-trips through POST /favorites', async () => {
+  store.state.speaker.favorites = [];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's11111', name: 'Folk Alley', art: 'http://example/art.png', note: '' }] }),
+    };
+  });
+  try {
+    const row = searchRow({
+      type: 'audio', guide_id: 's11111', text: 'Folk Alley',
+      subtext: 'Kent, OH', image: 'http://example/art.png',
+      item: 'station',
+    });
+    const heart = findFirstByClass(row, 'fav-heart');
+    assert.ok(heart, 'heart present');
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.equal(body.length, 1);
+    assert.equal(body[0].id, 's11111');
+    assert.equal(body[0].name, 'Folk Alley');
+    assert.equal(body[0].art, 'http://example/art.png');
+    assert.equal(body[0].note, '', 'note is the empty string per #126 capture rule');
+  } finally {
+    restore();
+  }
+});
+
+// --- browse rows (renderEntry) --------------------------------------
+
+test('browse renderEntry: station row carries a heart, no chevron', () => {
+  const node = renderEntry({
+    type: 'audio', guide_id: 's12345', text: 'KEXP',
+    image: 'http://example/kexp.png', subtext: 'Seattle, WA',
+  });
+  const heart = findFirstByClass(node, 'fav-heart');
+  assert.ok(heart, 'station row has a heart');
+  assert.equal(heart.hidden, false);
+  assert.equal(findFirstByClass(node, 'station-row__chev'), null);
+});
+
+test('browse renderEntry: show row carries a heart, no chevron', () => {
+  const node = renderEntry({
+    type: 'link', item: 'show', guide_id: 'p17',
+    text: 'Fresh Air', image: 'http://example/show.png',
+    URL: 'http://opml.radiotime.com/Browse.ashx?id=p17',
+  });
+  const heart = findFirstByClass(node, 'fav-heart');
+  assert.ok(heart, 'show row has a heart');
+  assert.equal(heart.hidden, false);
+  assert.equal(findFirstByClass(node, 'station-row__chev'), null);
+});
+
+test('browse renderEntry: drill row (g-prefix) has no heart, keeps chevron', () => {
+  const node = renderEntry({
+    text: 'Folk', URL: 'http://opml.radiotime.com/Browse.ashx?id=g79',
+  });
+  assert.equal(findFirstByClass(node, 'fav-heart'), null,
+    'drill rows never mount a heart');
+  // drill rows use the browse-row chevron variant
+  const chev = findFirstByClass(node, 'browse-row__chev');
+  assert.ok(chev, 'drill row keeps its chevron');
+});
+
+test('browse renderEntry: heart toggle round-trips through POST /favorites', async () => {
+  store.state.speaker.favorites = [];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's12345', name: 'KEXP', art: '', note: '' }] }),
+    };
+  });
+  try {
+    const node = renderEntry({
+      type: 'audio', guide_id: 's12345', text: 'KEXP',
+      image: 'http://example/kexp.png',
+    });
+    const heart = findFirstByClass(node, 'fav-heart');
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    // Per #126: {id, name, art, note: ''}. The art URL is whatever the
+    // row's normaliseRow pipeline emits (logoUrl may rewrite the
+    // input); we assert the shape + key invariants, not the exact URL.
+    assert.equal(body[0].id,   's12345');
+    assert.equal(body[0].name, 'KEXP');
+    assert.equal(typeof body[0].art, 'string');
+    assert.equal(body[0].note, '', 'note is the empty string per #126');
+  } finally {
+    restore();
+  }
+});
+
+// --- show-landing hero ---------------------------------------------
+
+test('show-landing hero: heart sits inside the hero name row with the show metadata', () => {
+  const body = doc.createElement('div');
+  const describe = {
+    head: { status: '200' },
+    body: [{
+      element: 'show',
+      guide_id: 'p17',
+      title: 'Fresh Air',
+      logo: 'http://example/show.png',
+      description: '',
+    }],
+  };
+  _renderShowLandingForTest(body, describe, null, null, null);
+  const hero = findFirstByClass(body, 'station-row--hero');
+  assert.ok(hero, 'show hero mounted');
+  const heart = findFirstByClass(hero, 'fav-heart');
+  assert.ok(heart, 'hero has a heart');
+  assert.equal(heart.hidden, false, 'heart visible on a p-prefix show id');
+  // Heart sits inside the hero name row (the layout wrapper), not at
+  // an arbitrary position.
+  const nameRow = findFirstByClass(hero, 'station-row__name-row');
+  assert.ok(nameRow, 'hero has a name row wrapper');
+  let inside = false;
+  for (const child of nameRow.childNodes || []) {
+    if (child === heart) { inside = true; break; }
+  }
+  assert.equal(inside, true, 'heart is a child of the hero name row');
+});
+
+test('show-landing hero: heart toggle captures {id, name, art, note: ""}', async () => {
+  store.state.speaker.favorites = [];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 'p17', name: 'Fresh Air', art: 'http://example/show.png', note: '' }] }),
+    };
+  });
+  try {
+    const body = doc.createElement('div');
+    _renderShowLandingForTest(body, {
+      head: { status: '200' },
+      body: [{
+        element: 'show', guide_id: 'p17', title: 'Fresh Air',
+        logo: 'http://example/show.png',
+      }],
+    }, null, null, null);
+    const heart = findFirstByClass(body, 'fav-heart');
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const sent = JSON.parse(post.opts.body);
+    assert.deepEqual(sent[0], {
+      id: 'p17', name: 'Fresh Air', art: 'http://example/show.png', note: '',
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('show-landing liveShow card: heart on the airing show hero', () => {
+  const card = renderLiveShowCard([
+    { type: 'link', item: 'show', guide_id: 'p17', text: 'Fresh Air',
+      image: 'http://example/show.png' },
+  ]);
+  const heart = findFirstByClass(card, 'fav-heart');
+  assert.ok(heart, 'liveShow hero carries a heart');
+  assert.equal(heart.hidden, false);
+});
+
+test('show-landing topic row: t-prefix → no visible heart (favourites are s/p only)', () => {
+  const card = renderTopicsCard([
+    { type: 'link', item: 'topic', guide_id: 't1001', text: 'Episode 1',
+      URL: 'http://opml.radiotime.com/Tune.ashx?id=t1001&sid=p17',
+      topic_duration: '3600' },
+  ]);
+  const heart = findFirstByClass(card, 'fav-heart');
+  // Topic rows go through stationRow without a `favorite` handle, so
+  // no heart element is rendered at all. The chevron stays.
+  if (heart) {
+    assert.equal(heart.hidden, true, 'heart hidden on t-prefix');
+  }
+  const chev = findFirstByClass(card, 'station-row__chev');
+  assert.ok(chev, 'topic row keeps its chevron');
+});
+
+// --- recently-viewed / popular helpers (via stationRow direct) ------
+
+test('stationRow: favourite handle wires a heart on s-prefix (recently-viewed shape)', () => {
+  const row = stationRow({
+    sid: 's12345', name: 'KEXP', art: 'http://example/kexp.png',
+    favorite: {
+      store,
+      getEntry: () => ({ id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '' }),
+    },
+  });
+  const heart = findFirstByClass(row, 'fav-heart');
+  assert.ok(heart, 'recently-viewed row has a heart');
+  assert.equal(heart.hidden, false);
+  assert.equal(findFirstByClass(row, 'station-row__chev'), null);
+});
+
+test('stationRow: omit favourite handle → chevron stays, no heart', () => {
+  const row = stationRow({
+    sid: 's12345', name: 'KEXP', art: 'http://example/kexp.png',
+  });
+  assert.equal(findFirstByClass(row, 'fav-heart'), null);
+  const chev = findFirstByClass(row, 'station-row__chev');
+  assert.ok(chev, 'no favourite handle → chevron is the trailing slot');
+});
+
+// --- Now-Playing card ----------------------------------------------
+//
+// Mount the production view via its default export. The window stub
+// from now-playing tests installs hashchange listeners; for the heart
+// we only need the card's name row, which mount() builds synchronously.
+
+const { installWindowAndLocation } = await import('./fixtures/dom-shim.js');
+installWindowAndLocation('#/');
+const nowPlayingView = (await import('../app/views/now-playing.js')).default;
+
+function setNowPlaying(np) {
+  store.update('speaker', (s) => {
+    s.speaker.nowPlaying = np;
+  });
+}
+
+function mountNowPlaying() {
+  const root = doc.createElement('section');
+  const destroy = nowPlayingView.init(root, store, {});
+  return { root, destroy };
+}
+
+test('Now-Playing card: heart visible when source=TUNEIN and item.location carries an s-id', () => {
+  setNowPlaying({
+    source: 'TUNEIN',
+    item: { itemName: 'KEXP', location: '/v1/playback/station/s12345' },
+    playStatus: 'PLAY_STATE',
+    art: 'http://example/kexp.png',
+  });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.ok(heart, 'heart present in Now-Playing card');
+    assert.equal(heart.hidden, false, 'heart visible on s-id TUNEIN source');
+    // Lives next to the np-name (inside the np-name-row).
+    const nameRow = findFirstByClass(root, 'np-name-row');
+    assert.ok(nameRow, 'name-row wrapper present');
+    let nested = false;
+    function walk(n) {
+      if (!n) return;
+      if (n === heart) { nested = true; return; }
+      for (const c of n.childNodes || []) walk(c);
+    }
+    walk(nameRow);
+    assert.equal(nested, true, 'heart is inside the name-row container');
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart visible on p-id (show drill) under TUNEIN', () => {
+  setNowPlaying({
+    source: 'TUNEIN',
+    item: { itemName: 'Fresh Air', location: '/v1/playback/station/p17' },
+    playStatus: 'PLAY_STATE',
+    art: 'http://example/show.png',
+  });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.ok(heart, 'heart present');
+    assert.equal(heart.hidden, false);
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart hidden on STANDBY', () => {
+  setNowPlaying({ source: 'STANDBY' });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.ok(heart, 'heart element exists');
+    assert.equal(heart.hidden, true, 'STANDBY hides the heart');
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart hidden on AUX', () => {
+  setNowPlaying({
+    source: 'AUX',
+    item: { itemName: 'AUX IN', location: '' },
+    playStatus: 'PLAY_STATE',
+  });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.equal(heart.hidden, true, 'AUX source → heart hidden');
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart hidden on BLUETOOTH', () => {
+  setNowPlaying({
+    source: 'BLUETOOTH',
+    item: { itemName: 'iPhone', location: '' },
+    playStatus: 'PLAY_STATE',
+  });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.equal(heart.hidden, true, 'BLUETOOTH source → heart hidden');
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart hidden on TUNEIN with topic (t-prefix not favouritable)', () => {
+  setNowPlaying({
+    source: 'TUNEIN',
+    item: { itemName: 'Episode 1', location: '/v1/playback/station/t12345' },
+    playStatus: 'PLAY_STATE',
+  });
+  const { root, destroy } = mountNowPlaying();
+  try {
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.equal(heart.hidden, true, 'topics are not favouritable');
+  } finally {
+    destroy();
+  }
+});
+
+test('Now-Playing card: heart toggle captures {id, name, art, note: ""} from item.location + itemName + np.art', async () => {
+  store.state.speaker.favorites = [];
+  setNowPlaying({
+    source: 'TUNEIN',
+    item: { itemName: 'KEXP', location: '/v1/playback/station/s12345' },
+    playStatus: 'PLAY_STATE',
+    art: 'http://example/kexp.png',
+  });
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    if (/\/favorites$/.test(String(url))) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ ok: true, data: [{ id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '' }] }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  try {
+    const { root, destroy } = mountNowPlaying();
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.ok(heart, 'heart present');
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.deepEqual(body[0], {
+      id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '',
+    });
+    destroy();
+  } finally {
+    restore();
+  }
+});

--- a/admin/test/test_favorites_view.js
+++ b/admin/test/test_favorites_view.js
@@ -1,0 +1,397 @@
+// Tests for the Favourites tab CRUD surface (issue #127):
+//
+//   - row shape: [drag-handle stub] [body — tap to play] [pencil] [trash]
+//   - pencil expands the row in place; Save commits + POSTs + collapses;
+//     Cancel collapses without writing.
+//   - trash optimistically removes the row + POSTs; toast offers Undo
+//     for 5 s; Undo re-inserts at the previous index and POSTs again.
+//   - delete + timeout (5 s elapsed) → deletion is permanent.
+//   - delete + POST failure → state reverts, toast surfaces.
+//
+// Strategy: dom-shim gives a working Element / document. We fake-time
+// the toast's setTimeout via `node:test`'s mock.timers so the 5 s
+// dwell collapses to a tick.
+//
+// Run: node --test admin/test
+
+import { test, beforeEach, mock } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { doc, installFetchNeverResolving } from './fixtures/dom-shim.js';
+
+installFetchNeverResolving();
+
+const { default: favoritesView } = await import('../app/views/favorites.js');
+const { store } = await import('../app/state.js');
+
+function makeRoot() { return doc.createElement('div'); }
+
+function installFetchStub(handler) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler;
+  return () => { globalThis.fetch = original; };
+}
+
+function mountFavorites(root) {
+  return favoritesView.init(root, store, { params: {} });
+}
+
+// Helpers — find row + its inline controls.
+
+function findRows(root) { return root.querySelectorAll('.favorites-row'); }
+function findRow(root, idx) { return findRows(root)[idx] || null; }
+function findEditBtn(row)   { return row.querySelector('.favorites-row__edit-btn'); }
+function findDeleteBtn(row) { return row.querySelector('.favorites-row__delete-btn'); }
+function findDragHandle(row){ return row.querySelector('.favorites-row__drag'); }
+function findBody(row)      { return row.querySelector('.favorites-row__body'); }
+function findEditForm(row)  { return row.querySelector('.favorites-row__edit'); }
+function findToastAction()  { return doc.querySelector('.toast--action .toast__action'); }
+function findToastText()    { return doc.querySelector('.toast--action .toast__text'); }
+
+function click(el) {
+  if (!el) throw new Error('click: target missing');
+  el.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+}
+
+function setInputValue(input, value) {
+  input.value = value;
+}
+
+beforeEach(() => {
+  store.state.speaker.favorites = null;
+  // Reset toast container so tests don't see stale toasts from a
+  // previous case.
+  const container = doc.getElementById('toast-container');
+  if (container && container.parentNode) container.parentNode.removeChild(container);
+});
+
+// --- row shape ------------------------------------------------------
+
+test('favorites tab: each row renders drag-handle | body | pencil | trash', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+    { id: 'p99',    name: 'Some Show', art: '', note: 'live mix' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const rows = findRows(root);
+    assert.equal(rows.length, 2, 'two rows rendered');
+    for (const row of rows) {
+      assert.ok(findDragHandle(row), 'drag-handle present');
+      assert.ok(findBody(row),       'body present');
+      assert.ok(findEditBtn(row),    'pencil present');
+      assert.ok(findDeleteBtn(row),  'trash present');
+    }
+    // Body text reflects the entry.
+    const firstName = rows[0].querySelector('.favorites-row__name');
+    assert.equal(firstName && firstName.textContent, 'Radio One');
+    // Notes surface in the body.
+    const secondNote = rows[1].querySelector('.favorites-row__note');
+    assert.equal(secondNote && secondNote.textContent, 'live mix');
+  } finally {
+    destroy();
+  }
+});
+
+// --- edit round-trip ------------------------------------------------
+
+test('favorites tab: pencil expands row; Save commits + POSTs + collapses', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+  ];
+  let captured = null;
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      captured = JSON.parse(opts.body);
+      return {
+        ok: true, status: 200,
+        json: async () => ({ ok: true, data: captured }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const row = findRow(root, 0);
+    click(findEditBtn(row));
+    const form = findEditForm(row);
+    assert.ok(form, 'edit form appears after pencil click');
+    assert.equal(row.classList.contains('is-expanded'), true, 'row marked as expanded');
+
+    const inputs = form.querySelectorAll('.favorites-edit__input');
+    assert.equal(inputs.length, 3, 'three inputs (name, art, note)');
+    setInputValue(inputs[0], 'New Name');
+    setInputValue(inputs[1], 'http://art');
+    setInputValue(inputs[2], 'edited note');
+
+    const saveBtn = form.querySelector('.favorites-edit__btn--save');
+    click(saveBtn);
+
+    // Optimistic mutation lands synchronously.
+    assert.equal(store.state.speaker.favorites[0].name, 'New Name');
+    assert.equal(store.state.speaker.favorites[0].art,  'http://art');
+    assert.equal(store.state.speaker.favorites[0].note, 'edited note');
+    // Form collapses.
+    assert.equal(findEditForm(findRow(root, 0)), null, 'edit form torn down after Save');
+    assert.equal(findRow(root, 0).classList.contains('is-expanded'), false);
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.ok(captured, 'POST issued');
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].name, 'New Name');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+test('favorites tab: pencil → Cancel collapses without writing', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+  ];
+  let posts = 0;
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      posts++;
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: [] }) };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const row = findRow(root, 0);
+    click(findEditBtn(row));
+    const form = findEditForm(row);
+    assert.ok(form);
+    const inputs = form.querySelectorAll('.favorites-edit__input');
+    setInputValue(inputs[0], 'Mutated');
+    const cancelBtn = form.querySelector('.favorites-edit__btn--cancel');
+    click(cancelBtn);
+    assert.equal(findEditForm(findRow(root, 0)), null, 'form collapsed after Cancel');
+    assert.equal(store.state.speaker.favorites[0].name, 'Radio One', 'state untouched');
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts, 0, 'no POST issued on Cancel');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+// --- delete + undo --------------------------------------------------
+
+test('favorites tab: trash removes row optimistically + POSTs; toast offers Undo', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+    { id: 'p99',    name: 'Some Show', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      const body = JSON.parse(opts.body);
+      posts.push(body);
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: body }) };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const row = findRow(root, 0);
+    click(findDeleteBtn(row));
+    // Optimistic removal.
+    assert.equal(store.state.speaker.favorites.length, 1);
+    assert.equal(store.state.speaker.favorites[0].id, 'p99');
+    // Toast with Undo appears.
+    const undo = findToastAction();
+    assert.ok(undo, 'Undo action visible in toast');
+    assert.equal(undo.textContent, 'Undo');
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 1, 'one POST fired for the delete');
+    assert.equal(posts[0].length, 1, 'POST body has the post-remove array');
+    assert.equal(posts[0][0].id, 'p99');
+
+    // Tap Undo — re-insert at the previous index + POST the restored list.
+    click(undo);
+    assert.equal(store.state.speaker.favorites.length, 2, 'restored optimistically');
+    assert.equal(store.state.speaker.favorites[0].id, 's12345', 'restored at original index');
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(posts.length, 2, 'a second POST fired for the restore');
+    assert.equal(posts[1].length, 2);
+    assert.equal(posts[1][0].id, 's12345');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+test('favorites tab: 5 s after delete, the toast auto-dismisses; deletion is permanent', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+  ];
+  const posts = [];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      const body = JSON.parse(opts.body);
+      posts.push(body);
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: body }) };
+    }
+    return new Promise(() => {});
+  });
+  // Mock node's setTimeout so we can fast-forward 5 s in one call.
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    click(findDeleteBtn(findRow(root, 0)));
+    assert.equal(store.state.speaker.favorites.length, 0);
+    const undo = findToastAction();
+    assert.ok(undo, 'Undo button shown after delete');
+
+    // Fast-forward past the 5-second dwell; the toast should dismiss
+    // and no further POST should fire (the deletion is permanent).
+    mock.timers.tick(5500);
+    assert.equal(store.state.speaker.favorites.length, 0, 'state stays empty after the toast times out');
+    assert.equal(posts.length, 1, 'still just the one delete POST');
+  } finally {
+    mock.timers.reset();
+    destroy();
+    restore();
+  }
+});
+
+test('favorites tab: delete + POST failure → state reverts, toast surfaces', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+  ];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      return {
+        ok: true, status: 400,
+        json: async () => ({ ok: false, error: { code: 'WRITE_FAILED', message: 'disk full' } }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    click(findDeleteBtn(findRow(root, 0)));
+    // Optimistic removal lands first…
+    assert.equal(store.state.speaker.favorites.length, 0);
+    // …then the failed POST resolves and the snapshot is restored.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(store.state.speaker.favorites.length, 1, 'state rolled back to the snapshot');
+    assert.equal(store.state.speaker.favorites[0].id, 's12345');
+    // Failure toast surfaces (any .toast that isn't the undo one).
+    const toasts = doc.querySelectorAll('.toast');
+    assert.ok(toasts.length >= 1, 'at least one toast visible after the failure');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+// --- edit POST failure ---------------------------------------------
+
+test('favorites tab: edit Save + POST failure → state reverts, toast surfaces', async () => {
+  const snapshot = { id: 's12345', name: 'Radio One', art: '', note: '' };
+  store.state.speaker.favorites = [snapshot];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      return {
+        ok: true, status: 400,
+        json: async () => ({ ok: false, error: { code: 'INVALID_NAME', message: 'bad' } }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    click(findEditBtn(findRow(root, 0)));
+    const form = findEditForm(findRow(root, 0));
+    const inputs = form.querySelectorAll('.favorites-edit__input');
+    setInputValue(inputs[0], 'Mutated');
+    click(form.querySelector('.favorites-edit__btn--save'));
+    // Optimistic edit lands first.
+    assert.equal(store.state.speaker.favorites[0].name, 'Mutated');
+    await new Promise((r) => setTimeout(r, 10));
+    // After the failed POST the snapshot is restored.
+    assert.equal(store.state.speaker.favorites[0].name, 'Radio One', 'reverted');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+// --- early-dismiss on subsequent activity ---------------------------
+
+test('favorites tab: any other user action dismisses the Undo toast early', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+    { id: 'p99',    name: 'Some Show', art: '', note: '' },
+  ];
+  const restore = installFetchStub(async (url, opts) => {
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      const body = JSON.parse(opts.body);
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: body }) };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    // Delete the first row → Undo toast appears.
+    click(findDeleteBtn(findRow(root, 0)));
+    assert.ok(findToastAction(), 'Undo toast present after delete');
+    // Tap the pencil on the surviving row → counts as activity, toast collapses.
+    click(findEditBtn(findRow(root, 0)));
+    // Toast container's only `.toast--action` should be removed (or
+    // marked dismissed pending the fade-out timer).
+    const node = doc.querySelector('.toast--action');
+    if (node) {
+      // is-shown removed → in fade-out animation.
+      assert.equal(node.classList.contains('is-shown'), false, 'Undo toast collapsed on subsequent activity');
+    }
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+// --- body tap plays -------------------------------------------------
+
+test('favorites tab: body tap fires /play with the entry id', async () => {
+  store.state.speaker.favorites = [
+    { id: 's12345', name: 'Radio One', art: '', note: '' },
+  ];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    if (/\/play$/.test(String(url))) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ ok: true, url: 'http://stream' }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const row = findRow(root, 0);
+    click(findBody(row));
+    await new Promise((r) => setTimeout(r, 10));
+    const playCall = calls.find((c) => /\/play$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(playCall, 'POST /play issued from body tap');
+    const body = JSON.parse(playCall.opts.body);
+    assert.equal(body.id, 's12345');
+    assert.equal(body.name, 'Radio One');
+  } finally {
+    destroy();
+    restore();
+  }
+});

--- a/admin/test/test_icons.js
+++ b/admin/test/test_icons.js
@@ -27,11 +27,12 @@ const STATIC_NAMES = [
   'power',
   'heart',
   'buffer',
+  'pencil', 'drag-handle',
 ];
 
-test('ICON_NAMES exposes 28 static glyphs + equalizer', () => {
-  assert.equal(STATIC_NAMES.length, 28);
-  assert.equal(ICON_NAMES.length, 29);
+test('ICON_NAMES exposes 30 static glyphs + equalizer', () => {
+  assert.equal(STATIC_NAMES.length, 30);
+  assert.equal(ICON_NAMES.length, 31);
   for (const n of STATIC_NAMES) assert.ok(ICON_NAMES.includes(n), `missing: ${n}`);
   assert.ok(ICON_NAMES.includes('equalizer'));
 });

--- a/admin/test/test_icons.js
+++ b/admin/test/test_icons.js
@@ -25,12 +25,13 @@ const STATIC_NAMES = [
   'clock', 'zap', 'x', 'back',
   'chevron-left',
   'power',
+  'heart',
   'buffer',
 ];
 
-test('ICON_NAMES exposes 27 static glyphs + equalizer', () => {
-  assert.equal(STATIC_NAMES.length, 27);
-  assert.equal(ICON_NAMES.length, 28);
+test('ICON_NAMES exposes 28 static glyphs + equalizer', () => {
+  assert.equal(STATIC_NAMES.length, 28);
+  assert.equal(ICON_NAMES.length, 29);
   for (const n of STATIC_NAMES) assert.ok(ICON_NAMES.includes(n), `missing: ${n}`);
   assert.ok(ICON_NAMES.includes('equalizer'));
 });

--- a/admin/test/test_now_playing.js
+++ b/admin/test/test_now_playing.js
@@ -44,6 +44,7 @@ function setSpeakerState(patch) {
       presets: null,
       volume: null,
       sources: null,
+      favorites: null,
     }, patch);
   });
 }
@@ -812,6 +813,214 @@ test('volume slider: WS-driven re-render mutates in place (focus survives)', () 
     assert.equal(sliderAfter.value, '55', 'value updated in place');
     assert.equal(globalThis.__focus_target__, sliderBefore,
       'focus reference still points at the original slider node');
+  } finally {
+    destroy();
+  }
+});
+
+// --- favourites grid (#129) -----------------------------------------
+
+test('favourites grid: zero favourites → section hidden, no cards rendered', () => {
+  setSpeakerState({ favorites: [] });
+
+  const { root, destroy } = mountView();
+  try {
+    const section = root.querySelector('.np-favorites');
+    assert.ok(section, 'favourites section mounted');
+    assert.equal(section.hidden, true,
+      'zero favourites → section is hidden entirely (no placeholder)');
+    const cards = root.querySelectorAll('.np-fav');
+    assert.equal(cards.length, 0, 'no cards rendered when the list is empty');
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites grid: null favourites (unfetched) → section hidden', () => {
+  setSpeakerState({ favorites: null });
+
+  const { root, destroy } = mountView();
+  try {
+    const section = root.querySelector('.np-favorites');
+    assert.equal(section.hidden, true, 'unfetched list reads as hidden');
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites grid: partial (1–8) → only the cards that exist, no placeholders', () => {
+  setSpeakerState({
+    favorites: [
+      { id: 's1', name: 'One' },
+      { id: 's2', name: 'Two' },
+      { id: 'p3', name: 'Three' },
+      { id: 's4', name: 'Four' },
+    ],
+  });
+
+  const { root, destroy } = mountView();
+  try {
+    const section = root.querySelector('.np-favorites');
+    assert.equal(section.hidden, false, 'section visible at length 4');
+    const cards = root.querySelectorAll('.np-fav');
+    assert.equal(cards.length, 4,
+      `expected exactly four cards, got ${cards.length} (no placeholder slots)`);
+    // Each card carries a deterministic hue token.
+    for (const c of cards) {
+      const hue = c.style.getPropertyValue('--np-fav-hue');
+      assert.ok(/^\d+$/.test(hue), `--np-fav-hue must be numeric, got ${hue}`);
+    }
+    // Names appear in order.
+    const names = cards.map((c) => c.querySelector('.np-fav-name').textContent);
+    assert.deepEqual(names, ['One', 'Two', 'Three', 'Four']);
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites grid: 9+ favourites → first nine render, remainder dropped', () => {
+  const many = Array.from({ length: 14 }, (_, i) => ({
+    id: `s${100 + i}`,
+    name: `Station ${i + 1}`,
+  }));
+  setSpeakerState({ favorites: many });
+
+  const { root, destroy } = mountView();
+  try {
+    const cards = root.querySelectorAll('.np-fav');
+    assert.equal(cards.length, 9, '3×3 grid caps at nine cards');
+    const lastName = cards[8].querySelector('.np-fav-name').textContent;
+    assert.equal(lastName, 'Station 9', 'the ninth favourite is the last visible');
+  } finally {
+    destroy();
+  }
+});
+
+test('favourites grid: tap card → /play POST with the favourite\'s id + name', async () => {
+  setSpeakerState({
+    favorites: [
+      { id: 's12345', name: 'KEXP' },
+      { id: 's2',     name: 'Two' },
+    ],
+  });
+
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url: String(url), body: opts && opts.body });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, url: 'http://example/stream.mp3' }),
+    };
+  };
+
+  const { root, destroy } = mountView();
+  try {
+    const first = root.querySelector('.np-fav');
+    first.dispatchEvent(ev('click'));
+    await new Promise((r) => setTimeout(r, 30));
+
+    const playCalls = calls.filter((c) => /\/play\b/.test(c.url));
+    assert.ok(playCalls.length >= 1,
+      `expected a /play POST, got ${JSON.stringify(calls.map((c) => c.url))}`);
+    const payload = JSON.parse(String(playCalls[0].body || '{}'));
+    assert.equal(payload.id, 's12345', 'POST body carries the favourite id');
+    assert.equal(payload.name, 'KEXP',  'POST body carries the favourite name (label)');
+  } finally {
+    globalThis.fetch = realFetch;
+    destroy();
+  }
+});
+
+test('favourites grid: long-press → location.hash = "#/favorites?focus=<id>"', async () => {
+  setSpeakerState({
+    favorites: [{ id: 's12345', name: 'KEXP' }],
+  });
+
+  globalThis.location.hash = '#/';
+
+  const { root, destroy } = mountView();
+  try {
+    const card = root.querySelector('.np-fav');
+    card.dispatchEvent(ev('pointerdown', { button: 0 }));
+    // LONG_PRESS_MS is 600 in the view; wait a bit longer.
+    await new Promise((r) => setTimeout(r, 700));
+    assert.equal(globalThis.location.hash, '#/favorites?focus=s12345',
+      'long-press routes to the favourites tab with ?focus=<id>');
+  } finally {
+    globalThis.location.hash = '#/';
+    destroy();
+  }
+});
+
+test('favourites grid: right-click (contextmenu) → same #/favorites?focus=<id> path', () => {
+  setSpeakerState({
+    favorites: [{ id: 'p99', name: 'Fresh Air' }],
+  });
+
+  globalThis.location.hash = '#/';
+
+  const { root, destroy } = mountView();
+  try {
+    const card = root.querySelector('.np-fav');
+    card.dispatchEvent(ev('contextmenu', { button: 2 }));
+    assert.equal(globalThis.location.hash, '#/favorites?focus=p99',
+      'right-click navigates immediately (no long-press delay)');
+  } finally {
+    globalThis.location.hash = '#/';
+    destroy();
+  }
+});
+
+test('favourites grid: tap right after a long-press is swallowed (no /play)', async () => {
+  setSpeakerState({
+    favorites: [{ id: 's12345', name: 'KEXP' }],
+  });
+
+  globalThis.location.hash = '#/';
+
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url: String(url), body: opts && opts.body });
+    return { ok: true, status: 200, json: async () => ({ ok: true, url: '' }) };
+  };
+
+  const { root, destroy } = mountView();
+  try {
+    const card = root.querySelector('.np-fav');
+    card.dispatchEvent(ev('pointerdown', { button: 0 }));
+    await new Promise((r) => setTimeout(r, 700));
+    // The long-press timer fired — now simulate the trailing click that
+    // a real pointer release would emit.
+    card.dispatchEvent(ev('click'));
+    await new Promise((r) => setTimeout(r, 10));
+    const playCalls = calls.filter((c) => /\/play\b/.test(c.url));
+    assert.equal(playCalls.length, 0,
+      'the click after a long-press must not trigger /play');
+  } finally {
+    globalThis.fetch = realFetch;
+    globalThis.location.hash = '#/';
+    destroy();
+  }
+});
+
+test('favourites grid: WS update mutates the grid (subscription wired)', () => {
+  setSpeakerState({ favorites: [] });
+
+  const { root, destroy } = mountView();
+  try {
+    assert.equal(root.querySelectorAll('.np-fav').length, 0, 'empty to start');
+
+    store.update('speaker', (s) => {
+      s.speaker.favorites = [{ id: 's1', name: 'One' }, { id: 's2', name: 'Two' }];
+    });
+
+    const cards = root.querySelectorAll('.np-fav');
+    assert.equal(cards.length, 2, 'subscription repaints the grid on store change');
+    assert.equal(root.querySelector('.np-favorites').hidden, false,
+      'section becomes visible once a favourite lands');
   } finally {
     destroy();
   }

--- a/admin/test/test_tunein_drill.js
+++ b/admin/test/test_tunein_drill.js
@@ -1,0 +1,320 @@
+// Tests for app/tunein-drill.js — the one-shot drill resolver.
+//
+// One fixture per row of the classification table in issue #122. Each
+// test injects a scripted fetcher via `opts.fetch` so the resolver
+// never reaches `globalThis.fetch`; the tests assert kind + payload
+// against the documented contract.
+//
+// Run: node --test admin/test
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const { resolveBrowseDrill } = await import('../app/tunein-drill.js');
+
+// Build a one-shot fetcher that resolves with the supplied value and
+// records every call. Tests assert the recorded args to make sure the
+// resolver passes `parts` through verbatim.
+function scriptedResolve(value) {
+  const calls = [];
+  const fn = async (...args) => {
+    calls.push(args);
+    return value;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// Build a one-shot fetcher that rejects with the supplied error.
+function scriptedReject(err) {
+  const calls = [];
+  const fn = async (...args) => {
+    calls.push(args);
+    throw err;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// --- transport throws -----------------------------------------------
+
+test('resolveBrowseDrill returns kind:error when the fetcher throws a TimeoutError', async () => {
+  const timeout = Object.assign(new Error('drill timed out after 15000ms'), {
+    name: 'TimeoutError',
+  });
+  const fetch = scriptedReject(timeout);
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'TIMEOUT');
+  assert.match(r.error.message, /timed out/i);
+});
+
+test('resolveBrowseDrill returns kind:error when the fetcher throws a network error', async () => {
+  const fetch = scriptedReject(new Error('failed to fetch'));
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'ERROR');
+  assert.equal(r.error.message, 'failed to fetch');
+});
+
+test('resolveBrowseDrill returns kind:error when the fetcher throws an HTTP-5xx-mapped Error', async () => {
+  // getJson maps non-2xx to `throw new Error(`${path} failed: HTTP ${res.status}`)`.
+  const fetch = scriptedReject(new Error('/tunein/browse failed: HTTP 502'));
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'ERROR');
+  assert.match(r.error.message, /HTTP 502/);
+});
+
+test('resolveBrowseDrill returns kind:error when the fetcher throws a non-Error value', async () => {
+  // Defence: a malformed throw shouldn't crash the resolver.
+  const fetch = async () => { throw 'boom'; };
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'ERROR');
+});
+
+// --- structured envelope `{ok:false, error:{code, message}}` --------
+
+test('resolveBrowseDrill maps the CGI structured envelope to kind:error verbatim', async () => {
+  const fetch = scriptedResolve({
+    ok: false,
+    error: { code: 'UPSTREAM_UNREACHABLE', message: 'speaker unreachable' },
+  });
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'UPSTREAM_UNREACHABLE');
+  assert.equal(r.error.message, 'speaker unreachable');
+});
+
+test('resolveBrowseDrill backfills missing fields on a partial structured envelope', async () => {
+  const fetch = scriptedResolve({ ok: false, error: { code: '', message: '' } });
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'ERROR');
+  assert.equal(r.error.message, 'ERROR');
+});
+
+// --- raw upstream-fetch-failure body `{error:"..."}` ----------------
+
+test('resolveBrowseDrill maps the raw `{error:"..."}` body to UPSTREAM_FETCH_FAILED', async () => {
+  // The busybox-shell CGI emits this exact body when its `wget` call
+  // against opml.radiotime.com fails. No `ok` key — only `error` as a
+  // bare string.
+  const fetch = scriptedResolve({ error: 'upstream fetch failed' });
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'error');
+  assert.equal(r.error.code, 'UPSTREAM_FETCH_FAILED');
+  assert.equal(r.error.message, 'upstream fetch failed');
+});
+
+// --- head.status non-200 + body:[] (TuneIn-rejected drill) ----------
+
+test('resolveBrowseDrill maps head.status!="200" + body:[] to kind:empty with the head.fault message', async () => {
+  // The c=pbrowse-on-Bo-egress shape — issue #84. The CGI is 200 but
+  // TuneIn rejected the drill; head carries the fault.
+  const fetch = scriptedResolve({
+    head: { status: '400', fault: 'Invalid root category' },
+    body: [],
+  });
+  const r = await resolveBrowseDrill({ c: 'pbrowse', id: 'p17' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Invalid root category');
+});
+
+test('resolveBrowseDrill tolerates numeric head.status when discriminating non-200', async () => {
+  const fetch = scriptedResolve({
+    head: { status: 400, fault: 'Bad something' },
+    body: [],
+  });
+  const r = await resolveBrowseDrill({ id: 'whatever' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Bad something');
+});
+
+test('resolveBrowseDrill maps head.status!="200" + body:[] with no fault to the fallback message', async () => {
+  const fetch = scriptedResolve({ head: { status: '500' }, body: [] });
+  const r = await resolveBrowseDrill({ id: 'x' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Nothing here.');
+});
+
+// --- body:[] with head.status 200 -----------------------------------
+
+test('resolveBrowseDrill maps body:[] with head.status 200 to kind:empty with the fallback message', async () => {
+  const fetch = scriptedResolve({
+    head: { title: 'Music', status: '200' },
+    body: [],
+  });
+  const r = await resolveBrowseDrill({ c: 'music' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Nothing here.');
+});
+
+test('resolveBrowseDrill maps body:[] with absent head.status to the fallback message', async () => {
+  // Defence: a body-empty response with no head at all should still
+  // produce the empty state, not crash.
+  const fetch = scriptedResolve({ body: [] });
+  const r = await resolveBrowseDrill({ id: 'x' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Nothing here.');
+});
+
+test('resolveBrowseDrill treats a response with no body array as empty', async () => {
+  // A malformed payload (e.g. `null` or `{head:…}` with no body)
+  // should land on empty rather than ok, otherwise renderOutline would
+  // run against a missing `.body` array.
+  const fetch = scriptedResolve({ head: { status: '200' } });
+  const r = await resolveBrowseDrill({ id: 'x' }, { fetch });
+  assert.equal(r.kind, 'empty');
+});
+
+// --- single-entry tombstone body ------------------------------------
+
+test('resolveBrowseDrill maps a single-entry tombstone body to kind:empty with the tombstone text', async () => {
+  // The c=lang/l117 (Welsh) response shape — exists at fixtures/api/
+  // c424724-l117-tombstone.tunein.json.
+  const fetch = scriptedResolve({
+    head: { title: 'Music', status: '200' },
+    body: [
+      { element: 'outline', type: 'text', text: 'No stations or shows available' },
+    ],
+  });
+  const r = await resolveBrowseDrill({ c: 'music', filter: 'l117' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'No stations or shows available');
+});
+
+test('resolveBrowseDrill falls back to "Nothing here." when the tombstone has no text', async () => {
+  const fetch = scriptedResolve({
+    head: { status: '200' },
+    body: [{ type: 'text' }],
+  });
+  const r = await resolveBrowseDrill({ id: 'x' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Nothing here.');
+});
+
+test('resolveBrowseDrill does NOT treat a section wrapper with children as a tombstone', async () => {
+  // A typeless+keyless wrapper with children classifies as tombstone
+  // under the fallback rule, but it carries real rows below it. The
+  // resolver must hand the wrapper through on the ok path so renderOutline
+  // can mount the section.
+  const fetch = scriptedResolve({
+    head: { title: 'X', status: '200' },
+    body: [
+      {
+        text: 'Stations',
+        key: 'stations',
+        children: [
+          { type: 'audio', guide_id: 's1', text: 'One' },
+        ],
+      },
+    ],
+  });
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'ok');
+  assert.ok(r.json && Array.isArray(r.json.body) && r.json.body.length === 1);
+});
+
+// --- ok path --------------------------------------------------------
+
+test('resolveBrowseDrill maps a populated multi-section body to kind:ok with the raw json', async () => {
+  const json = {
+    head: { title: 'Folk', status: '200' },
+    body: [
+      {
+        text: 'Stations', key: 'stations',
+        children: [{ type: 'audio', guide_id: 's1', text: 'One' }],
+      },
+      {
+        text: 'Shows', key: 'shows',
+        children: [{ type: 'link', item: 'show', guide_id: 'p1', text: 'A Show' }],
+      },
+    ],
+  };
+  const fetch = scriptedResolve(json);
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'ok');
+  assert.equal(r.json, json, 'ok path returns the raw json by reference');
+});
+
+test('resolveBrowseDrill maps a flat-row populated body to kind:ok', async () => {
+  const json = {
+    head: { title: 'Stations only', status: '200' },
+    body: [
+      { type: 'audio', guide_id: 's1', text: 'One' },
+      { type: 'audio', guide_id: 's2', text: 'Two' },
+    ],
+  };
+  const fetch = scriptedResolve(json);
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'ok');
+  assert.equal(r.json, json);
+});
+
+test('resolveBrowseDrill maps a body containing a tombstone alongside real rows to kind:ok', async () => {
+  // The single-tombstone rule requires length===1 — a tombstone mixed
+  // with real rows is just one row; the renderer handles it.
+  const json = {
+    head: { status: '200' },
+    body: [
+      { type: 'text', text: 'No stations or shows available' },
+      { type: 'audio', guide_id: 's1', text: 'A real row' },
+    ],
+  };
+  const fetch = scriptedResolve(json);
+  const r = await resolveBrowseDrill({ id: 'g79' }, { fetch });
+  assert.equal(r.kind, 'ok');
+});
+
+// --- parts pass-through ---------------------------------------------
+
+test('resolveBrowseDrill forwards parts to the fetcher verbatim', async () => {
+  const json = {
+    head: { status: '200' },
+    body: [{ type: 'audio', guide_id: 's1', text: 'One' }],
+  };
+  const fetch = scriptedResolve(json);
+  const parts = { c: 'music', filter: 'l109' };
+  await resolveBrowseDrill(parts, { fetch });
+  assert.equal(fetch.calls.length, 1);
+  assert.equal(fetch.calls[0][0], parts, 'first arg passed by reference');
+});
+
+// --- fixture-driven: tombstone payload via captured fixture ---------
+//
+// One end-to-end fixture wire — the captured c=music/filter=l117 (Welsh)
+// response. This was previously asserted by renderOutline's tombstone
+// test; the classification has moved upstream of renderOutline so the
+// fixture parity assertion moves here.
+
+test('resolveBrowseDrill on the captured Welsh tombstone fixture → kind:empty', async () => {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const fixture = JSON.parse(
+    fs.readFileSync(
+      path.resolve('admin/test/fixtures/api/c424724-l117-tombstone.tunein.json'),
+      'utf8',
+    ),
+  );
+  const fetch = scriptedResolve(fixture);
+  const r = await resolveBrowseDrill({ c: 'music', filter: 'l117' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'No stations or shows available');
+});
+
+test('resolveBrowseDrill on the captured p17-pbrowse-invalid fixture → kind:empty with head.fault', async () => {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const fixture = JSON.parse(
+    fs.readFileSync(
+      path.resolve('admin/test/fixtures/api/p17-pbrowse-invalid.tunein.json'),
+      'utf8',
+    ),
+  );
+  const fetch = scriptedResolve(fixture);
+  const r = await resolveBrowseDrill({ c: 'pbrowse', id: 'p17' }, { fetch });
+  assert.equal(r.kind, 'empty');
+  assert.equal(r.message, 'Invalid root category');
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,9 +208,13 @@ Architecture in three layers:
    strings rewritten at deploy time.
 2. **Shell CGIs under `/cgi-bin/api/v1/`** — `tunein` (forwarder for
    browse / search / probe), `presets` (atomic file-write +
-   `/storePreset`), `speaker` (wildcard proxy to `localhost:8090` with
-   a same-origin CSRF guard), `refresh-all` (bulk re-probe + atomic
-   resolver rewrite). All busybox-shell, all linted by shellcheck.
+   `/storePreset`), `favorites` (atomic JSON write for the admin-owned
+   favourites list, disjoint from the firmware presets),
+   `speaker` (wildcard proxy to `localhost:8090` with a same-origin
+   CSRF guard), `refresh-all` (bulk re-probe + atomic resolver
+   rewrite). All busybox-shell, all linted by shellcheck. Mutating
+   endpoints use POST — busybox httpd v1.19.4 (2017) returns 501 for
+   PUT before the CGI runs.
 3. **WebSocket client** — connects to the speaker's port 8080 with the
    `gabbo` subprotocol. Reconnect with exponential backoff + full
    jitter; REST polling fallback when WS is down. The admin reflects
@@ -222,14 +226,22 @@ Mono) live under `/mnt/nv/resolver/fonts/` and are referenced by
 relative URL — the LAN can be cut off from the public internet and
 the admin still loads. No CDN, no Google Fonts, no `unpkg`.
 
-User-facing surface as of 0.4:
+User-facing surface as of 0.7:
 
 - Now-playing — transport, volume, source picker, preset row,
-  long-press to assign.
+  long-press to assign, 3×3 favourites preview grid below the preset
+  grid (long-press on a favourite card jumps to the Favourites tab
+  focused on that entry).
 - Browse — Genre / Location / Language drill via TuneIn's outline.
+  Every playable row carries an inline heart toggle.
 - Search — debounced TuneIn search; landing page shows recently
-  viewed and popular.
-- Station detail — metadata, probe state, 3×2 preset grid, test-play.
+  viewed and popular. Every playable result carries the heart.
+- Station detail — metadata, probe state, 3×2 preset grid, test-play,
+  inline heart next to the station name.
+- Favourites — dedicated tab with full CRUD (drag reorder,
+  expand-in-place edit, toast-undo delete). Persists in a JSON file
+  at `/mnt/nv/resolver/admin-data/favorites.json`. Disjoint from the
+  six firmware-owned hardware presets — a station can be both.
 - Settings — Appearance (theme), Speaker (name / power / sleep),
   Audio (bass / balance / mono-stereo), Bluetooth (own MAC + active
   device), Multi-room (placeholder), Network (signal bars),


### PR DESCRIPTION
## Summary

Eight-issue milestone landing two themes on one branch:

- **Favourites** — admin-owned record of hearted stations and shows, end-to-end (CGI + tab + inline hearts + reorder/CRUD). Disjoint from the firmware-owned six hardware presets.
- **TuneIn drill seam + Crumb stack split** — consolidates one-shot drill fetch classification behind `resolveBrowseDrill`, and splits `crumbs.js` into pure `crumb-parts.js` + DOM `crumb-renderer.js`.

See the milestone description for the full PRD: https://github.com/skarl/bose-soundtouch-resurrect/milestone/7

### Notable

- **Favourites use POST, not PUT.** Bo's firmware ships busybox httpd v1.19.4 (2017) which returns 501 for PUT before the CGI runs. Documented in `docs/architecture.md` and the changelog.
- File-disjoint waves merged sequentially. Wave 1 (#122, #124, #125), wave 2 (#123, #126, #127, #129), wave 3 (#128). One small merge conflict in `views/favorites.js` between the CRUD tab and the focus deep-link; resolved cleanly.

### Tests

`npm test` → **1028 / 1028** green (up from 934 at the start of the milestone). Shell-side `test_favorites_cgi.sh` → **30 / 30** offline.

### Smoke on Bo (192.168.178.30)

- GET `/cgi-bin/api/v1/favorites` (cold) → `{ok:true, data:[]}`
- POST round-trip with 1, 3, and 4 entries → file persists at `/mnt/nv/resolver/admin-data/favorites.json`
- POST with invalid `id` → structured envelope `INVALID_ID`
- Reorder round-trip → list order updates on disk
- Admin shell serves with new `<meta name="admin-version" content="v0.6.0-17-gf030a36">`

## Closes

Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #128
Closes #129

## Test plan

- [x] `npm test` green
- [x] `shellcheck --severity=warning admin/cgi-bin/api/v1/favorites` clean
- [x] CGI smoke on Bo: GET / POST / reorder / invalid-id rejection
- [x] Admin shell serves after `admin/deploy.sh`
- [ ] Manual UI: heart from station-detail, search row, browse row, show-landing row, Now-Playing card
- [ ] Manual UI: Favourites tab — edit, delete + undo, drag reorder
- [ ] Manual UI: Now-Playing 3×3 grid — tap to play, long-press → `#/favorites?focus=<id>`