### PR TITLE
0.7.1 — favourites filter + visual polish + architecture deepening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.7.1] - 2026-05-15
+
+### Added
+
+- **Favourites filter** — pill input above the Favourites tab list
+  filters by name and id substring (case-insensitive). Drag reorder
+  is disabled while a filter is active so the filtered subset can't
+  be reordered against the unfiltered ground truth. The predicate is
+  exported as `filterFavorites(list, query)` from
+  `admin/app/favorites.js`.
+- **Shared `pillInput({...})` primitive** in
+  `admin/app/components.js` — leading-icon + clear-button text input
+  used by the Search bar and the Favourites filter. CSS namespace is
+  `.pill-input*` (renamed from the previous `.search-input*`).
+- **Shared `.page` outer wrapper + `.page-title` / `.page-title-bar`
+  primitive** — every primary view (Browse, Search, Favourites,
+  Settings) wraps its body in `.page` for normalised vertical chrome
+  and renders its title in a subtle pill box that visually rhymes
+  with the filter input. Favourites list renders as one continuous
+  rounded card.
+- **`admin/app/row-internals.js`** — new module hoisting the
+  helpers `appendMetaSeparator`, `genreChipEl`, `browseUrlToHash`,
+  and `buildFavoriteHeart` that were previously duplicated between
+  `components.js` (`stationRow`) and `show-hero.js` (`showHero`).
+  Both call sites now import from `row-internals.js`.
+- **ADR 0003** —
+  [`docs/adr/0003-favourites-stay-fetch-only.md`](docs/adr/0003-favourites-stay-fetch-only.md).
+  Documents why the Favourites field stays a fetch-only Field
+  reconciled on boot + `visibilitychange`, and why no
+  resolver-to-SPA push channel is being added.
+
+### Changed
+
+- **Now-Playing heart captures the station label, not the sid.** The
+  heart on the Now-Playing card now resolves the entry's `name`
+  through `renderNowPlayingTitle(np)` (the same source of truth used
+  to render the visible title) instead of falling back to the sid.
+  Hearting from the NP card now seeds `name` consistently with
+  hearting from any row.
+- **`toggleFavorite` collapsed into a thin wrapper over
+  `replaceFavorites`.** The two action shapes now share one
+  optimistic-write + rollback + toast path; `toggleFavorite`
+  validates the id, computes the next list, and delegates.
+- **Favourites row uses the shared station-row skin.** The dedicated
+  `.favorites-row*` CSS namespace is gone; favourites rows render
+  through `.station-row` with a `.station-row--crud` modifier that
+  adds the drag-handle / pencil / trash affordances and the
+  expand-in-place edit row.
+- **`joinFilters` lives in `crumb-parts.js`.** Filter normalisation
+  consolidated into the pure crumb-parts module;
+  `outline-render.js` imports both `stringifyCrumbs` and
+  `joinFilters` from there.
+- **Outline-render takes an explicit render context.** Every render
+  entry-point in `admin/app/views/browse/outline-render.js` now
+  receives `ctx = {childCrumbs, currentParts}` from the navigation
+  seam in `browse.js`. The old module-level `_childCrumbs` /
+  `_currentParts` slots are gone — render state threads through
+  arguments end-to-end, so two parallel renders can no longer race
+  the same module slots.
+
+### Fixed
+
+- **Mobile horizontal-overflow** on `.section-h__meta` and
+  `.settings-segment__opt`. Both elements force-wrap inside narrow
+  viewports rather than triggering a horizontal scrollbar.
+- **Mini-player title clamps on narrow viewports.** Adds
+  `min-width: 0` to `.shell-mini` so the grid item lets long station
+  names ellipsis instead of widening the row.
+- **Inline CSS dropped from JS-emitted DOM.** The speaker-unreachable
+  modal moved its chrome to dedicated `.speaker-unreachable*` rules
+  in `style.css`; the `stationArt` `size` parameter is gone (the
+  size lives entirely in CSS now). Several duplicate CSS blocks
+  consolidated.
+- **Search sticky bar aligns with sibling views.** Vertical padding
+  on the Search tab's sticky filter bar is dropped so the input row
+  sits on the same baseline as the title-pill rows in Favourites /
+  Browse / Settings.
+
 ## [v0.7.0] - 2026-05-14
 
 ### Added
@@ -269,5 +347,6 @@ Calling these out so future maintainers don't re-derive them:
 - CI: GitHub Actions workflow running shellcheck on `scripts/` and a
   Python compile + error-path check on `resolver/build.py`.
 
+[v0.7.1]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.7.1
 [v0.7.0]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.7.0
 [v0.1.0]: https://github.com/skarl/bose-soundtouch-resurrect/releases/tag/v0.1.0

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,8 +51,24 @@ The act of crawling TuneIn's outline tree — from a root (genre / location / la
 _Avoid_: browse, search (those are distinct concepts in TuneIn's API).
 
 **Crumb stack**:
-The breadcrumb trail in the browse view plus the `parts` value type that backs it. Owns parsing, rendering, hydration, and the trail's relationship to the URL hash. Split across two sibling modules: `crumb-parts.js` (pure value type + label-resolution reads, no DOM) and `crumb-renderer.js` (DOM pillbar + async hydration).
+The breadcrumb trail in the browse view plus the `parts` value type that backs it. Owns parsing, rendering, hydration, and the trail's relationship to the URL hash. Split across two sibling modules: `crumb-parts.js` (pure value type + label-resolution reads + filter normalisation via `joinFilters`, no DOM) and `crumb-renderer.js` (DOM pillbar + async hydration). `outline-render.js` imports both `stringifyCrumbs` and `joinFilters` from `crumb-parts`.
 _Avoid_: breadcrumb, trail (those refer to the visual element only; the stack is the value).
+
+**Render context (`ctx`)**:
+The `{childCrumbs, currentParts}` argument threaded through every render entry-point in `admin/app/views/browse/outline-render.js`. `childCrumbs` is the crumb-token prefix child rows embed in `from=…`; `currentParts` is the current drill's parts, used by the refinement-chip composer to stack THIS page's filters onto chip URLs. Built at each navigation seam in `browse.js` (`renderRoot` / `selectTab` / `renderDrill` / `renderShowLanding`). Replaced the earlier module-level `_childCrumbs` / `_currentParts` slots — render state is per-call now, not per-module.
+_Avoid_: state, scope (too generic).
+
+**Row-internals**:
+`admin/app/row-internals.js` — shared helpers used by both `stationRow` (in `components.js`) and `showHero` (in `show-hero.js`): meta-separator dot, clickable genre chip, browse-URL → SPA-hash converter, favourite-heart mount. Renderer details, not row primitives — kept out of `components.js` because they carry no public surface.
+_Avoid_: row helpers, row utils (lose the file boundary).
+
+**Pill-input**:
+The `pillInput({...})` primitive in `admin/app/components.js` and the `.pill-input*` CSS namespace it owns. Leading-icon + clear-button text input shared by the Search bar and the Favourites filter. Renamed from the earlier `.search-input*` namespace once it became a multi-caller primitive.
+_Avoid_: search-input (the legacy name; bound to one caller).
+
+**Page**:
+The shared `.page` outer wrapper plus `.page-title` / `.page-title-bar` block — the normalised view-chrome primitive. Every primary view (Browse, Search, Favourites, Settings) wraps its body in `.page`; the title renders in a subtle pill that visually rhymes with the filter input. `.page` only contributes vertical gap between section blocks; horizontal centring + max-width come from `.shell-body`.
+_Avoid_: container, view-shell (already overloaded; the shell is the four-zone outer chrome, the page is the per-view inner chrome).
 
 **Drill seam**:
 `admin/app/tunein-drill.js` — single classifier owning the one-shot **TuneIn drill** fetch policy. Maps every wire shape (transport throws, structured envelopes, raw `{"error":"..."}` bodies, `head.status` non-200 + empty body, status-200 empty body, single-tombstone bodies, ok payloads) onto a tagged result: `{kind:'ok'|'empty'|'error'}`. Browse's drill renderer and show-landing's browse half both consume it.

--- a/admin/app/components.js
+++ b/admin/app/components.js
@@ -11,7 +11,12 @@ import * as theme from './theme.js';
 import { canonicaliseBrowseUrl } from './tunein-url.js';
 import { parseSid, isPlayableSid } from './tunein-sid.js';
 import { createPlayButton } from './play-button.js';
-import { favoriteHeart, isFavoriteId } from './favorites.js';
+import {
+  appendMetaSeparator,
+  genreChipEl,
+  browseUrlToHash,
+  buildFavoriteHeart,
+} from './row-internals.js';
 
 export { isPlayableSid };
 
@@ -589,30 +594,12 @@ export function stationRow({
 // override exists for callers that want to resolve a live name/art
 // at click time (e.g. now-playing).
 export function trailingAffordance({ sid, name, art = '', favorite } = {}) {
-  if (favorite && favorite.store && isFavoriteId(sid)) {
-    const getEntry = typeof favorite.getEntry === 'function'
-      ? favorite.getEntry
-      : () => ({ id: sid, name: name || sid, art: art || '', note: '' });
-    return favoriteHeart({
-      store: favorite.store,
-      getEntry,
-      onCleanup: favorite.onCleanup,
-    });
-  }
+  const heart = buildFavoriteHeart({ sid, name, art, favorite });
+  if (heart) return heart;
   const chev = document.createElement('span');
   chev.className = 'station-row__chev';
   chev.appendChild(icon('arrow', 14));
   return chev;
-}
-
-// Append a "·" dot to a meta line. Used between each segment of the
-// chip-and-meta row so location/bitrate/reliability/genre never collide
-// when they line up.
-function appendMetaSeparator(meta) {
-  const sep = document.createElement('span');
-  sep.className = 'station-row__sep';
-  sep.textContent = '·';
-  meta.appendChild(sep);
 }
 
 // reliabilityBadge — small coloured dot + percentage label. CSS
@@ -640,53 +627,6 @@ function reliabilityBadge(spec) {
     el.appendChild(text);
   }
   return el;
-}
-
-// genreChipEl — small clickable pill that drills into the genre.
-// The href is composed via canonicaliseBrowseUrl so the URL passes
-// through the language-tree rewrite and the magic-param strip; the
-// resulting `Browse.ashx?id=g<NN>&render=json` is then translated
-// into the SPA hash form (#/browse?id=g<NN>).
-function genreChipEl(chip) {
-  const id = chip && typeof chip.id === 'string' ? chip.id : '';
-  if (!id) {
-    const stub = document.createElement('span');
-    stub.className = 'station-row__chip station-row__chip--genre is-disabled';
-    return stub;
-  }
-  // Compose a Browse URL from the bare id and canonicalise it, then
-  // strip the host/path/render so we land on a #/browse?... hash.
-  let drillHash;
-  try {
-    const browseUrl = canonicaliseBrowseUrl(`Browse.ashx?id=${encodeURIComponent(id)}`);
-    drillHash = browseUrlToHash(browseUrl);
-  } catch (_err) {
-    drillHash = `#/browse?id=${encodeURIComponent(id)}`;
-  }
-  const a = document.createElement('a');
-  a.className = 'station-row__chip station-row__chip--genre';
-  a.setAttribute('href', drillHash);
-  a.setAttribute('data-chip-kind', 'genre');
-  a.setAttribute('data-genre-id', id);
-  a.textContent = id;
-  // The chip is its own click target inside the row anchor; the row
-  // itself drills to the station's detail view, the chip drills to
-  // the genre. Stop the click bubbling so the row's href doesn't fire.
-  a.addEventListener('click', (evt) => {
-    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
-  });
-  return a;
-}
-
-// Convert a canonical `Browse.ashx?...&render=json` URL into the SPA
-// hash form. Drops the path + render param; preserves drill keys.
-function browseUrlToHash(canonical) {
-  const qIdx = canonical.indexOf('?');
-  if (qIdx < 0) return '#/browse';
-  const qs = new URLSearchParams(canonical.slice(qIdx + 1));
-  qs.delete('render');
-  const out = qs.toString();
-  return out ? `#/browse?${out}` : '#/browse';
 }
 
 // tertiaryLine — the third subtitle slot. `spec` is either a plain

--- a/admin/app/components.js
+++ b/admin/app/components.js
@@ -364,14 +364,14 @@ export function equalizer({ playing = false } = {}) {
   return wrap;
 }
 
-// stationArt({ url, name, size }) — uniform art slot that delegates
-// loading + hashed-name fallback to setArt(). Wraps an <img> in a sized
-// box so callers don't have to repeat the box-art-image pattern.
+// stationArt({ url, name }) — uniform art slot that delegates
+// loading + hashed-name fallback to setArt(). Wraps an <img> in a
+// box sized by the parent context's CSS (`.station-row .station-art`
+// is 40x40; .station-header .station-art is 5rem).
 // update({ url, name }) re-points the image without re-creating the node.
-export function stationArt({ url = '', name = '', size = 48 } = {}) {
+export function stationArt({ url = '', name = '' } = {}) {
   const wrap = document.createElement('span');
   wrap.setAttribute('class', 'station-art');
-  wrap.setAttribute('style', `width:${size}px;height:${size}px`);
 
   const img = document.createElement('img');
   img.setAttribute('class', 'station-art__img');
@@ -602,7 +602,7 @@ export function stationRow({
   row.href = hrefForSid(sid);
   row.dataset.sid = sid;
 
-  row.appendChild(stationArt({ url: art, name: name || sid, size: 40 }));
+  row.appendChild(stationArt({ url: art, name: name || sid }));
 
   const body = document.createElement('span');
   body.className = 'station-row__body';

--- a/admin/app/components.js
+++ b/admin/app/components.js
@@ -122,6 +122,107 @@ export function updatePill(el, state) {
   applyConnPill(el, modeOf(state));
 }
 
+// pillInput({ placeholder, ariaLabel, initialValue, onInput, debounceMs,
+//             showClear, iconGlyph }) — pill-shaped text input with a
+// leading icon and an optional clear-X. Returns { wrap, input, setValue }.
+//
+// `wrap` is the .pill-input-wrap element ready to mount. `input` is the
+// live <input> reference (callers that want to focus / select can).
+// `setValue(v)` sets the input value programmatically and fires onInput
+// when the value changes; clear-X empties the input, fires onInput(''),
+// and refocuses. When `debounceMs > 0`, onInput is trailing-debounced.
+export function pillInput({
+  placeholder = '',
+  ariaLabel = '',
+  initialValue = '',
+  onInput,
+  debounceMs = 0,
+  showClear = true,
+  iconGlyph = 'search',
+} = {}) {
+  const wrap = document.createElement('div');
+  wrap.className = 'pill-input-wrap';
+
+  const leading = document.createElement('span');
+  leading.className = 'pill-input-icon';
+  leading.appendChild(icon(iconGlyph, 14));
+  wrap.appendChild(leading);
+
+  const input = document.createElement('input');
+  input.setAttribute('type', 'search');
+  input.setAttribute('class', 'pill-input');
+  if (placeholder) input.setAttribute('placeholder', placeholder);
+  input.setAttribute('autocomplete', 'off');
+  input.setAttribute('spellcheck', 'false');
+  if (ariaLabel) input.setAttribute('aria-label', ariaLabel);
+  input.value = initialValue;
+  wrap.appendChild(input);
+
+  let clearBtn = null;
+  if (showClear) {
+    clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.className = 'pill-input-clear';
+    clearBtn.setAttribute('aria-label', 'Clear');
+    clearBtn.appendChild(icon('x', 12));
+    clearBtn.hidden = !initialValue;
+    wrap.appendChild(clearBtn);
+  }
+
+  let debounceTimer = null;
+  function clearDebounce() {
+    if (debounceTimer != null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  }
+
+  function fire(value) {
+    if (typeof onInput !== 'function') return;
+    if (debounceMs > 0) {
+      clearDebounce();
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        onInput(value);
+      }, debounceMs);
+    } else {
+      onInput(value);
+    }
+  }
+
+  function syncClearVisibility(value) {
+    if (clearBtn) clearBtn.hidden = !value;
+  }
+
+  input.addEventListener('input', (ev) => {
+    const v = ev && ev.target && typeof ev.target.value === 'string'
+      ? ev.target.value
+      : input.value;
+    syncClearVisibility(v);
+    fire(v);
+  });
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      input.value = '';
+      syncClearVisibility('');
+      clearDebounce();
+      if (typeof onInput === 'function') onInput('');
+      input.focus();
+    });
+  }
+
+  function setValue(v) {
+    const next = v == null ? '' : String(v);
+    if (next === input.value) return;
+    input.value = next;
+    syncClearVisibility(next);
+    fire(next);
+  }
+
+  return { wrap, input, setValue };
+}
+
 // switchEl({ checked, label, onChange }) — binary toggle with proper
 // role="switch" + aria-checked. The returned element exposes toggle()
 // and setChecked(next) so callers (and tests) can flip programmatically;

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -160,11 +160,9 @@ export async function replaceFavorites(store, next, prev, errorLabel) {
 // entry: { id, name, art?, note? }. `id` is required; `name` falls back
 //        to the id if missing so the persisted record always has a label.
 //
-// Behaviour:
-//   1. Snapshot current state.speaker.favorites.
-//   2. Apply the toggle locally and touch('speaker').
-//   3. POST the new list. On structured-error or transport failure,
-//      restore the snapshot, touch('speaker') again, surface a toast.
+// Thin wrapper over replaceFavorites: validates the id, computes the
+// next list via withFavoriteAdded / withFavoriteRemoved, and delegates
+// the optimistic write + rollback + toast to replaceFavorites.
 //
 // Returns the response envelope on success, or a synthetic
 // `{ ok:false, error:{code:'TRANSPORT', message}}` on transport throw
@@ -176,38 +174,16 @@ export async function toggleFavorite(store, entry) {
   const prev = Array.isArray(store.state.speaker.favorites)
     ? store.state.speaker.favorites.slice()
     : [];
-  const isFav = indexOfFavorite(prev, entry.id) >= 0;
   const safeEntry = {
     id:   entry.id,
     name: typeof entry.name === 'string' && entry.name ? entry.name : entry.id,
     art:  typeof entry.art  === 'string' ? entry.art  : '',
     note: typeof entry.note === 'string' ? entry.note : '',
   };
-  const next = isFav
+  const next = indexOfFavorite(prev, entry.id) >= 0
     ? withFavoriteRemoved(prev, entry.id)
     : withFavoriteAdded(prev, safeEntry);
-  store.state.speaker.favorites = next;
-  store.touch('speaker');
-
-  let envelope;
-  try {
-    envelope = await favoritesReplace(next);
-  } catch (err) {
-    store.state.speaker.favorites = prev;
-    store.touch('speaker');
-    const msg = (err && err.message) || 'transport error';
-    showToast(`Couldn't update favourites: ${msg}`);
-    return { ok: false, error: { code: 'TRANSPORT', message: msg } };
-  }
-
-  if (!envelope || envelope.ok !== true) {
-    store.state.speaker.favorites = prev;
-    store.touch('speaker');
-    const code = (envelope && envelope.error && envelope.error.code) || 'UNKNOWN';
-    showToast(`Couldn't update favourites (${code})`);
-    return envelope || { ok: false, error: { code, message: '' } };
-  }
-  return envelope;
+  return replaceFavorites(store, next, prev, "Couldn't update favourites");
 }
 
 // favoriteHeart({ getEntry, store, sizePx, onCleanup? }) — heart toggle

--- a/admin/app/favorites.js
+++ b/admin/app/favorites.js
@@ -104,6 +104,41 @@ export function spliceReorder(list, fromIdx, toGap) {
   return next;
 }
 
+// normaliseForFilter — case-fold + diacritic-strip a string into a form
+// suitable for substring comparison. Uses NFD to decompose accents into
+// combining marks, then drops the marks (Unicode block U+0300..U+036F).
+// Empty / non-string input collapses to ''. Kept local to favorites.js
+// because no other module in the admin app needs it today; promote to a
+// shared helper if a second caller appears.
+function normaliseForFilter(s) {
+  if (typeof s !== 'string' || s === '') return '';
+  let n = s;
+  if (typeof n.normalize === 'function') {
+    try { n = n.normalize('NFD'); } catch (_err) { /* hosts without NFD */ }
+  }
+  return n.replace(/[̀-ͯ]/g, '').toLowerCase();
+}
+
+// filterFavorites — return a filtered copy of `list` whose entries match
+// `query` as a case-folded, diacritic-stripped substring of any of name,
+// note, or id. Empty / whitespace `query` returns the original `list`
+// reference so callers can `if (next === list)` to skip extra work.
+// Order is preserved.
+export function filterFavorites(list, query) {
+  if (!Array.isArray(list)) return [];
+  const needle = normaliseForFilter(typeof query === 'string' ? query.trim() : '');
+  if (!needle) return list;
+  const out = [];
+  for (const entry of list) {
+    if (!entry) continue;
+    const hay = normaliseForFilter(
+      `${entry.name || ''} ${entry.note || ''} ${entry.id || ''}`,
+    );
+    if (hay.indexOf(needle) >= 0) out.push(entry);
+  }
+  return out;
+}
+
 // replaceFavorites — write a hand-built next-list to the speaker, with
 // optimistic state + rollback to the supplied snapshot on failure.
 //

--- a/admin/app/row-internals.js
+++ b/admin/app/row-internals.js
@@ -1,0 +1,89 @@
+// Shared internals for stationRow (components.js) and showHero
+// (show-hero.js). Both views render the same visual primitives — meta
+// separator dot, clickable genre chip, browse-URL → SPA-hash converter,
+// and the favourite-eligibility heart-mount — so the helpers live in one
+// place rather than being copy-paired between the two modules.
+//
+// Kept out of components.js because it carries no public surface: these
+// are renderer details, not row primitives. show-hero and components
+// import from here directly.
+
+import { canonicaliseBrowseUrl } from './tunein-url.js';
+import { favoriteHeart, isFavoriteId } from './favorites.js';
+
+// Append a "·" dot to a meta line. Used between each segment of the
+// chip-and-meta row so location/bitrate/reliability/genre never collide
+// when they line up.
+export function appendMetaSeparator(metaEl) {
+  const sep = document.createElement('span');
+  sep.className = 'station-row__sep';
+  sep.textContent = '·';
+  metaEl.appendChild(sep);
+}
+
+// genreChipEl — small clickable pill that drills into the genre.
+// The href is composed via canonicaliseBrowseUrl so the URL passes
+// through the language-tree rewrite and the magic-param strip; the
+// resulting `Browse.ashx?id=g<NN>&render=json` is then translated
+// into the SPA hash form (#/browse?id=g<NN>).
+export function genreChipEl(chip) {
+  const id = chip && typeof chip.id === 'string' ? chip.id : '';
+  if (!id) {
+    const stub = document.createElement('span');
+    stub.className = 'station-row__chip station-row__chip--genre is-disabled';
+    return stub;
+  }
+  let drillHash;
+  try {
+    const browseUrl = canonicaliseBrowseUrl(`Browse.ashx?id=${encodeURIComponent(id)}`);
+    drillHash = browseUrlToHash(browseUrl);
+  } catch (_err) {
+    drillHash = `#/browse?id=${encodeURIComponent(id)}`;
+  }
+  const a = document.createElement('a');
+  a.className = 'station-row__chip station-row__chip--genre';
+  a.setAttribute('href', drillHash);
+  a.setAttribute('data-chip-kind', 'genre');
+  a.setAttribute('data-genre-id', id);
+  a.textContent = id;
+  // The chip is its own click target inside the row anchor; the row
+  // itself drills to the station's detail view, the chip drills to
+  // the genre. Stop the click bubbling so the row's href doesn't fire.
+  a.addEventListener('click', (evt) => {
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+  });
+  return a;
+}
+
+// Convert a canonical `Browse.ashx?...&render=json` URL into the SPA
+// hash form. Drops the path + render param; preserves drill keys.
+export function browseUrlToHash(canonicalUrl) {
+  const qIdx = canonicalUrl.indexOf('?');
+  if (qIdx < 0) return '#/browse';
+  const qs = new URLSearchParams(canonicalUrl.slice(qIdx + 1));
+  qs.delete('render');
+  const out = qs.toString();
+  return out ? `#/browse?${out}` : '#/browse';
+}
+
+// buildFavoriteHeart — returns a favouriteHeart button when the sid is
+// favouritable AND a favourite-store handle is wired in; otherwise
+// returns null so the caller can fall through to its own affordance
+// (chevron on stationRow, no extra node on showHero).
+//
+// `favorite: { store, getEntry?, onCleanup? }`. When `getEntry` is
+// omitted, the entry shape is built from the static row fields:
+//   { id: sid, name: name || sid, art: art || '', note: '' }
+// The `getEntry` override exists for callers that want to resolve a
+// live name/art at click time (e.g. now-playing).
+export function buildFavoriteHeart({ sid, name, art = '', favorite } = {}) {
+  if (!favorite || !favorite.store || !isFavoriteId(sid)) return null;
+  const getEntry = typeof favorite.getEntry === 'function'
+    ? favorite.getEntry
+    : () => ({ id: sid, name: name || sid, art: art || '', note: '' });
+  return favoriteHeart({
+    store: favorite.store,
+    getEntry,
+    onCleanup: favorite.onCleanup,
+  });
+}

--- a/admin/app/show-hero.js
+++ b/admin/app/show-hero.js
@@ -21,9 +21,12 @@
 
 import { stationArt } from './components.js';
 import { isPlayableSid } from './tunein-sid.js';
-import { canonicaliseBrowseUrl } from './tunein-url.js';
 import { createPlayButton } from './play-button.js';
-import { favoriteHeart, isFavoriteId } from './favorites.js';
+import {
+  appendMetaSeparator,
+  genreChipEl,
+  buildFavoriteHeart,
+} from './row-internals.js';
 
 // Drill-only prefixes / unknown specs render nothing useful as a hero,
 // but the caller is in charge of whether to mount one. We mirror the
@@ -58,16 +61,8 @@ export function showHero({
   nameEl.textContent = name || sid;
   nameRow.appendChild(nameEl);
 
-  if (favorite && favorite.store && isFavoriteId(sid)) {
-    const getEntry = typeof favorite.getEntry === 'function'
-      ? favorite.getEntry
-      : () => ({ id: sid, name: name || sid, art: art || '', note: '' });
-    nameRow.appendChild(favoriteHeart({
-      store: favorite.store,
-      getEntry,
-      onCleanup: favorite.onCleanup,
-    }));
-  }
+  const heart = buildFavoriteHeart({ sid, name, art, favorite });
+  if (heart) nameRow.appendChild(heart);
 
   body.appendChild(nameRow);
 
@@ -100,56 +95,3 @@ export function showHero({
 
   return hero;
 }
-
-// --- internal helpers --------------------------------------------------
-//
-// These mirror the private helpers inside components.js. They're
-// duplicated here rather than re-exported because #87's contract is
-// "do not add new exports to components.js"; the helpers are small
-// and tied to the row's visual layout. A future refactor can hoist
-// them into a shared internal module once both row + hero stabilise.
-
-function appendMetaSeparator(meta) {
-  const sep = document.createElement('span');
-  sep.className = 'station-row__sep';
-  sep.textContent = '·';
-  meta.appendChild(sep);
-}
-
-function genreChipEl(chip) {
-  const id = chip && typeof chip.id === 'string' ? chip.id : '';
-  if (!id) {
-    const stub = document.createElement('span');
-    stub.className = 'station-row__chip station-row__chip--genre is-disabled';
-    return stub;
-  }
-  let drillHash;
-  try {
-    const browseUrl = canonicaliseBrowseUrl(`Browse.ashx?id=${encodeURIComponent(id)}`);
-    drillHash = browseUrlToHash(browseUrl);
-  } catch (_err) {
-    drillHash = `#/browse?id=${encodeURIComponent(id)}`;
-  }
-  const a = document.createElement('a');
-  a.className = 'station-row__chip station-row__chip--genre';
-  a.setAttribute('href', drillHash);
-  a.setAttribute('data-chip-kind', 'genre');
-  a.setAttribute('data-genre-id', id);
-  a.textContent = id;
-  // No outer anchor to bubble into on a hero, but keep the stop so the
-  // hero stays drop-in compatible if a future container ever wraps it.
-  a.addEventListener('click', (evt) => {
-    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
-  });
-  return a;
-}
-
-function browseUrlToHash(canonical) {
-  const qIdx = canonical.indexOf('?');
-  if (qIdx < 0) return '#/browse';
-  const qs = new URLSearchParams(canonical.slice(qIdx + 1));
-  qs.delete('render');
-  const out = qs.toString();
-  return out ? `#/browse?${out}` : '#/browse';
-}
-

--- a/admin/app/show-hero.js
+++ b/admin/app/show-hero.js
@@ -44,7 +44,7 @@ export function showHero({
   hero.className = 'station-row station-row--hero';
   hero.dataset.sid = sid;
 
-  hero.appendChild(stationArt({ url: art, name: name || sid, size: 40 }));
+  hero.appendChild(stationArt({ url: art, name: name || sid }));
 
   const body = document.createElement('span');
   body.className = 'station-row__body';

--- a/admin/app/speaker-state.js
+++ b/admin/app/speaker-state.js
@@ -100,6 +100,7 @@ export const FIELDS = [
     // to visible. The POST round-trip updates state optimistically from
     // the caller; the GET path is the floor in case another tab
     // mutated the list.
+    // see also: docs/adr/0003-favourites-stay-fetch-only.md
     name: 'favorites',
     fetcher: favoritesList,
     apply(state, env) {

--- a/admin/app/speaker-unreachable.js
+++ b/admin/app/speaker-unreachable.js
@@ -56,67 +56,10 @@ export function reduce(prev, event) {
   return cur;
 }
 
-// Inline styles keep the blocking overlay self-contained — no edit to
-// style.css required. The position:fixed + inset:0 + high z-index makes
-// the overlay a true modal: pointer events can't reach the shell behind
-// it. The card centers via flex on the root. The colour tokens reuse
-// the existing CSS custom properties so light + dark themes both work
-// without per-theme overrides.
-const ROOT_STYLE = [
-  'position: fixed',
-  'inset: 0',
-  'z-index: 2000',
-  'background: rgba(0, 0, 0, 0.55)',
-  'display: flex',
-  'align-items: center',
-  'justify-content: center',
-  'padding: 1rem',
-  'font: inherit',
-].join('; ');
-
-const CARD_STYLE = [
-  'background: var(--bg, #fff)',
-  'color: var(--fg, #000)',
-  'border: 1px solid var(--border, rgba(0,0,0,0.12))',
-  'border-radius: 12px',
-  'padding: 1.25rem 1.25rem 1rem',
-  'max-width: 28rem',
-  'width: 100%',
-  'box-shadow: 0 8px 32px rgba(0, 0, 0, 0.32)',
-  'display: flex',
-  'flex-direction: column',
-  'gap: 0.75rem',
-].join('; ');
-
-const TITLE_STYLE = [
-  'margin: 0',
-  'font-size: 1.05rem',
-  'font-weight: 600',
-].join('; ');
-
-const BODY_STYLE = [
-  'margin: 0',
-  'color: var(--muted, #555)',
-  'font-size: 0.95rem',
-  'line-height: 1.4',
-].join('; ');
-
-const BUTTON_STYLE = [
-  'align-self: flex-end',
-  'margin-top: 0.5rem',
-  'padding: 0.5rem 1rem',
-  'border-radius: 8px',
-  'border: 1px solid var(--border, rgba(0,0,0,0.12))',
-  'background: var(--accent, #2563eb)',
-  'color: #fff',
-  'font: inherit',
-  'font-weight: 600',
-  'cursor: pointer',
-].join('; ');
-
 // Build the overlay DOM. Returns the root element plus handles to the
 // pieces that need to mutate on state change. The overlay starts hidden
-// — render() decides when to show it.
+// — render() decides when to show it. All visual rules live under the
+// `.speaker-unreachable*` selectors in style.css.
 function buildOverlay() {
   const root = document.createElement('div');
   root.className = 'speaker-unreachable';
@@ -124,27 +67,22 @@ function buildOverlay() {
   root.setAttribute('aria-modal', 'true');
   root.setAttribute('aria-labelledby', 'speaker-unreachable-title');
   root.setAttribute('aria-describedby', 'speaker-unreachable-body');
-  root.setAttribute('style', ROOT_STYLE);
   root.hidden = true;
 
   const card = document.createElement('div');
   card.className = 'speaker-unreachable__card';
-  card.setAttribute('style', CARD_STYLE);
 
   const title = document.createElement('h2');
   title.id = 'speaker-unreachable-title';
   title.className = 'speaker-unreachable__title';
-  title.setAttribute('style', TITLE_STYLE);
 
   const body = document.createElement('p');
   body.id = 'speaker-unreachable-body';
   body.className = 'speaker-unreachable__body';
-  body.setAttribute('style', BODY_STYLE);
 
   const retry = document.createElement('button');
   retry.type = 'button';
   retry.className = 'speaker-unreachable__retry';
-  retry.setAttribute('style', BUTTON_STYLE);
   retry.textContent = 'Retry';
 
   card.appendChild(title);

--- a/admin/app/views/browse.js
+++ b/admin/app/views/browse.js
@@ -29,13 +29,10 @@ import { resolveBrowseDrill } from '../tunein-drill.js';
 import {
   renderOutline,
   renderEntry,
-  setChildCrumbs,
-  setCurrentParts,
   pluralize,
   skeleton,
   errorNode,
   emptyNode,
-  _setChildCrumbsForTest,
 } from './browse/outline-render.js';
 import {
   loadShowLanding,
@@ -99,7 +96,6 @@ export {
   renderFilterBadge,
   renderFilterBadges,
   _renderShowLandingForTest,
-  _setChildCrumbsForTest,
   _setActivePagersForTest,
   _setFilterInputForTest,
   _resetBrowseStateForTest,
@@ -164,9 +160,6 @@ function isShowDrillParts(parts) {
 // ---- root view (segmented tabs) -------------------------------------
 
 function renderRoot(root) {
-  // Root tabs view has no current parts (no drill).
-  setCurrentParts(null);
-
   const tabsBar = document.createElement('div');
   tabsBar.className = 'browse-tabs';
   tabsBar.setAttribute('role', 'tablist');
@@ -205,8 +198,6 @@ function renderRoot(root) {
     </section>
   `);
 
-  // Root view has no parent crumbs — children embed an empty `from=`.
-  setChildCrumbs([]);
   selectTab(TABS[0], buttons, body, headerLeft, headerCount);
 }
 
@@ -218,13 +209,16 @@ function selectTab(tab, buttons, body, headerLeft, headerCount) {
     b.setAttribute('aria-selected', active ? 'true' : 'false');
   }
   // Each tab is a top-level entry: children's crumb stack starts with
-  // just this tab's anchor token. setChildCrumbs hands the prefix off
-  // to outline-render so renderEntry sees the correct value.
+  // just this tab's anchor token. The ctx threads the prefix into
+  // outline-render so renderEntry composes child hrefs correctly.
   const tabToken = crumbTokenFor(tab.params);
-  setChildCrumbs(tabToken ? [tabToken] : []);
+  const ctx = {
+    childCrumbs: tabToken ? [tabToken] : [],
+    currentParts: null,
+  };
   headerLeft.textContent = tab.label;
   headerCount.textContent = '';
-  loadInto(body, tuneinBrowse(tab.params), headerCount, null);
+  loadInto(body, tuneinBrowse(tab.params), headerCount, null, ctx);
 }
 
 // ---- drill view (id=...) --------------------------------------------
@@ -290,12 +284,16 @@ function buildDrillFrame(parts, crumbs) {
 }
 
 function renderDrill(root, parts, crumbs) {
-  // Hand the current parts to outline-render so refinement chips
-  // (renderPivotChips / renderRelatedChips) can append THIS page's
-  // filters to their own when composing chip hrefs (#106).
-  setCurrentParts(parts);
-
   const frame = buildDrillFrame(parts, crumbs);
+
+  // Render context for the outline pipeline. childCrumbs is the stack
+  // child rows embed in `from=…`; currentParts hands THIS page's
+  // filters to the refinement-chip composer so chaining stacks rather
+  // than replaces (#106).
+  const ctx = {
+    childCrumbs: frame.childCrumbs,
+    currentParts: parts,
+  };
 
   // Page-top filter input, always visible (not behind an icon).
   // Instant DOM filter on keystroke; 300ms-debounced auto-crawl
@@ -317,8 +315,6 @@ function renderDrill(root, parts, crumbs) {
       ${body}
     </section>
   `);
-
-  setChildCrumbs(frame.childCrumbs);
 
   // Cold-load: any crumb whose label isn't already cached gets
   // hydrated in parallel (concurrency cap DESCRIBE_CONCURRENCY).
@@ -347,7 +343,7 @@ function renderDrill(root, parts, crumbs) {
     titleEl: frame.titleEl,
     crumbToken: frame.currentToken,
     trailEl: frame.trailEl,
-  });
+  }, ctx);
 }
 
 // loadDrillBody — drill-specific body loader. Reads the seam's
@@ -355,7 +351,7 @@ function renderDrill(root, parts, crumbs) {
 // the renderOutline branch keeps the success-path side-effects the
 // original loadInto carried (header count, title upgrade, crumb-label
 // cache write, Load-more wiring, sticky-filter rehydration).
-function loadDrillBody(body, parts, headerCount, head) {
+function loadDrillBody(body, parts, headerCount, head, ctx) {
   body.replaceChildren();
   body.appendChild(skeleton());
   if (headerCount) headerCount.textContent = '';
@@ -371,7 +367,7 @@ function loadDrillBody(body, parts, headerCount, head) {
         return;
       }
       const json = r.json;
-      const total = renderOutline(body, json);
+      const total = renderOutline(body, json, ctx);
       if (headerCount && total > 0) {
         headerCount.textContent = `${total.toLocaleString()} ${pluralize(total)}`;
       }
@@ -391,7 +387,9 @@ function loadDrillBody(body, parts, headerCount, head) {
       }
       // Mount one pager + Load-more button per section that came back
       // with a cursor URL parked on it by renderSection / renderFlatSection.
-      mountLoadMoreButtons(body);
+      // Hand the same ctx to the pager so paginated rows get the same
+      // childCrumbs / currentParts as the page-0 render.
+      mountLoadMoreButtons(body, { ctx });
       // If the filter input already has text (e.g. user navigates with
       // a sticky filter), apply it to the freshly-rendered rows and
       // kick the coordinator.
@@ -451,11 +449,15 @@ function registerLcodeRepatch(parts, crumbIdEl, trailEl, stack, backEl, filterBa
 // the show landing has no list tall enough to need filtering. The
 // body is filled by loadShowLanding.
 function renderShowLanding(root, parts, crumbs) {
-  // Show-landing isn't a filterable drill, but keep _currentParts in
-  // sync so the chip composers see a consistent state across mounts.
-  setCurrentParts(parts);
-
   const frame = buildDrillFrame(parts, crumbs);
+
+  // Show-landing isn't a filterable drill, but the related sections
+  // it mounts are real drill rows — they need the child crumb prefix
+  // and currentParts so chip / row hrefs compose correctly.
+  const ctx = {
+    childCrumbs: frame.childCrumbs,
+    currentParts: parts,
+  };
 
   const body = document.createElement('div');
   body.className = 'browse-body';
@@ -471,14 +473,12 @@ function renderShowLanding(root, parts, crumbs) {
     </section>
   `);
 
-  setChildCrumbs(frame.childCrumbs);
-
   if (frame.trailEl) hydrateCrumbLabels(frame.stack, frame.trailEl, frame.backEl);
 
   loadShowLanding(body, parts.id, frame.headerCount, {
     titleEl: frame.titleEl,
     crumbToken: frame.currentToken,
-  });
+  }, ctx);
 }
 
 // ---- shared loader --------------------------------------------------
@@ -488,14 +488,14 @@ function renderShowLanding(root, parts, crumbs) {
 // the loader upgrades titleEl to json.head.title and stashes the label
 // in the cache under tunein.label.<crumbToken>.
 
-function loadInto(body, promise, headerCount, head) {
+function loadInto(body, promise, headerCount, head, ctx) {
   body.replaceChildren();
   body.appendChild(skeleton());
   if (headerCount) headerCount.textContent = '';
   promise
     .then((json) => {
       body.replaceChildren();
-      const total = renderOutline(body, json);
+      const total = renderOutline(body, json, ctx);
       if (headerCount && total > 0) {
         headerCount.textContent = `${total.toLocaleString()} ${pluralize(total)}`;
       }
@@ -515,7 +515,7 @@ function loadInto(body, promise, headerCount, head) {
       }
       // Mount one pager + Load-more button per section that came back
       // with a cursor URL parked on it by renderSection / renderFlatSection.
-      mountLoadMoreButtons(body);
+      mountLoadMoreButtons(body, { ctx });
       // If the filter input already has text (e.g. user navigates with
       // a sticky filter), apply it to the freshly-rendered rows and
       // kick the coordinator. The DOM filter is cheap; skipping it

--- a/admin/app/views/browse.js
+++ b/admin/app/views/browse.js
@@ -191,7 +191,7 @@ function renderRoot(root) {
   });
 
   mount(root, html`
-    <section data-view="browse">
+    <section class="page" data-view="browse">
       ${tabsBar}
       ${header}
       ${body}
@@ -307,7 +307,7 @@ function renderDrill(root, parts, crumbs) {
   body.setAttribute('aria-live', 'polite');
 
   mount(root, html`
-    <section data-view="browse" data-mode="drill">
+    <section class="page" data-view="browse" data-mode="drill">
       ${frame.bar}
       ${frame.titleRow}
       ${filterWrap}
@@ -465,7 +465,7 @@ function renderShowLanding(root, parts, crumbs) {
   body.setAttribute('aria-live', 'polite');
 
   mount(root, html`
-    <section data-view="browse" data-mode="show-landing">
+    <section class="page" data-view="browse" data-mode="show-landing">
       ${frame.bar}
       ${frame.titleRow}
       ${frame.header}

--- a/admin/app/views/browse/crumb-parts.js
+++ b/admin/app/views/browse/crumb-parts.js
@@ -72,6 +72,19 @@ export function filtersOf(parts) {
   return [];
 }
 
+// Joined-string view of filtersOf — the wire form `l109,g22`. Prefers
+// `parts.filters: string[]` (the canonical multi-value form); falls
+// back to the legacy `parts.filter: string` verbatim. Empty → ''.
+export function joinFilters(parts) {
+  if (!parts) return '';
+  if (Array.isArray(parts.filters)) {
+    const cleaned = parts.filters.filter((s) => typeof s === 'string' && s !== '');
+    return cleaned.join(',');
+  }
+  if (typeof parts.filter === 'string' && parts.filter !== '') return parts.filter;
+  return '';
+}
+
 // Stash a `filters: string[]` (and back-compat `filter: string`) on a
 // parts object. Empty arrays drop both fields so the URL composer emits
 // the bare drill (no `filter=` param).

--- a/admin/app/views/browse/crumb-parts.js
+++ b/admin/app/views/browse/crumb-parts.js
@@ -193,10 +193,8 @@ export function crumbLabelFor(parts) {
 }
 
 // Pure URL composer for the SPA-internal drill hash. Mirrors
-// outline-render's drillHashFor but takes the crumb prefix explicitly
-// instead of reading the module-level `_childCrumbs` — this is the
-// pure surface backHrefFor needs (crumb-parts.js may not depend on
-// outline-render.js, which is DOM-bound).
+// outline-render's drillHashFor but is duplicated here so crumb-parts
+// stays DOM-free (it cannot import outline-render, which is DOM-bound).
 function drillHash(parts, crumbs) {
   const qs = new URLSearchParams();
   if (parts.id)     qs.set('id', parts.id);

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -37,7 +37,7 @@ import {
   renderLiveShowCard,
   renderTopicsCard,
 } from './show-landing.js';
-import { stringifyCrumbs } from './crumb-parts.js';
+import { stringifyCrumbs, filtersOf, joinFilters } from './crumb-parts.js';
 import { trailingAffordance } from '../../components.js';
 
 // The crumb-token prefix that child links should embed in `from=...`.
@@ -100,31 +100,6 @@ export function drillHashFor(parts, crumbs) {
   const fromStr  = stringifyCrumbs(fromList);
   if (fromStr) qs.set('from', fromStr);
   return `#/browse?${qs.toString()}`;
-}
-
-// Resolve a parts object's filter list to the wire string `l109,g22`.
-// Prefers `parts.filters: string[]` (the canonical multi-value form);
-// falls back to the legacy `parts.filter: string`. Empty → ''.
-function joinFilters(parts) {
-  if (Array.isArray(parts.filters)) {
-    const cleaned = parts.filters.filter((s) => typeof s === 'string' && s !== '');
-    return cleaned.join(',');
-  }
-  if (typeof parts.filter === 'string' && parts.filter !== '') return parts.filter;
-  return '';
-}
-
-// Return the canonical filter list for parts (always an array). See
-// joinFilters; this is the same source-of-truth read but in array form.
-function filtersOfParts(parts) {
-  if (!parts) return [];
-  if (Array.isArray(parts.filters)) {
-    return parts.filters.filter((s) => typeof s === 'string' && s !== '');
-  }
-  if (typeof parts.filter === 'string' && parts.filter !== '') {
-    return parts.filter.split(',').map((s) => s.trim()).filter(Boolean);
-  }
-  return [];
 }
 
 export function pluralize(n) {
@@ -457,7 +432,7 @@ function crumbTokenForParts(parts) {
     ? parts.id
     : (typeof parts.c === 'string' && parts.c !== '' ? parts.c : '');
   if (!anchor) return null;
-  const filters = filtersOfParts(parts);
+  const filters = filtersOf(parts);
   if (filters.length > 0) {
     return `${anchor}:${filters.join('+')}`;
   }
@@ -533,7 +508,7 @@ export function primeLabelForChip(parts, label) {
   if (!parts || typeof label !== 'string') return;
   const text = label.trim();
   if (!text) return;
-  const filters = filtersOfParts(parts);
+  const filters = filtersOf(parts);
   if (filters.length > 0) {
     const newFilter = filters[filters.length - 1];
     cache.set(`tunein.label.${newFilter}`, text, TTL_LABEL);
@@ -615,9 +590,9 @@ export function renderPivotChips(pivots) {
 // noise on the wire).
 function mergeFiltersFromCurrent(chipParts) {
   if (!_currentParts) return chipParts;
-  const current = filtersOfParts(_currentParts);
+  const current = filtersOf(_currentParts);
   if (current.length === 0) return chipParts;
-  const chipFilters = filtersOfParts(chipParts);
+  const chipFilters = filtersOf(chipParts);
   const seen = new Set();
   const merged = [];
   for (const f of current.concat(chipFilters)) {

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -8,11 +8,13 @@
 // outline-render imports them so renderSection's existing dispatch
 // stays unchanged.
 //
-// All drill-row hash composition runs through drillHashFor, which
-// reads the module-local `_childCrumbs` set by browse.js (renderRoot
-// / selectTab / renderDrill) before rendering. Tests poke
-// _setChildCrumbsForTest to drive renderEntry without mounting a
-// full view.
+// Every render entry-point takes a `ctx = {childCrumbs, currentParts}`
+// argument that browse.js builds at each navigation seam (renderRoot
+// / selectTab / renderDrill / renderShowLanding). `childCrumbs` is the
+// crumb-token prefix child rows embed in `from=…`; `currentParts` is
+// the current drill's parts, used by the refinement-chip composer
+// (#106) to stack THIS page's filters onto chip URLs. The ctx threads
+// explicitly through every internal helper — no module-level state.
 
 import { stationRow } from '../../components.js';
 import { icon } from '../../icons.js';
@@ -40,49 +42,27 @@ import {
 import { stringifyCrumbs, filtersOf, joinFilters } from './crumb-parts.js';
 import { trailingAffordance } from '../../components.js';
 
-// The crumb-token prefix that child links should embed in `from=...`.
-// Set by renderDrill / selectTab before the row constructor runs, and
-// read by drillHashFor() when composing each row's href. Module-local
-// rather than thread-through-args so renderEntry's signature (which
-// is exported and used by tests) stays stable.
-let _childCrumbs = [];
+// Default ctx used when callers don't supply one (test fixtures that
+// only exercise the row-shape without caring about from= / filter
+// stacking). Equivalent to "root-level entry, no current parts".
+const EMPTY_CTX = { childCrumbs: [], currentParts: null };
 
-// Browse.js drives the production setter — every drill mount pushes the
-// stack for child rows here. Tests use _setChildCrumbsForTest below.
-export function setChildCrumbs(crumbs) {
-  _childCrumbs = Array.isArray(crumbs) ? crumbs.slice() : [];
-}
-
-// Test-only setter for the module-local crumb prefix. Production code
-// drives _childCrumbs through renderRoot / selectTab / renderDrill;
-// tests use this to assert renderEntry's href composition without
-// having to mount a full view.
-export function _setChildCrumbsForTest(crumbs) {
-  _childCrumbs = Array.isArray(crumbs) ? crumbs.slice() : [];
-}
-
-// Current-page parts (#106). The pivot / related chip composers append
-// THIS page's filters to the chip's own filter list so multi-filter
-// drills stack cleanly (e.g. Bayreuth → +Country → +German lands on
-// `?id=r101821&filter=g26,l170`). browse.js renderDrill sets this
-// before rendering the outline; root view / tests clear it.
-let _currentParts = null;
-
-export function setCurrentParts(parts) {
-  _currentParts = (parts && typeof parts === 'object') ? parts : null;
-}
-
-export function _setCurrentPartsForTest(parts) {
-  _currentParts = (parts && typeof parts === 'object') ? parts : null;
+function normaliseCtx(ctx) {
+  if (!ctx) return EMPTY_CTX;
+  const childCrumbs = Array.isArray(ctx.childCrumbs) ? ctx.childCrumbs : [];
+  const currentParts = (ctx.currentParts && typeof ctx.currentParts === 'object')
+    ? ctx.currentParts
+    : null;
+  return { childCrumbs, currentParts };
 }
 
 // Compose the hash anchor for a drill row from its parts. Mirrors
 // composeDrillUrl but emits the SPA-internal hash form. The keys are
 // already plain strings; URLSearchParams handles encoding.
 //
-// `crumbs` is the prefix the child link should embed in `from=...`.
-// Defaults to the module-level `_childCrumbs` so renderEntry callers
-// don't need to pass it through. Empty arrays omit `from=` entirely.
+// `crumbs` is the prefix the child link embeds in `from=...`. Required
+// — every call site has a stack to pass (an empty array for the root
+// view). Empty arrays omit `from=` entirely.
 //
 // Multi-filter (#106): emits the joined wire form `filter=l109,g22`
 // when `parts.filters: string[]` is non-empty. Falls back to the
@@ -96,7 +76,7 @@ export function drillHashFor(parts, crumbs) {
   if (filterStr)    qs.set('filter', filterStr);
   if (parts.pivot)  qs.set('pivot', parts.pivot);
   if (parts.offset) qs.set('offset', parts.offset);
-  const fromList = Array.isArray(crumbs) ? crumbs : _childCrumbs;
+  const fromList = Array.isArray(crumbs) ? crumbs : [];
   const fromStr  = stringifyCrumbs(fromList);
   if (fromStr) qs.set('from', fromStr);
   return `#/browse?${qs.toString()}`;
@@ -146,7 +126,8 @@ export function emptyNode(message) {
 //
 // Returns the total visible row count (cursors + pivots are excluded
 // — they're meta, not rows the user reads through).
-export function renderOutline(body, json) {
+export function renderOutline(body, json, ctx) {
+  const c = normaliseCtx(ctx);
   const rawItems = Array.isArray(json && json.body) ? json.body : [];
 
   // Local Radio surface (issue #82): c=local responses include a
@@ -156,7 +137,7 @@ export function renderOutline(body, json) {
   // The localCountry row can sit either at body root (typical c=local
   // shape) or inside a section's children — handle both by walking
   // one level deep.
-  const items = liftLocalCountry(rawItems, body, json);
+  const items = liftLocalCountry(rawItems, body, json, c);
 
   let total = 0;
 
@@ -166,7 +147,7 @@ export function renderOutline(body, json) {
   const flatRows = [];
   for (const entry of items) {
     if (Array.isArray(entry.children) && entry.children.length > 0) {
-      const rendered = renderSection(entry);
+      const rendered = renderSection(entry, c);
       if (rendered != null) {
         total += rendered.visibleCount;
         body.appendChild(rendered.element);
@@ -176,7 +157,7 @@ export function renderOutline(body, json) {
     }
   }
   if (flatRows.length > 0) {
-    const rendered = renderFlatSection(flatRows);
+    const rendered = renderFlatSection(flatRows, c);
     total += rendered.visibleCount;
     body.appendChild(rendered.element);
   }
@@ -189,12 +170,12 @@ export function renderOutline(body, json) {
 // double-mount it. Search depth is one level: body[] root, then any
 // section's `children`. Returns the original array unchanged when
 // no localCountry row is found.
-function liftLocalCountry(rawItems, body, json) {
+function liftLocalCountry(rawItems, body, json, ctx) {
   // Top-level scan first — c=local typically lays out the link as a
   // body-root sibling of the audio entries.
   for (let i = 0; i < rawItems.length; i++) {
     if (isLocalCountryEntry(rawItems[i])) {
-      const card = renderLocalCountryCard(rawItems[i], json);
+      const card = renderLocalCountryCard(rawItems[i], json, ctx);
       if (card) body.appendChild(card);
       return rawItems.slice(0, i).concat(rawItems.slice(i + 1));
     }
@@ -207,7 +188,7 @@ function liftLocalCountry(rawItems, body, json) {
     if (!entry || !Array.isArray(entry.children)) return entry;
     const idx = entry.children.findIndex(isLocalCountryEntry);
     if (idx < 0) return entry;
-    const card = renderLocalCountryCard(entry.children[idx], json);
+    const card = renderLocalCountryCard(entry.children[idx], json, ctx);
     if (card) body.appendChild(card);
     const newKids = entry.children.slice(0, idx).concat(entry.children.slice(idx + 1));
     return { ...entry, children: newKids };
@@ -227,14 +208,15 @@ function isLocalCountryEntry(entry) {
 // The label prefers `entry.text` ("Germany"); if missing, the head
 // title is the next-best signal. Final fallback is a bare "country
 // root" so the affordance still surfaces.
-function renderLocalCountryCard(entry, json) {
+function renderLocalCountryCard(entry, json, ctx) {
+  const c = normaliseCtx(ctx);
   const parts = drillPartsFor(entry);
   const drillable = parts != null;
   const card = document.createElement(drillable ? 'a' : 'span');
   card.className = drillable
     ? 'browse-local-country'
     : 'browse-local-country is-disabled';
-  if (drillable) card.setAttribute('href', drillHashFor(parts));
+  if (drillable) card.setAttribute('href', drillHashFor(parts, c.childCrumbs));
   card.setAttribute('data-local-country', '1');
 
   const labelEl = document.createElement('span');
@@ -281,7 +263,8 @@ function pickLocalCountryName(entry, json) {
 //
 // Returns { element, visibleCount }. visibleCount counts rows the
 // user sees — pivots and the cursor don't count.
-export function renderSection(section) {
+export function renderSection(section, ctx) {
+  const cx = normaliseCtx(ctx);
   const sectionKey = typeof section.key === 'string' ? section.key : '';
   const headerText = typeof section.text === 'string' ? section.text : '';
 
@@ -328,9 +311,9 @@ export function renderSection(section) {
     } else if (sectionKey === 'topics') {
       wrap.appendChild(renderTopicsCard(visibleChildren));
     } else if (sectionKey === 'related') {
-      wrap.appendChild(renderRelatedChips(section.children || []));
+      wrap.appendChild(renderRelatedChips(section.children || [], cx));
     } else {
-      wrap.appendChild(renderCard(visibleChildren));
+      wrap.appendChild(renderCard(visibleChildren, cx));
     }
   } else if (sectionKey === 'related') {
     // Pure-pivot related sections (visibleChildren empty because every
@@ -340,7 +323,7 @@ export function renderSection(section) {
       return t === 'pivot';
     });
     if (onlyPivots.length > 0) {
-      wrap.appendChild(renderRelatedChips(section.children || []));
+      wrap.appendChild(renderRelatedChips(section.children || [], cx));
     }
   }
 
@@ -350,7 +333,7 @@ export function renderSection(section) {
   if (sectionKey !== 'related') {
     const pivots = extractPivots(section);
     if (pivots.length > 0) {
-      wrap.appendChild(renderPivotChips(pivots));
+      wrap.appendChild(renderPivotChips(pivots, cx));
     }
   }
 
@@ -374,7 +357,8 @@ export function renderSection(section) {
 // 2 lays out identically to page 1 inside a section card. The
 // `data-section="flat"` marker keeps the live-verification selector
 // honest in the flat case too.
-export function renderFlatSection(entries) {
+export function renderFlatSection(entries, ctx) {
+  const cx = normaliseCtx(ctx);
   const visible = entries.filter((c) => {
     const t = classifyOutline(c);
     return t !== 'cursor' && t !== 'pivot' && t !== 'tombstone';
@@ -393,7 +377,7 @@ export function renderFlatSection(entries) {
   primeTuneinSkipCaches(visible);
 
   if (visible.length > 0) {
-    wrap.appendChild(renderCard(visible));
+    wrap.appendChild(renderCard(visible, cx));
   }
 
   const footer = document.createElement('div');
@@ -410,11 +394,12 @@ export function renderFlatSection(entries) {
   return { element: wrap, visibleCount: visible.length };
 }
 
-export function renderCard(entries) {
+export function renderCard(entries, ctx) {
+  const cx = normaliseCtx(ctx);
   const card = document.createElement('div');
   card.className = 'browse-card';
   for (let i = 0; i < entries.length; i++) {
-    const row = renderEntry(entries[i]);
+    const row = renderEntry(entries[i], cx);
     if (i === entries.length - 1) row.classList.add('is-last');
     card.appendChild(row);
   }
@@ -562,14 +547,15 @@ export function primeTuneinSkipCaches(entries) {
 // new filter axis (typically one value); the merge happens at href
 // composition time, the label-cache prime stays keyed on the new
 // filter only (`primeLabelForChip` writes the bare filter key).
-export function renderPivotChips(pivots) {
+export function renderPivotChips(pivots, ctx) {
+  const cx = normaliseCtx(ctx);
   const wrap = document.createElement('div');
   wrap.className = 'browse-pivots';
   for (const pivot of pivots) {
     const parts = drillPartsForUrl(pivot.url);
     const chip = document.createElement(parts ? 'a' : 'span');
     chip.className = parts ? 'browse-pivot' : 'browse-pivot is-disabled';
-    if (parts) chip.setAttribute('href', drillHashFor(mergeFiltersFromCurrent(parts)));
+    if (parts) chip.setAttribute('href', drillHashFor(mergeFiltersFromCurrent(parts, cx), cx.childCrumbs));
     chip.textContent = pivot.label || `pivot=${pivot.axis}`;
     chip.setAttribute('data-pivot-axis', pivot.axis);
     // Issue #105: pivot chips' text labels the axis value (e.g.
@@ -588,9 +574,10 @@ export function renderPivotChips(pivots) {
 // appended after the current page's filters (deduped — TuneIn's
 // upstream accepts repeats but emitting the same filter twice is just
 // noise on the wire).
-function mergeFiltersFromCurrent(chipParts) {
-  if (!_currentParts) return chipParts;
-  const current = filtersOf(_currentParts);
+function mergeFiltersFromCurrent(chipParts, ctx) {
+  const currentParts = ctx && ctx.currentParts;
+  if (!currentParts) return chipParts;
+  const current = filtersOf(currentParts);
   if (current.length === 0) return chipParts;
   const chipFilters = filtersOf(chipParts);
   const seen = new Set();
@@ -623,7 +610,8 @@ function mergeFiltersFromCurrent(chipParts) {
 // as the pivot chips that already shipped — visual parity, no extra
 // stylesheet entries. Each chip carries `data-chip-kind` (pivot /
 // nav / drill / station / show) so tests can target by intent.
-export function renderRelatedChips(children) {
+export function renderRelatedChips(children, ctx) {
+  const cx = normaliseCtx(ctx);
   const wrap = document.createElement('div');
   wrap.className = 'browse-pivots browse-related';
   for (const entry of children || []) {
@@ -636,7 +624,7 @@ export function renderRelatedChips(children) {
     // page's filters so chaining filter chips stacks rather than
     // replaces. Plain drill chips (no filter axis) pass through
     // unchanged.
-    if (parts) chip.setAttribute('href', drillHashFor(mergeFiltersFromCurrent(parts)));
+    if (parts) chip.setAttribute('href', drillHashFor(mergeFiltersFromCurrent(parts, cx), cx.childCrumbs));
     chip.setAttribute('data-chip-kind', kind);
     if (kind === 'pivot') {
       const k = typeof entry.key === 'string' ? entry.key : '';
@@ -669,7 +657,8 @@ export function renderRelatedChips(children) {
 //                    out before renderEntry is called; we still
 //                    render something sensible if a caller passes
 //                    one in)
-export function renderEntry(entry) {
+export function renderEntry(entry, ctx) {
+  const cx = normaliseCtx(ctx);
   const kind = classifyOutline(entry);
   const norm = normaliseRow(entry);
 
@@ -702,7 +691,7 @@ export function renderEntry(entry) {
   } else if (kind === 'show') {
     // Shows are drill-into-detail, not direct play. Reuse stationRow
     // for layout parity but the URL goes through the drill hash.
-    node = showRow(entry, norm);
+    node = showRow(entry, norm, cx);
   } else if (kind === 'tombstone') {
     node = disabledRow(norm.primary || '(unavailable)');
   } else {
@@ -710,7 +699,7 @@ export function renderEntry(entry) {
     // browse-row shape. Pivot/cursor entries shouldn't reach here in
     // the multi-section path (they're stripped or chip-rendered) but
     // we keep the fallback honest.
-    node = drillRow(entry, norm, kind);
+    node = drillRow(entry, norm, kind, cx);
   }
   // Stash the raw outline so the page-top filter can match against
   // text / subtext / playing / current_track without a re-classify
@@ -728,13 +717,14 @@ export function renderEntry(entry) {
 // Show rows reuse the station-row layout (art + name + secondary line
 // + chevron) but route to a browse-drill hash, since shows are an
 // `id=p<NNN>` browse target rather than a direct stream.
-function showRow(entry, norm) {
+function showRow(entry, norm, ctx) {
+  const cx = normaliseCtx(ctx);
   const id = norm.id || (entry && entry.guide_id) || '';
   const row = document.createElement('a');
   row.className = 'station-row';
   // Shows live under Browse.ashx — drill, don't tune.
   const parts = drillPartsFor(entry) || (id ? { id } : null);
-  row.setAttribute('href', parts ? drillHashFor(parts) : '#');
+  row.setAttribute('href', parts ? drillHashFor(parts, cx.childCrumbs) : '#');
   if (id) row.setAttribute('data-sid', id);
 
   // Inline the station-row internals so we don't pull in stationRow's
@@ -794,12 +784,13 @@ function showRow(entry, norm) {
 // through canonicaliseBrowseUrl so the language-tree rewrite
 // (§ 7.3) and magic-param strip (§ 7.4) happen once, at the seam
 // where API-emitted URLs cross into client-emitted URLs.
-function drillRow(entry, norm, _kind) {
+function drillRow(entry, norm, _kind, ctx) {
+  const cx = normaliseCtx(ctx);
   const drillParts = drillPartsFor(entry);
   const drillable = drillParts != null;
   const row = document.createElement(drillable ? 'a' : 'span');
   row.className = drillable ? 'browse-row' : 'browse-row is-disabled';
-  if (drillable) row.setAttribute('href', drillHashFor(drillParts));
+  if (drillable) row.setAttribute('href', drillHashFor(drillParts, cx.childCrumbs));
 
   const badgeText = drillParts
     ? (drillParts.id || (drillParts.c ? `c=${drillParts.c}` : ''))

--- a/admin/app/views/browse/outline-render.js
+++ b/admin/app/views/browse/outline-render.js
@@ -732,7 +732,6 @@ function showRow(entry, norm, ctx) {
   // parity with station rows.
   const art = document.createElement('span');
   art.className = 'station-art';
-  art.setAttribute('style', 'width:40px;height:40px');
   if (norm.image) {
     const img = document.createElement('img');
     img.className = 'station-art__img';

--- a/admin/app/views/browse/pager-crawl.js
+++ b/admin/app/views/browse/pager-crawl.js
@@ -72,6 +72,11 @@ export function mountLoadMoreButtons(body, opts) {
   const pageCap = (opts && Number.isFinite(opts.pageCap))
     ? opts.pageCap
     : undefined;
+  // Render ctx for newly-fetched rows. Stashed on each pager so the
+  // Load-more click handler + the coordinator's appendNewRows can
+  // re-build the row with the same childCrumbs / currentParts the
+  // page-0 render used.
+  const ctx = (opts && opts.ctx) || null;
   const sections = findAllSections(body);
   for (const section of sections) {
     const cursorUrl = section.getAttribute('data-cursor-url');
@@ -89,6 +94,7 @@ export function mountLoadMoreButtons(body, opts) {
       pageCap,
       section: section.getAttribute('data-section') || '',
     });
+    pager._renderCtx = ctx;
     _activePagers.push(pager);
     mountLoadMoreButton(section, footer, pager);
   }
@@ -221,8 +227,9 @@ export function appendNewRows(section, pager) {
   if (lastBefore && lastBefore.classList && typeof lastBefore.classList.remove === 'function') {
     lastBefore.classList.remove('is-last');
   }
+  const ctx = pager && pager._renderCtx ? pager._renderCtx : null;
   for (let i = alreadyMounted; i < rows.length; i++) {
-    const node = renderEntry(rows[i]);
+    const node = renderEntry(rows[i], ctx);
     if (i === rows.length - 1) node.classList.add('is-last');
     card.appendChild(node);
   }

--- a/admin/app/views/browse/show-landing.js
+++ b/admin/app/views/browse/show-landing.js
@@ -53,7 +53,7 @@ import {
 // fire in parallel; we wait on Describe synchronously and route the
 // Browse half through resolveBrowseDrill so empty / error / tombstone
 // classification is structured rather than swallowed.
-export function loadShowLanding(body, showId, headerCount, head) {
+export function loadShowLanding(body, showId, headerCount, head, ctx) {
   body.replaceChildren();
   body.appendChild(skeleton());
   if (headerCount) headerCount.textContent = '';
@@ -72,7 +72,7 @@ export function loadShowLanding(body, showId, headerCount, head) {
 
   Promise.all([describePromise, browsePromise])
     .then(([describeJson, browseJson]) => {
-      renderShowLandingBody(body, describeJson, browseJson, headerCount, head);
+      renderShowLandingBody(body, describeJson, browseJson, headerCount, head, ctx);
     })
     .catch((err) => {
       body.replaceChildren();
@@ -84,11 +84,11 @@ export function loadShowLanding(body, showId, headerCount, head) {
 // Browse payloads and walks them into the body. Exported (as the
 // test-only `_renderShowLandingForTest`) so tests can drive the path
 // without faking fetch.
-export function _renderShowLandingForTest(body, describeJson, browseJson, headerCount, head) {
-  return renderShowLandingBody(body, describeJson, browseJson, headerCount, head);
+export function _renderShowLandingForTest(body, describeJson, browseJson, headerCount, head, ctx) {
+  return renderShowLandingBody(body, describeJson, browseJson, headerCount, head, ctx);
 }
 
-function renderShowLandingBody(body, describeJson, browseJson, headerCount, head) {
+function renderShowLandingBody(body, describeJson, browseJson, headerCount, head, ctx) {
   // Clear any prior children (skeleton). Use replaceChildren when the
   // host DOM supports it; fall back to a manual removeChild loop for
   // the xmldom test shim which lacks replaceChildren.
@@ -133,7 +133,7 @@ function renderShowLandingBody(body, describeJson, browseJson, headerCount, head
   if (browseJson && Array.isArray(browseJson.body) && browseJson.body.length > 0) {
     for (const entry of browseJson.body) {
       if (Array.isArray(entry.children) && entry.children.length > 0) {
-        const rendered = renderSection(entry);
+        const rendered = renderSection(entry, ctx);
         if (rendered) {
           relatedCount += rendered.visibleCount;
           body.appendChild(rendered.element);

--- a/admin/app/views/favorites-drag.js
+++ b/admin/app/views/favorites-drag.js
@@ -194,6 +194,11 @@ export function installFavoriteDrag({
   function onPointerDown(evt) {
     if (evt && evt.button !== undefined && evt.button !== 0) return;
     if (active) return;
+    // aria-disabled on the handle is the kill-switch for the filter
+    // tab (#135) — drag against a filtered subset is semantically
+    // ambiguous, so the view marks the handle and we bail before any
+    // ghost / indicator gets mounted.
+    if (handle.getAttribute && handle.getAttribute('aria-disabled') === 'true') return;
     const list = typeof getList === 'function' ? getList() : null;
     const idx  = typeof getFromIdx === 'function' ? getFromIdx() : -1;
     if (!Array.isArray(list) || list.length < 2) return;

--- a/admin/app/views/favorites-drag.js
+++ b/admin/app/views/favorites-drag.js
@@ -12,7 +12,7 @@
 //
 // Lifecycle, per drag:
 //
-//   pointerdown on .favorites-row__drag
+//   pointerdown on .station-row__drag
 //     → setPointerCapture(pointerId)
 //     → snapshot fromIdx + a ghost (semi-transparent fixed clone)
 //     → mount a drop indicator (a thin <div>) into the list container
@@ -125,8 +125,8 @@ function placeIndicator(listEl, indicator, rows, gap) {
 
 // installFavoriteDrag — wire one drag handle. Called per row.
 //
-//   handle      — the .favorites-row__drag span
-//   row         — the .favorites-row element (used as source + rect)
+//   handle      — the .station-row__drag span
+//   row         — the .station-row--crud element (used as source + rect)
 //   listEl      — the .favorites-list container (parent of all rows)
 //   getList     — () → current favourites array (pulled from store at
 //                  pointerdown so a mid-flight reconcile doesn't strand
@@ -161,7 +161,7 @@ export function installFavoriteDrag({
     // Re-read on every move — the DOM is the source of truth for which
     // rows are currently rendered (replaceChildren during a render
     // would otherwise leave the cache pointing at detached nodes).
-    return Array.from(listEl.querySelectorAll('.favorites-row'));
+    return Array.from(listEl.querySelectorAll('.station-row--crud'));
   }
 
   function teardown() {

--- a/admin/app/views/favorites-drag.js
+++ b/admin/app/views/favorites-drag.js
@@ -95,10 +95,10 @@ function buildGhost(sourceRow) {
 
 function positionGhost(ghost, x, y) {
   if (!ghost || !ghost.style) return;
-  ghost.style.setProperty('position', 'fixed');
+  // Cursor coordinates — must stay inline. position:fixed +
+  // pointer-events:none live on .favorites-drag-ghost in style.css.
   ghost.style.setProperty('left', `${x}px`);
   ghost.style.setProperty('top',  `${y}px`);
-  ghost.style.setProperty('pointer-events', 'none');
 }
 
 function buildIndicator() {

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -2,14 +2,19 @@
 //
 // CRUD management surface. Each row carries always-on affordances:
 //
-//   [drag-handle stub]  [body — tap to play]  [pencil]  [trash]
+//   [drag-handle]  [body — tap to play]  [pencil]  [trash]
 //
-// The drag-handle is a visual stub in this slice (issue #127); the
-// behaviour wiring lands in #128. Pencil expands the row vertically
-// in place, exposing inputs for name / art / note plus Save & Cancel.
-// Trash optimistically removes the row, fires POST immediately, and
-// shows a 5-second toast with Undo; tapping Undo re-inserts the entry
-// at its previous index and POSTs the restored list.
+// The row reuses the shared .station-row pill skin (#134) — same art
+// size, name typography, and meta-line treatment as search/browse. The
+// .station-row--crud modifier flips the layout to a 4-slot grid and
+// adds the CRUD-specific affordances (drag-handle leading, pencil +
+// trash trailing, inline edit form expansion below).
+//
+// Pencil expands the row vertically in place, exposing inputs for
+// name / art / note plus Save & Cancel. Trash optimistically removes
+// the row, fires POST immediately, and shows a 5-second toast with
+// Undo; tapping Undo re-inserts the entry at its previous index and
+// POSTs the restored list.
 //
 // Validation failures from the CGI surface as toasts; local state
 // reverts to match the last-known-good response (via replaceFavorites
@@ -47,46 +52,26 @@ function buildEmptyState() {
   return wrap;
 }
 
-// Build the row body — the tappable play target. Mirrors the stationRow
-// visual contract (art + name + optional note) without the chev or
-// auto-attached Play icon, because here the row body itself is the
-// play affordance and the pencil/trash own the right gutter.
-function buildBody({ entry, onPlay }) {
-  const body = document.createElement('button');
-  body.type = 'button';
-  body.className = 'favorites-row__body';
-  body.setAttribute('aria-label', `Play ${entry.name || entry.id} on Bo`);
-
-  body.appendChild(stationArt({ url: entry.art || '', name: entry.name || entry.id, size: 40 }));
-
-  const text = document.createElement('span');
-  text.className = 'favorites-row__text';
+// Build the body block — name + optional meta line. Mirrors the
+// stationRow visual contract; the row root owns the click handler so
+// the body is a layout span, not a button.
+function buildBody({ entry }) {
+  const body = document.createElement('span');
+  body.className = 'station-row__body';
 
   const name = document.createElement('span');
-  name.className = 'favorites-row__name';
+  name.className = 'station-row__name';
   name.textContent = entry.name || entry.id;
-  text.appendChild(name);
+  body.appendChild(name);
 
   if (entry.note) {
-    const note = document.createElement('span');
-    note.className = 'favorites-row__note';
-    note.textContent = entry.note;
-    text.appendChild(note);
-  }
-
-  body.appendChild(text);
-
-  if (isPlayableSid(entry.id)) {
-    body.addEventListener('click', (evt) => {
-      if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
-      if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
-      onPlay();
-    });
-  } else {
-    // Non-playable ids (shouldn't appear in favourites, but keep the
-    // affordance honest) — render the body but disable the play action.
-    body.disabled = true;
-    body.classList.add('is-disabled');
+    const meta = document.createElement('span');
+    meta.className = 'station-row__meta';
+    const noteEl = document.createElement('span');
+    noteEl.className = 'station-row__loc';
+    noteEl.textContent = entry.note;
+    meta.appendChild(noteEl);
+    body.appendChild(meta);
   }
 
   return body;
@@ -98,21 +83,25 @@ function buildBody({ entry, onPlay }) {
 // tears the form down without writing.
 function buildEditForm({ seed, onSave, onCancel }) {
   const form = document.createElement('form');
-  form.className = 'favorites-row__edit';
-  // Prevent the browser's default form submission — we own the save.
+  form.className = 'station-row__edit';
   form.addEventListener('submit', (evt) => {
     if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+  });
+  // The row root owns the play click; any click inside the form (inputs,
+  // labels) must not bubble up and trigger /play.
+  form.addEventListener('click', (evt) => {
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
   });
 
   function fieldRow(labelText, inputType, value) {
     const wrap = document.createElement('label');
-    wrap.className = 'favorites-edit__field';
+    wrap.className = 'station-row__edit-field';
     const lbl = document.createElement('span');
-    lbl.className = 'favorites-edit__label';
+    lbl.className = 'station-row__edit-label';
     lbl.textContent = labelText;
     const input = document.createElement('input');
     input.type = inputType;
-    input.className = 'favorites-edit__input';
+    input.className = 'station-row__edit-input';
     input.value = value || '';
     wrap.appendChild(lbl);
     wrap.appendChild(input);
@@ -128,11 +117,11 @@ function buildEditForm({ seed, onSave, onCancel }) {
   form.appendChild(noteField.wrap);
 
   const actions = document.createElement('div');
-  actions.className = 'favorites-edit__actions';
+  actions.className = 'station-row__edit-actions';
 
   const cancelBtn = document.createElement('button');
   cancelBtn.type = 'button';
-  cancelBtn.className = 'favorites-edit__btn favorites-edit__btn--cancel';
+  cancelBtn.className = 'station-row__edit-btn station-row__edit-btn--cancel';
   cancelBtn.textContent = 'Cancel';
   cancelBtn.addEventListener('click', (evt) => {
     if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
@@ -142,7 +131,7 @@ function buildEditForm({ seed, onSave, onCancel }) {
 
   const saveBtn = document.createElement('button');
   saveBtn.type = 'submit';
-  saveBtn.className = 'favorites-edit__btn favorites-edit__btn--save';
+  saveBtn.className = 'station-row__edit-btn station-row__edit-btn--save';
   saveBtn.textContent = 'Save';
   saveBtn.addEventListener('click', (evt) => {
     if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
@@ -190,8 +179,9 @@ function buildIconButton({ glyph, label, className, onClick }) {
 // wires drag on the handle (drag plumbing needs the listEl + live
 // store, both of which are owned at the buildList level).
 function buildRow({ entry, store, onActivity }) {
-  const row = document.createElement('div');
-  row.className = 'favorites-row';
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'station-row station-row--crud';
   row.setAttribute('role', 'listitem');
   row.dataset.favId = entry.id;
 
@@ -199,27 +189,44 @@ function buildRow({ entry, store, onActivity }) {
   // attached after the row joins the DOM (the controller needs the
   // list container as its parent).
   const handle = document.createElement('span');
-  handle.className = 'favorites-row__drag';
+  handle.className = 'station-row__drag';
   handle.setAttribute('aria-hidden', 'true');
   handle.appendChild(icon('drag-handle', 16));
+  // A tap on the handle that doesn't escalate to a drag would otherwise
+  // bubble to the row and fire /play. Block it.
+  handle.addEventListener('click', (evt) => {
+    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
+  });
   row.appendChild(handle);
 
-  // [body — tap to play]
-  const body = buildBody({
-    entry,
-    onPlay: () => {
+  row.appendChild(stationArt({ url: entry.art || '', name: entry.name || entry.id, size: 40 }));
+
+  // [body — name + optional meta]. The row itself is the play target.
+  row.appendChild(buildBody({ entry }));
+
+  // Body tap → play. Wire on the row root since the body is a layout
+  // span (not a button) and the dom-shim doesn't bubble events.
+  if (isPlayableSid(entry.id)) {
+    row.setAttribute('aria-label', `Play ${entry.name || entry.id} on Bo`);
+    row.addEventListener('click', (evt) => {
+      if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+      if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
       onActivity();
       playSid({ sid: entry.id, label: entry.name || entry.id });
-    },
-  });
-  row.appendChild(body);
+    });
+  } else {
+    // Non-playable ids (shouldn't appear in favourites, but keep the
+    // affordance honest) — render the row but disable the play action.
+    row.disabled = true;
+    row.classList.add('is-disabled');
+  }
 
   // [pencil]
   let editForm = null;
   const pencil = buildIconButton({
     glyph: 'pencil',
     label: `Edit ${entry.name || entry.id}`,
-    className: 'favorites-row__edit-btn',
+    className: 'station-row__crud-edit',
     onClick: () => {
       onActivity();
       if (editForm) {
@@ -251,9 +258,6 @@ function buildRow({ entry, store, onActivity }) {
             art:  next.art,
             note: next.note,
           };
-          // Collapse optimistically — the optimistic state already
-          // shows the new values on the visible row via the store
-          // subscription.
           if (editForm) editForm.remove();
           editForm = null;
           row.classList.remove('is-expanded');
@@ -275,7 +279,7 @@ function buildRow({ entry, store, onActivity }) {
   const trash = buildIconButton({
     glyph: 'trash',
     label: `Delete ${entry.name || entry.id}`,
-    className: 'favorites-row__delete-btn',
+    className: 'station-row__crud-delete',
     onClick: () => {
       onActivity();
       const list = (store.state.speaker && store.state.speaker.favorites) || [];
@@ -358,14 +362,11 @@ function buildList({ entries, store, onActivity, onCleanup }) {
 // string and passes it through `ctx.query`. We honour it once at mount
 // (and once after the initial render lands data) by scrolling the
 // matching row into view and applying `.is-focused` for a brief flash.
-// Deliberately scoped to mount-time so #127's CRUD edits to the row
-// renderer below stay disjoint. Edit-mode is never auto-entered — a
-// long-press from Now Playing must not accidentally open the editor.
 const FOCUS_FLASH_MS = 1600;
 
 function applyFocus(body, focusId) {
   if (!body || typeof focusId !== 'string' || !focusId) return false;
-  const rows = body.querySelectorAll('.favorites-row');
+  const rows = body.querySelectorAll('.station-row--crud');
   for (const row of rows) {
     const favId = row.dataset && row.dataset.favId;
     if (favId !== focusId) continue;

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -424,7 +424,7 @@ function applyFocus(body, focusId) {
 export default defineView({
   mount(root, store, ctx, env) {
     mount(root, html`
-      <section class="favorites" data-view="favorites">
+      <section class="page favorites" data-view="favorites">
         <div class="page-title-bar">
           <h1 class="page-title">Favourites</h1>
         </div>

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -239,7 +239,7 @@ function buildRow({ entry, store, onActivity, dragDisabled }) {
   });
   row.appendChild(handle);
 
-  row.appendChild(stationArt({ url: entry.art || '', name: entry.name || entry.id, size: 40 }));
+  row.appendChild(stationArt({ url: entry.art || '', name: entry.name || entry.id }));
 
   // [body — name + optional meta]. The row itself is the play target.
   row.appendChild(buildBody({ entry }));

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -25,7 +25,7 @@
 // second tab that mutated the list flows back into this one.
 
 import { html, mount, defineView } from '../dom.js';
-import { stationArt } from '../components.js';
+import { stationArt, pillInput } from '../components.js';
 import { reconcileField } from '../speaker-state.js';
 import { isPlayableSid } from '../tunein-sid.js';
 import { icon } from '../icons.js';
@@ -35,18 +35,53 @@ import {
   indexOfFavorite,
   withFavoriteRemoved,
   replaceFavorites,
+  filterFavorites,
 } from '../favorites.js';
 import { installFavoriteDrag } from './favorites-drag.js';
 
 const UNDO_DWELL_MS = 5000;
+const FILTER_DEBOUNCE_MS = 150;
 
-function buildEmptyState() {
+// buildEmptyState — two shapes share one shell.
+//   { kind: 'none' }                — no favourites at all (broadened wording
+//                                     since both stations and shows can be
+//                                     hearted now).
+//   { kind: 'no-match', query, onClear } — non-empty filter matched zero rows;
+//                                     surfaces the user's query verbatim plus
+//                                     a "Clear filter" link wired to onClear.
+function buildEmptyState(spec = { kind: 'none' }) {
   const wrap = document.createElement('section');
   wrap.className = 'favorites-empty';
   const head = document.createElement('h2');
-  head.textContent = 'No favourites yet';
   const body = document.createElement('p');
-  body.textContent = 'Tap the heart on a station to add it here.';
+  if (spec && spec.kind === 'no-match') {
+    head.textContent = 'No matches';
+    const lead = document.createElement('span');
+    lead.textContent = 'No favourites match ';
+    const code = document.createElement('code');
+    code.textContent = String(spec.query || '');
+    const tail = document.createElement('span');
+    tail.textContent = '.';
+    body.appendChild(lead);
+    body.appendChild(code);
+    body.appendChild(tail);
+    wrap.appendChild(head);
+    wrap.appendChild(body);
+    const clearLine = document.createElement('p');
+    const clearLink = document.createElement('button');
+    clearLink.type = 'button';
+    clearLink.className = 'favorites-empty__clear';
+    clearLink.textContent = 'Clear filter';
+    clearLink.addEventListener('click', (evt) => {
+      if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
+      if (typeof spec.onClear === 'function') spec.onClear();
+    });
+    clearLine.appendChild(clearLink);
+    wrap.appendChild(clearLine);
+    return wrap;
+  }
+  head.textContent = 'No favourites yet';
+  body.textContent = 'Tap the heart on a station or show to add it here.';
   wrap.appendChild(head);
   wrap.appendChild(body);
   return wrap;
@@ -178,7 +213,7 @@ function buildIconButton({ glyph, label, className, onClick }) {
 // Returns { row, handle }; the caller hangs the row on the list and
 // wires drag on the handle (drag plumbing needs the listEl + live
 // store, both of which are owned at the buildList level).
-function buildRow({ entry, store, onActivity }) {
+function buildRow({ entry, store, onActivity, dragDisabled }) {
   const row = document.createElement('button');
   row.type = 'button';
   row.className = 'station-row station-row--crud';
@@ -191,6 +226,11 @@ function buildRow({ entry, store, onActivity }) {
   const handle = document.createElement('span');
   handle.className = 'station-row__drag';
   handle.setAttribute('aria-hidden', 'true');
+  // Reorder against a filter-narrowed subset is semantically ambiguous
+  // (gap N of the visible list doesn't map cleanly onto gap N of the
+  // underlying full list). Mark the handle aria-disabled so the install
+  // hook bails out and the CSS can fade it.
+  if (dragDisabled) handle.setAttribute('aria-disabled', 'true');
   handle.appendChild(icon('drag-handle', 16));
   // A tap on the handle that doesn't escalate to a drag would otherwise
   // bubble to the row and fire /play. Block it.
@@ -318,14 +358,14 @@ function buildRow({ entry, store, onActivity }) {
   return { row, handle };
 }
 
-function buildList({ entries, store, onActivity, onCleanup }) {
+function buildList({ entries, store, onActivity, onCleanup, dragDisabled }) {
   const list = document.createElement('div');
   list.className = 'favorites-list';
   list.setAttribute('role', 'list');
   const built = [];
   for (const entry of entries) {
     if (!entry || typeof entry.id !== 'string') continue;
-    const { row, handle } = buildRow({ entry, store, onActivity });
+    const { row, handle } = buildRow({ entry, store, onActivity, dragDisabled });
     list.appendChild(row);
     built.push({ entry, row, handle });
   }
@@ -392,6 +432,24 @@ export default defineView({
       </section>
     `);
     const body = root.querySelector('.favorites-body');
+    const titleBar = root.querySelector('.page-title-bar');
+
+    // Filter is local view state, not store state — it's a UI concern,
+    // not speaker state. Closure-scoped so the speaker subscription's
+    // re-render reads the latest needle.
+    let filterQuery = '';
+    const filter = pillInput({
+      placeholder:  'Filter favourites',
+      ariaLabel:    'Filter favourites',
+      initialValue: '',
+      debounceMs:   FILTER_DEBOUNCE_MS,
+      onInput: (value) => {
+        filterQuery = typeof value === 'string' ? value : '';
+        render();
+      },
+    });
+    filter.wrap.classList.add('favorites-filter');
+    if (titleBar) titleBar.appendChild(filter.wrap);
 
     // Activity hook: tracks the most recent action-toast so any other
     // user-initiated action collapses it early. An in-flight Undo toast
@@ -411,23 +469,40 @@ export default defineView({
       ? ctx.query.focus
       : '';
 
+    function clearFilter() {
+      filterQuery = '';
+      filter.setValue('');
+      render();
+    }
+
     function render() {
       const list = (store.state.speaker && store.state.speaker.favorites) || null;
-      // null = unfetched. Show the empty state immediately so a slow
-      // GET doesn't leave the body blank; reconcile-on-mount will land
-      // shortly and re-render with the real list.
+      // null = unfetched. Show the zero-favourites empty state immediately
+      // so a slow GET doesn't leave the body blank; reconcile-on-mount
+      // will land shortly and re-render with the real list.
       const entries = Array.isArray(list) ? list : [];
       if (!body) return;
       if (entries.length === 0) {
-        body.replaceChildren(buildEmptyState());
-      } else {
-        body.replaceChildren(buildList({
-          entries, store, onActivity,
-          onCleanup: env.onCleanup,
+        body.replaceChildren(buildEmptyState({ kind: 'none' }));
+        return;
+      }
+      const visible = filterFavorites(entries, filterQuery);
+      const dragDisabled = visible !== entries;
+      if (visible.length === 0) {
+        body.replaceChildren(buildEmptyState({
+          kind: 'no-match',
+          query: filterQuery,
+          onClear: clearFilter,
         }));
-        if (pendingFocusId && applyFocus(body, pendingFocusId)) {
-          pendingFocusId = '';
-        }
+        return;
+      }
+      body.replaceChildren(buildList({
+        entries: visible, store, onActivity,
+        onCleanup: env.onCleanup,
+        dragDisabled,
+      }));
+      if (pendingFocusId && applyFocus(body, pendingFocusId)) {
+        pendingFocusId = '';
       }
     }
 

--- a/admin/app/views/favorites.js
+++ b/admin/app/views/favorites.js
@@ -384,9 +384,9 @@ export default defineView({
   mount(root, store, ctx, env) {
     mount(root, html`
       <section class="favorites" data-view="favorites">
-        <header class="favorites-header">
-          <h1>Favourites</h1>
-        </header>
+        <div class="page-title-bar">
+          <h1 class="page-title">Favourites</h1>
+        </div>
         <div class="favorites-body"></div>
       </section>
     `);

--- a/admin/app/views/now-playing.js
+++ b/admin/app/views/now-playing.js
@@ -174,7 +174,7 @@ export default defineView({
         const item = np.item;
         const id = extractGuideIdFromLocation(item && item.location);
         if (!id) return null;
-        const name = (item && (item.itemName || item.name)) || '';
+        const name = renderNowPlayingTitle(np);
         const art  = (np && typeof np.art === 'string' && np.art.startsWith('http'))
           ? np.art : '';
         return { id, name, art, note: '' };

--- a/admin/app/views/now-playing.js
+++ b/admin/app/views/now-playing.js
@@ -66,7 +66,7 @@ export default defineView({
     volumeSlider.classList.add('np-slider');
 
     mount(root, html`
-      <section class="np-view" data-view="now-playing">
+      <section class="page np-view" data-view="now-playing">
         <div class="np-card">
           <div class="np-card__top">
             <div class="np-art-wrap">

--- a/admin/app/views/search.js
+++ b/admin/app/views/search.js
@@ -435,7 +435,7 @@ export default defineView({
     emptyEl.appendChild(popularSection);
 
     mount(root, html`
-      <section data-view="search">
+      <section class="page" data-view="search">
         <div class="search-bar">
           ${wrap}
           ${toggleWrap}

--- a/admin/app/views/search.js
+++ b/admin/app/views/search.js
@@ -31,7 +31,7 @@
 
 import { html, mount, defineView } from '../dom.js';
 import { tuneinSearch, tuneinBrowse } from '../api.js';
-import { stationRow } from '../components.js';
+import { stationRow, pillInput } from '../components.js';
 import { icon } from '../icons.js';
 import { classifyOutline, normaliseRow } from '../tunein-outline.js';
 import { canonicaliseBrowseUrl, extractDrillKey } from '../tunein-url.js';
@@ -361,37 +361,17 @@ export default defineView({
       : '';
 
     // --- input wrapper: leading glyph + input + clear-X + pending dot --
-    const wrap = document.createElement('div');
-    wrap.className = 'search-input-wrap';
-
-    const leading = document.createElement('span');
-    leading.className = 'search-input-icon';
-    leading.appendChild(icon('search', 14));
-
-    const input = document.createElement('input');
-    input.type = 'search';
-    input.className = 'search-input';
-    input.placeholder = SEARCH_PLACEHOLDER;
-    input.autocomplete = 'off';
-    input.spellcheck = false;
-    input.setAttribute('aria-label', 'Search stations');
-    input.value = initialQ;
-
-    const clearBtn = document.createElement('button');
-    clearBtn.type = 'button';
-    clearBtn.className = 'search-clear';
-    clearBtn.setAttribute('aria-label', 'Clear search');
-    clearBtn.appendChild(icon('x', 12));
-    clearBtn.hidden = !initialQ;
+    const { wrap, input } = pillInput({
+      placeholder:  SEARCH_PLACEHOLDER,
+      ariaLabel:    'Search stations',
+      initialValue: initialQ,
+      onInput:      (value) => handleInput(value),
+    });
 
     const pending = document.createElement('span');
     pending.className = 'search-pending';
     pending.setAttribute('aria-hidden', 'true');
     pending.hidden = true;
-
-    wrap.appendChild(leading);
-    wrap.appendChild(input);
-    wrap.appendChild(clearBtn);
     wrap.appendChild(pending);
 
     // --- "Include podcasts" toggle (default ON; sessionStorage) -------
@@ -568,7 +548,6 @@ export default defineView({
       const q = value.trim();
       writeHash(q);
       clearDebounce();
-      clearBtn.hidden = q.length === 0;
       if (!q) {
         inFlightToken++;
         pending.hidden = true;
@@ -661,13 +640,6 @@ export default defineView({
           popularEl.appendChild(p2);
         });
     }
-
-    input.addEventListener('input', (ev) => handleInput(ev.target.value));
-    clearBtn.addEventListener('click', () => {
-      input.value = '';
-      handleInput('');
-      input.focus();
-    });
 
     // Toggle change re-runs the active search with the new filter.
     toggleInput.addEventListener('change', () => {

--- a/admin/app/views/search.js
+++ b/admin/app/views/search.js
@@ -233,7 +233,6 @@ function drillSearchRow(entry, norm) {
 
   const art = document.createElement('span');
   art.className = 'station-art';
-  art.setAttribute('style', 'width:40px;height:40px');
   if (norm.image) {
     const img = document.createElement('img');
     img.className = 'station-art__img';
@@ -323,7 +322,6 @@ function unavailableSection(entries) {
 
     const art = document.createElement('span');
     art.className = 'station-art';
-    art.setAttribute('style', 'width:40px;height:40px');
     if (entries[i] && typeof entries[i].image === 'string' && entries[i].image) {
       const img = document.createElement('img');
       img.className = 'station-art__img';

--- a/admin/app/views/settings.js
+++ b/admin/app/views/settings.js
@@ -37,7 +37,9 @@ export default defineView({
   mount(root, store, _ctx, env) {
     mount(root, html`
       <section class="settings-view" data-view="settings">
-        <h1 class="settings-title">Settings</h1>
+        <div class="page-title-bar">
+          <h1 class="page-title">Settings</h1>
+        </div>
         <div class="settings-cards"></div>
       </section>
     `);

--- a/admin/app/views/settings.js
+++ b/admin/app/views/settings.js
@@ -36,7 +36,7 @@ const DEFAULT_OPEN = new Set(['appearance']);
 export default defineView({
   mount(root, store, _ctx, env) {
     mount(root, html`
-      <section class="settings-view" data-view="settings">
+      <section class="page settings-view" data-view="settings">
         <div class="page-title-bar">
           <h1 class="page-title">Settings</h1>
         </div>

--- a/admin/app/views/station.js
+++ b/admin/app/views/station.js
@@ -143,7 +143,7 @@ function renderSkeleton(root, sid) {
   assignBox.appendChild(buildAssignGrid());
 
   mount(root, html`
-    <section class="station-detail" data-view="station" data-sid="${sid}">
+    <section class="page station-detail" data-view="station" data-sid="${sid}">
       ${backBar}
       <header class="station-header">
         <div class="station-art" hidden></div>

--- a/admin/e2e/README.md
+++ b/admin/e2e/README.md
@@ -1,16 +1,19 @@
 # admin/e2e — Playwright smoke suite
 
 End-to-end coverage for the admin SPA, running against a deployed admin
-on a Bose SoundTouch speaker. This is the verification gate before
-human-in-the-loop review for the 0.4.2 TuneIn rewrite.
+on a Bose SoundTouch speaker. The suite was scaffolded as the
+verification gate for the 0.4.2 TuneIn rewrite and has grown alongside
+the admin since; new specs land here whenever a slice ships behaviour
+that the unit suite can't pin without a real browser + speaker.
 
 ## Prerequisites
 
 - **Node.js** ≥ 18 (project standardises on 20 LTS).
 - **Playwright browsers** (Chromium is enough for this suite).
-- A speaker on your network running the resolver from `resolver/install.sh`
-  with the admin SPA deployed via `admin/deploy.sh`. The project's test
-  speaker is **Bo** at `192.168.178.36:8181`.
+- A speaker on your network running the resolver and the admin SPA
+  deployed via `admin/deploy.sh`. The default `BOSE_HOST` in
+  `playwright.config.js` points at the project's test speaker; override
+  via the `BOSE_HOST` env var to target your own.
 
 ## First-time setup
 
@@ -27,11 +30,11 @@ repo, and the directory is git-ignored.
 ## Running
 
 ```bash
-# Run the full suite against the default host (Bo at 192.168.178.36).
+# Run the full suite against the default host (the project test speaker).
 npm test
 
 # Target a different speaker.
-BOSE_HOST=192.168.178.42 npm test
+BOSE_HOST=<speaker-ip> npm test
 
 # Watch it run with a real browser window.
 npm run test:headed
@@ -62,6 +65,9 @@ single-spec dev runs (e.g. `npx playwright test tests/play.spec.js
 | `search.spec.js`       | #80 | "Folk Alley" yields a p-prefix row with inline Play; toggling "Include podcasts" off removes p-prefix rows. |
 | `show-drill.spec.js`   | #81 | Show drill renders topic rows; tapping a topic's Play icon fires the /play CGI. |
 | `local-polish.spec.js` | #82 / #85 | "Browse all of <country>" card, retired-annotation guard on a live tiny-country drill (#85), every `<img loading="lazy">`, `related` chips, station-detail CTA reads "Play". |
+| `station-redirect.spec.js` | #86 | `#/station/p<N>` and `#/station/t<N>` redirect to the browse view (no dead-end on the not-found placeholder); unknown prefixes still 404; `s`-sids unaffected. |
+| `transport-controls.spec.js` | #88 | Buffering indicator on the now-playing play button (MITM `BUFFERING_STATE`); Prev/Next enable on a topic-list drill and fire `/play` with the neighbour topic id. |
+| `mobile-overflow.spec.js` | #119 | Phone-viewport horizontal-overflow guard for every primary view + the station-detail / preset-modal carriers. |
 | `full-smoke.spec.js`   | —   | Orchestrator entry — writes `test-results/0.4.2-smoke-report.md` summarising the run. |
 
 ## Patterns
@@ -93,31 +99,10 @@ The reporter is wired into `playwright.config.js`; `--reporter=line`
 overrides the config and skips it (handy for single-spec dev iteration
 where the report is not needed).
 
-## Deferred — orchestrator run
-
-**The orchestrator run + closing comment on issue #83 is deferred.**
-
-During the scaffolding pass (Wave 7 of the 0.4.2 milestone) the user's
-internet was down, and Bo's TuneIn-dependent routes would have produced
-spurious failures against the upstream. The suite is structurally
-complete: every spec ships with assertions matching its slice's
-acceptance criteria, the standard listener block is wired in, and the
-MITM error path is hooked up.
-
-Once connectivity returns:
-
-1. `cd admin/e2e && npm install && npx playwright install chromium`
-2. `BOSE_HOST=192.168.178.36 npm test`
-3. Read `test-results/0.4.2-smoke-report.md` + the HTML report at
-   `playwright-report/`.
-4. Post the report as a closing comment on
-   [issue #83](https://github.com/skarl/bose-soundtouch-resurrect/issues/83)
-   if every spec passes, or as a follow-up comment naming the
-   originating slice issue(s) if any fail.
-
 ## Where this fits
 
-The unit-test suite (`admin/test/*.js`) covers reshape, validators, and
-WS message handling in pure JS — no browser, no speaker. This suite
-covers the rendered DOM + the live speaker. They are complementary;
-both should pass before a 0.4.x tag is cut.
+The unit-test suite (`admin/test/*.js`) covers reshape, validators,
+WebSocket dispatch, render helpers, and favourites logic in pure JS —
+no browser, no speaker. This suite covers the rendered DOM + the live
+speaker. They are complementary; both should pass before a release tag
+is cut.

--- a/admin/e2e/package.json
+++ b/admin/e2e/package.json
@@ -2,7 +2,7 @@
   "name": "bose-soundtouch-admin-e2e",
   "private": true,
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.7.1",
   "description": "End-to-end Playwright suite for the admin SPA. Targets a deployed admin on a Bose SoundTouch speaker (default: Bo, the project's test speaker) via the BOSE_HOST env var.",
   "scripts": {
     "test": "playwright test",

--- a/admin/style.css
+++ b/admin/style.css
@@ -1031,9 +1031,11 @@ main {
   margin: 0 0 0.75rem;
 }
 
-/* Pill-shaped input with leading search glyph + trailing clear button.
-   The wrapper is the visible border, the <input> is borderless inside. */
-.search-input-wrap {
+/* Pill-shaped input with leading glyph + trailing clear button. The
+   wrapper is the visible border, the <input> is borderless inside.
+   Namespaced .pill-input* so non-search callers (favourites filter,
+   future browse-text-filter) can reuse the shell. */
+.pill-input-wrap {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1046,17 +1048,17 @@ main {
   transition: border-color 120ms ease, background 120ms ease;
 }
 
-.search-input-wrap:focus-within {
+.pill-input-wrap:focus-within {
   border-color: var(--accent);
   background: var(--bg);
   color: var(--fg);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .search-input-wrap { transition: none; }
+  .pill-input-wrap { transition: none; }
 }
 
-.search-input {
+.pill-input {
   flex: 1 1 auto;
   min-width: 0;
   font: inherit;
@@ -1068,16 +1070,16 @@ main {
   padding: 0;
 }
 
-.search-input::placeholder { color: var(--muted); }
+.pill-input::placeholder { color: var(--muted); }
 
-.search-input-icon {
+.pill-input-icon {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
   color: var(--muted);
 }
 
-.search-clear {
+.pill-input-clear {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1090,7 +1092,7 @@ main {
   cursor: pointer;
 }
 
-.search-clear:hover { color: var(--fg); background: var(--surface-hi); }
+.pill-input-clear:hover { color: var(--fg); background: var(--surface-hi); }
 
 .search-pending {
   display: inline-block;

--- a/admin/style.css
+++ b/admin/style.css
@@ -242,17 +242,33 @@ main {
 .conn-pill[data-state="reconnecting"] { color: var(--pill-amber); }
 .conn-pill[data-state="polling"]      { color: var(--fg-muted);   }
 
+/* --- page wrapper (shared outer chrome for top-level views) ------ */
+
+/* Single seam owning the per-view column rhythm. Outer padding +
+   max-width come from .shell-body; .page only contributes the vertical
+   gap between section blocks (page-title-bar, body, etc.) and a
+   consistent flex-column shape so individual views don't reinvent it.
+   No max-width here — keep it full-width like Favourites; the
+   .shell-body cap (720/880px) is the single horizontal constraint. */
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 /* --- page title (shared across top-level views) ------------------ */
 
 /* Flex container that puts the page heading on one row with any
    sibling top-of-page affordance (filter input, action button, etc.).
-   Stacks on narrow viewports so the title keeps its full width. */
+   Stacks on narrow viewports so the title keeps its full width. The
+   bottom margin is 0 — .page's gap rule owns the spacing to the next
+   block so the title-bar doesn't double-space. */
 .page-title-bar {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 0.5rem;
-  margin: 0 0 1rem;
+  margin: 0;
 }
 
 @media (min-width: 480px) {
@@ -286,7 +302,7 @@ main {
   display: flex;
   gap: 4px;
   padding: 3px;
-  margin: 0.75rem 0 0.5rem;
+  margin: 0;
   background: var(--surface-hi);
   border-radius: 8px;
 }
@@ -405,11 +421,7 @@ main {
 
 /* --- now-playing view (compact card + 3-col preset grid) --------- */
 
-.np-view {
-  display: flex;
-  flex-direction: column;
-  gap: 0.875rem;
-}
+/* Outer chrome (padding, max-width, gap) lives in .page. */
 
 /* Single composite card: tinted top region (art + metadata + transport)
    sitting above a thin volume row separated by a border. The hero tint
@@ -1036,7 +1048,7 @@ main {
   z-index: 5;
   background: var(--bg);
   padding: 0.5rem 0;
-  margin: 0 0 0.75rem;
+  margin: 0;
 }
 
 /* Pill-shaped input with leading glyph + trailing clear button. The
@@ -1203,11 +1215,7 @@ main {
 
 /* --- station detail ---------------------------------------------- */
 
-.station-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
+/* Outer chrome (padding, max-width, gap) lives in .page. */
 
 .station-header {
   display: flex;
@@ -1290,10 +1298,8 @@ main {
 .fav-heart[hidden] { display: none; }
 
 /* Favourites tab body — plain list. The empty state mirrors the
- * search-empty hint style: a faint header + one-line tip. */
-.favorites {
-  padding: 1rem;
-}
+ * search-empty hint style: a faint header + one-line tip. Outer
+ * chrome (padding, max-width, gap) lives in .page. */
 .favorites-empty {
   color: var(--muted);
   padding: 2rem 0;
@@ -1788,12 +1794,8 @@ main {
 
 /* --- settings view (#/settings) ---------------------------------- */
 
-.settings-view {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  max-width: 640px;
-}
+/* Outer chrome (padding, max-width, gap) lives in .page. The cards
+   container owns its own tighter inter-card gap below. */
 
 /* Card-with-chevron collapsibles. The header is a real <button>, so
    focus-visible + Enter/Space + aria-expanded all work for free; the
@@ -3427,7 +3429,7 @@ select.settings-input {
   align-items: center;
   gap: 10px;
   padding: 4px 8px 4px 4px;
-  margin: 0 0 8px;
+  margin: 0;
   background: var(--surface);
   border-radius: 999px;
   min-height: 32px;

--- a/admin/style.css
+++ b/admin/style.css
@@ -997,7 +997,7 @@ main {
   top: 0;
   z-index: 5;
   background: var(--bg);
-  padding: 0.5rem 0;
+  padding: 0;
   margin: 0;
 }
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -265,9 +265,17 @@ main {
 }
 
 .page-title {
-  font-size: 1.5rem;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 14px;
   margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
 /* --- browse view ------------------------------------------------- */
@@ -1324,7 +1332,11 @@ main {
 .favorites-list {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  overflow: hidden;
 }
 
 /* Favourites CRUD row — reuses the .station-row pill skin (#134) and
@@ -1339,9 +1351,12 @@ main {
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  border-bottom: 0;
-  border-radius: 6px;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
   width: 100%;
+}
+.favorites-list .station-row--crud:last-child {
+  border-bottom: 0;
 }
 .station-row--crud.is-expanded {
   background: var(--surface-hi);

--- a/admin/style.css
+++ b/admin/style.css
@@ -242,6 +242,34 @@ main {
 .conn-pill[data-state="reconnecting"] { color: var(--pill-amber); }
 .conn-pill[data-state="polling"]      { color: var(--fg-muted);   }
 
+/* --- page title (shared across top-level views) ------------------ */
+
+/* Flex container that puts the page heading on one row with any
+   sibling top-of-page affordance (filter input, action button, etc.).
+   Stacks on narrow viewports so the title keeps its full width. */
+.page-title-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+
+@media (min-width: 480px) {
+  .page-title-bar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+}
+
+.page-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
 /* --- browse view ------------------------------------------------- */
 
 /* Segmented 3-tab control. Sunken track + active pill matches
@@ -1256,10 +1284,6 @@ main {
 .favorites {
   padding: 1rem;
 }
-.favorites-header h1 {
-  font-size: 1.5rem;
-  margin: 0 0 1rem;
-}
 .favorites-empty {
   color: var(--muted);
   padding: 2rem 0;
@@ -1775,12 +1799,6 @@ main {
   flex-direction: column;
   gap: 0.5rem;
   max-width: 640px;
-}
-
-.settings-title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin: 0 0 0.25rem;
 }
 
 /* Card-with-chevron collapsibles. The header is a real <button>, so

--- a/admin/style.css
+++ b/admin/style.css
@@ -990,56 +990,6 @@ main {
   .np-mute { transition: none; }
 }
 
-.preset-row {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.5rem;
-}
-
-.preset-slot {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.5rem;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.8rem;
-  min-height: 5rem;
-  position: relative;
-}
-
-.preset-slot.empty {
-  color: var(--muted);
-  background: var(--surface);
-}
-
-.preset-num {
-  position: absolute;
-  top: 0.25rem;
-  left: 0.4rem;
-  font-size: 0.7rem;
-  color: var(--muted);
-  font-weight: 600;
-}
-
-.preset-art {
-  width: 2rem;
-  height: 2rem;
-  object-fit: cover;
-  border-radius: 3px;
-  margin-top: 0.5rem;
-}
-
-.preset-name {
-  display: block;
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 /* --- search view ------------------------------------------------- */
 
 .search-bar {
@@ -1223,16 +1173,19 @@ main {
   align-items: flex-start;
 }
 
-.station-art {
+/* Larger station-art variant used by the station-detail header. The
+   base .station-art rules (display, overflow, border-radius, bg) live
+   in the `--- station-art` block; this scopes only the size and
+   header-specific override of the background token. */
+.station-header .station-art {
   width: 5rem;
   height: 5rem;
   flex: 0 0 auto;
   background: var(--border);
   border-radius: 6px;
-  overflow: hidden;
 }
 
-.station-art img {
+.station-header .station-art img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1589,12 +1542,6 @@ main {
   margin: 0 0 0.5rem;
   color: var(--muted);
   font-size: 0.9rem;
-}
-
-.station-assign-row {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.5rem;
 }
 
 .station-assign-btn {
@@ -2120,22 +2067,12 @@ select.settings-input {
       padding: 8px 12px;
     }
 
-    /* Preset assign / row layouts also shift to 3-up on narrow views. */
-    .preset-row,
-    .station-assign-row {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
     .station-test-play {
       min-height: 3.5rem;
     }
 
     .np-preset {
       min-height: 92px;
-    }
-
-    .preset-slot {
-      min-height: 5.5rem;
     }
 
     /* Station detail: stack header art above text. */
@@ -2213,6 +2150,63 @@ select.settings-input {
 .confirm-btn--danger:hover {
   background: #a93226;
   border-color: #a93226;
+}
+
+/* --- speaker-unreachable overlay (api.js upstream-failure) -------- */
+/* Blocking modal raised when the speaker proxy reports the device is
+   unreachable. Higher z-index than .confirm-backdrop so it always
+   trumps any in-flight confirm dialog. */
+
+.speaker-unreachable {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  font: inherit;
+}
+
+.speaker-unreachable__card {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.25rem 1rem;
+  max-width: 28rem;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.speaker-unreachable__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.speaker-unreachable__body {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.speaker-unreachable__retry {
+  align-self: flex-end;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 /* --- prefers-reduced-motion -------------------------------------- */
@@ -3592,14 +3586,9 @@ a.browse-bar__crumb:focus-visible {
   font-size: 0.8rem;
 }
 
-/* Search empty state — single stacked column. The earlier two-column
-   grid was the polish that didn't match the mockup. */
-.search-empty {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
+/* Search empty state — single stacked column. Layout for the wrap
+   itself lives at the `.search-results, .search-empty` block above
+   in the search view section. */
 .search-empty-section {
   margin: 0;
   display: flex;

--- a/admin/style.css
+++ b/admin/style.css
@@ -864,7 +864,7 @@ main {
 
 /* Brief flash on the Favourites tab when arriving via
    `#/favorites?focus=<id>` (long-press from the Now-Playing grid). */
-.favorites-row.is-focused {
+.station-row--crud.is-focused {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
   animation: favorites-focus-flash 1400ms ease-out;
@@ -876,7 +876,7 @@ main {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .favorites-row.is-focused { animation: none; }
+  .station-row--crud.is-focused { animation: none; }
 }
 
 /* STANDBY / asleep state */
@@ -1305,32 +1305,30 @@ main {
   gap: 0.25rem;
 }
 
-/* Favourites row — [drag-handle stub] [body] [pencil] [trash]. The
- * body is a flex-1 button so the row can be tapped to play without
- * stealing pencil/trash click targets. Pencil expands the row in
- * place: the form is appended as a sibling under the row controls and
- * `.is-expanded` lifts the row's background so the form reads as
- * "part of this entry". */
-.favorites-row {
+/* Favourites CRUD row — reuses the .station-row pill skin (#134) and
+ * flips the layout to a 4-slot grid: drag-handle, art+body, pencil,
+ * trash. The shared .station-row base rules give us art sizing, name
+ * typography, and the meta-line treatment for free; the modifier
+ * overrides the flex layout to grid + drops the bottom border so the
+ * row reads as a pill in the list, not a list-item with a divider. */
+.station-row--crud {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto auto 1fr auto auto;
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
+  border-bottom: 0;
   border-radius: 6px;
-  background: transparent;
-  transition: background 120ms ease;
+  width: 100%;
 }
-.favorites-row.is-expanded {
+.station-row--crud.is-expanded {
   background: var(--surface-hi);
-  /* Make the form span the full row when expanded. */
-  grid-template-columns: auto 1fr auto auto;
 }
-.favorites-row.is-expanded .favorites-row__edit {
+.station-row--crud.is-expanded .station-row__edit {
   grid-column: 1 / -1;
 }
 
-.favorites-row__drag {
+.station-row__drag {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1343,11 +1341,11 @@ main {
   touch-action: none;
   user-select: none;
 }
-.favorites-row__drag:active { cursor: grabbing; }
+.station-row__drag:active { cursor: grabbing; }
 
 /* Source row while a drag is in flight — fade it so the ghost reads
  * as "this is where the row currently lives". */
-.favorites-row.is-dragging {
+.station-row--crud.is-dragging {
   opacity: 0.4;
 }
 
@@ -1378,61 +1376,8 @@ main {
   overflow: hidden;
 }
 
-.favorites-row__body {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 4px 6px;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  text-align: left;
-  font: inherit;
-  cursor: pointer;
-  min-width: 0;
-  border-radius: 4px;
-  transition: background 120ms ease;
-}
-.favorites-row__body:hover,
-.favorites-row__body:focus-visible {
-  background: var(--surface-hi);
-}
-.favorites-row__body:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-.favorites-row__body.is-disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
-.favorites-row__text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-.favorites-row__name {
-  font-weight: 500;
-  font-size: 13.5px;
-  line-height: 1.2;
-  color: var(--fg);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-.favorites-row__note {
-  font-size: 11.5px;
-  color: var(--muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-
-.favorites-row__edit-btn,
-.favorites-row__delete-btn {
+.station-row__crud-edit,
+.station-row__crud-delete {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1446,20 +1391,21 @@ main {
   border-radius: 4px;
   transition: color 120ms ease, background 120ms ease;
 }
-.favorites-row__edit-btn:hover,
-.favorites-row__edit-btn:focus-visible,
-.favorites-row__delete-btn:hover,
-.favorites-row__delete-btn:focus-visible {
+.station-row__crud-edit:hover,
+.station-row__crud-edit:focus-visible,
+.station-row__crud-delete:hover,
+.station-row__crud-delete:focus-visible {
   color: var(--fg);
   background: var(--surface-hi);
 }
-.favorites-row__delete-btn:hover,
-.favorites-row__delete-btn:focus-visible {
+.station-row__crud-delete:hover,
+.station-row__crud-delete:focus-visible {
   color: var(--danger, #c0392b);
 }
 
-/* Inline edit form. Three single-line inputs + Save / Cancel. */
-.favorites-row__edit {
+/* Inline edit form, expanded under a CRUD row when the pencil is
+ * tapped. Three single-line inputs + Save / Cancel. */
+.station-row__edit {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1467,16 +1413,16 @@ main {
   margin-top: 6px;
   border-top: 1px solid var(--border);
 }
-.favorites-edit__field {
+.station-row__edit-field {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.favorites-edit__label {
+.station-row__edit-label {
   font-size: 11.5px;
   color: var(--muted);
 }
-.favorites-edit__input {
+.station-row__edit-input {
   font: inherit;
   padding: 6px 8px;
   border: 1px solid var(--border);
@@ -1484,17 +1430,17 @@ main {
   background: var(--surface);
   color: var(--fg);
 }
-.favorites-edit__input:focus-visible {
+.station-row__edit-input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.favorites-edit__actions {
+.station-row__edit-actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
   margin-top: 4px;
 }
-.favorites-edit__btn {
+.station-row__edit-btn {
   font: inherit;
   padding: 6px 12px;
   border: 1px solid var(--border);
@@ -1503,7 +1449,7 @@ main {
   color: var(--fg);
   cursor: pointer;
 }
-.favorites-edit__btn--save {
+.station-row__edit-btn--save {
   background: var(--accent);
   color: var(--accent-fg, white);
   border-color: var(--accent);

--- a/admin/style.css
+++ b/admin/style.css
@@ -2910,6 +2910,9 @@ select.settings-input {
   text-transform: none;
   color: var(--text-dim, var(--fg-muted));
   white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .section-h--inline {
@@ -3623,6 +3626,7 @@ a.browse-bar__crumb:focus-visible {
 
 .settings-segment__opt {
   flex: 1 1 0;
+  min-width: 0;
   font: inherit;
   font-size: 0.82rem;
   font-weight: 500;
@@ -3632,6 +3636,9 @@ a.browse-bar__crumb:focus-visible {
   background: transparent;
   color: var(--muted);
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -1299,6 +1299,28 @@ main {
 .favorites-empty p {
   margin: 0;
 }
+.favorites-empty__clear {
+  margin-top: 0.75rem;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--accent, #4a90e2);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/* Filter input mounted in .page-title-bar — caps the width on wide
+ * viewports so the title still gets a useful share of the row. The
+ * .page-title-bar media query already stacks → row at 480 px. */
+.favorites-filter {
+  flex: 1 1 auto;
+}
+@media (min-width: 480px) {
+  .favorites-filter {
+    flex: 0 1 320px;
+  }
+}
 .favorites-list {
   display: flex;
   flex-direction: column;
@@ -1342,6 +1364,15 @@ main {
   user-select: none;
 }
 .station-row__drag:active { cursor: grabbing; }
+
+/* When the favourites filter is active the drag handle is no-op (#135).
+ * Fade + block pointer interaction so the affordance reads as inactive
+ * without being yanked from the layout. */
+.station-row__drag[aria-disabled="true"] {
+  opacity: 0.25;
+  cursor: default;
+  pointer-events: none;
+}
 
 /* Source row while a drag is in flight — fade it so the ghost reads
  * as "this is where the row currently lives". */

--- a/admin/style.css
+++ b/admin/style.css
@@ -2442,6 +2442,7 @@ select.settings-input {
   border-top: 1px solid var(--border);
   background: var(--surface);
   animation: shell-mini-in 180ms ease-out;
+  min-width: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/admin/test/components-demo.html
+++ b/admin/test/components-demo.html
@@ -175,19 +175,23 @@
   }
 
   // --- station art --------------------------------------------------
+  // Demo wraps each art slot in a sized .station-row so the
+  // `.station-row .station-art` rule picks up the 40x40 dimensions.
   const artRow = document.getElementById('art-row');
   for (const [label, opts] of [
-    ['url',      { url: 'https://placehold.co/96x96/png',     name: 'Real',       size: 96 }],
-    ['no url',   { url: '',                                   name: 'BBC Radio 1', size: 96 }],
-    ['no name',  { url: '',                                   name: '',           size: 96 }],
-    ['48 px',    { url: '',                                   name: 'Small',      size: 48 }],
+    ['url',      { url: 'https://placehold.co/96x96/png',     name: 'Real' }],
+    ['no url',   { url: '',                                   name: 'BBC Radio 1' }],
+    ['no name',  { url: '',                                   name: '' }],
+    ['fallback', { url: '',                                   name: 'Small' }],
   ]) {
     const group = document.createElement('div');
     group.className = 'group';
-    const a = stationArt(opts);
+    const sized = document.createElement('div');
+    sized.className = 'station-row';
+    sized.appendChild(stationArt(opts));
     const lbl = document.createElement('span');
     lbl.textContent = label;
-    group.appendChild(a);
+    group.appendChild(sized);
     group.appendChild(lbl);
     artRow.appendChild(group);
   }

--- a/admin/test/test_browse_outline.js
+++ b/admin/test/test_browse_outline.js
@@ -31,10 +31,6 @@ const {
   skeleton,
   errorNode,
   pluralize,
-  setChildCrumbs,
-  setCurrentParts,
-  _setChildCrumbsForTest,
-  _setCurrentPartsForTest,
 } = await import('../app/views/browse/outline-render.js');
 
 function classOf(el) { return el.getAttribute('class') || ''; }
@@ -66,43 +62,26 @@ function findAllBy(root, predicate) {
 // --- drillHashFor contract ------------------------------------------
 
 test('drillHashFor composes id / c / filter / pivot / offset query keys', () => {
-  _setChildCrumbsForTest([]);
-  const h = drillHashFor({ id: 'g79', filter: 'l109', offset: '20' });
+  const h = drillHashFor({ id: 'g79', filter: 'l109', offset: '20' }, []);
   assert.match(h, /^#\/browse\?/);
   assert.match(h, /id=g79/);
   assert.match(h, /filter=l109/);
   assert.match(h, /offset=20/);
 });
 
-test('drillHashFor reads module-level _childCrumbs as the default from= prefix', () => {
-  _setChildCrumbsForTest(['music', 'g79']);
-  const h = drillHashFor({ id: 'c424724' });
+test('drillHashFor embeds the supplied crumbs as the from= prefix', () => {
+  const h = drillHashFor({ id: 'c424724' }, ['music', 'g79']);
   assert.match(h, /from=music%2Cg79/);
-  _setChildCrumbsForTest([]);
 });
 
-test('drillHashFor accepts an explicit crumbs override (used by the Back link)', () => {
-  _setChildCrumbsForTest(['music', 'g79']);
+test('drillHashFor accepts an explicit crumbs argument (used by the Back link)', () => {
   const h = drillHashFor({ id: 'g79' }, ['music']);
   assert.match(h, /from=music(?:&|$)/);
-  // The module-level value is ignored when the caller passes one in.
-  assert.equal(h.includes('music%2Cg79'), false);
-  _setChildCrumbsForTest([]);
 });
 
 test('drillHashFor with empty crumbs array omits from= entirely', () => {
-  _setChildCrumbsForTest([]);
-  const h = drillHashFor({ c: 'music' });
+  const h = drillHashFor({ c: 'music' }, []);
   assert.equal(h.includes('from='), false);
-});
-
-// --- setChildCrumbs / _setChildCrumbsForTest are equivalent ---------
-
-test('setChildCrumbs is the production setter for the crumb prefix', () => {
-  setChildCrumbs(['g1', 'g2']);
-  const h = drillHashFor({ id: 'g3' });
-  assert.match(h, /from=g1%2Cg2/);
-  setChildCrumbs([]);
 });
 
 // --- drillPartsFor / drillPartsForUrl --------------------------------
@@ -540,27 +519,23 @@ test('renderEntry does not fire a fetch when priming the cache (#105)', async ()
 //
 // Refinement chips (renderPivotChips / renderRelatedChips) compose
 // their hrefs by APPENDING to the current page's filters, not
-// replacing them. The composer reads `_currentParts` (set by
-// browse.js before each drill mount); tests drive it through
-// _setCurrentPartsForTest.
+// replacing them. The composer reads `ctx.currentParts`; tests pass
+// ctx directly at the call site.
 
 test('drillHashFor emits parts.filters: [N] as a comma-joined filter= — #106', () => {
-  _setChildCrumbsForTest([]);
-  const h = drillHashFor({ id: 'r101821', filters: ['g26', 'l170'] });
+  const h = drillHashFor({ id: 'r101821', filters: ['g26', 'l170'] }, []);
   // URLSearchParams encodes the comma as %2C; the hash router decodes
   // it back to ',' on the receiving end. Either form is wire-correct.
   assert.match(h, /filter=g26%2Cl170/);
 });
 
 test('drillHashFor falls back to legacy parts.filter when filters is absent — #106 back-compat', () => {
-  _setChildCrumbsForTest([]);
-  const h = drillHashFor({ id: 'r101821', filter: 'g26,l170' });
+  const h = drillHashFor({ id: 'r101821', filter: 'g26,l170' }, []);
   assert.match(h, /filter=g26%2Cl170/);
 });
 
 test('drillHashFor with empty parts.filters omits filter= entirely — #106', () => {
-  _setChildCrumbsForTest([]);
-  const h = drillHashFor({ id: 'r101821', filters: [] });
+  const h = drillHashFor({ id: 'r101821', filters: [] }, []);
   assert.doesNotMatch(h, /filter=/);
 });
 
@@ -568,55 +543,46 @@ test('renderPivotChips appends to current page filters when composing the chip h
   // Current page is Bayreuth refined by Country (g26). A pivot chip
   // adding a Language filter (l170) must produce filter=g26,l170 on
   // its href so the click stacks rather than replaces.
-  _setCurrentPartsForTest({ id: 'r101821', filters: ['g26'] });
-  try {
-    const wrap = renderPivotChips([{
-      url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
-      label: 'Hungarian',
-      axis:  'language',
-    }]);
-    const chip = findFirstByClass(wrap, 'browse-pivot');
-    assert.ok(chip);
-    const href = chip.getAttribute('href');
-    assert.match(href, /filter=g26%2Cl170/, `expected filter=g26,l170 in ${href}`);
-    assert.match(href, /id=r101821/);
-  } finally {
-    _setCurrentPartsForTest(null);
-  }
+  const ctx = { childCrumbs: [], currentParts: { id: 'r101821', filters: ['g26'] } };
+  const wrap = renderPivotChips([{
+    url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
+    label: 'Hungarian',
+    axis:  'language',
+  }], ctx);
+  const chip = findFirstByClass(wrap, 'browse-pivot');
+  assert.ok(chip);
+  const href = chip.getAttribute('href');
+  assert.match(href, /filter=g26%2Cl170/, `expected filter=g26,l170 in ${href}`);
+  assert.match(href, /id=r101821/);
 });
 
 test('renderRelatedChips appends to current page filters when composing chip hrefs — #106', () => {
-  _setCurrentPartsForTest({ id: 'r101821', filters: ['g26'] });
-  try {
-    const wrap = renderRelatedChips([
-      {
-        text: 'Hungarian',
-        URL:  'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
-        key:  'pivotLanguage',
-      },
-    ]);
-    const chip = findFirstByClass(wrap, 'browse-pivot');
-    assert.ok(chip);
-    const href = chip.getAttribute('href');
-    assert.match(href, /filter=g26%2Cl170/, `expected filter=g26,l170 in ${href}`);
-  } finally {
-    _setCurrentPartsForTest(null);
-  }
+  const ctx = { childCrumbs: [], currentParts: { id: 'r101821', filters: ['g26'] } };
+  const wrap = renderRelatedChips([
+    {
+      text: 'Hungarian',
+      URL:  'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
+      key:  'pivotLanguage',
+    },
+  ], ctx);
+  const chip = findFirstByClass(wrap, 'browse-pivot');
+  assert.ok(chip);
+  const href = chip.getAttribute('href');
+  assert.match(href, /filter=g26%2Cl170/, `expected filter=g26,l170 in ${href}`);
 });
 
 test('renderPivotChips with no current parts emits the chip URL verbatim — #106', () => {
   // No current parts (root view or test default) — chip composition
   // falls through to the URL-derived parts unchanged.
-  _setCurrentPartsForTest(null);
   const wrap = renderPivotChips([{
     url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
     label: 'Hungarian',
     axis:  'language',
-  }]);
+  }], { childCrumbs: [], currentParts: null });
   const chip = findFirstByClass(wrap, 'browse-pivot');
   const href = chip.getAttribute('href');
   assert.match(href, /filter=l170/);
-  assert.doesNotMatch(href, /g26/, `no inherited filters when _currentParts is null: ${href}`);
+  assert.doesNotMatch(href, /g26/, `no inherited filters when currentParts is null: ${href}`);
 });
 
 test('renderPivotChips cumulative stack — Bayreuth → +Country → +German lands on filter=g26,l170 — #106', () => {
@@ -625,40 +591,32 @@ test('renderPivotChips cumulative stack — Bayreuth → +Country → +German la
   // Step 2: clicks Country chip → URL adds filter=g26.
   // Step 3: clicks Language chip with current parts {filters: ['g26']}
   //         → URL becomes filter=g26,l170.
-  _setCurrentPartsForTest({ id: 'r101821', filters: ['g26'] });
-  try {
-    const wrap = renderPivotChips([{
-      url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
-      label: 'German',
-      axis:  'language',
-    }]);
-    const chip = findFirstByClass(wrap, 'browse-pivot');
-    const href = chip.getAttribute('href');
-    assert.match(href, /filter=g26%2Cl170/, `cumulative stack: ${href}`);
-  } finally {
-    _setCurrentPartsForTest(null);
-  }
+  const ctx = { childCrumbs: [], currentParts: { id: 'r101821', filters: ['g26'] } };
+  const wrap = renderPivotChips([{
+    url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
+    label: 'German',
+    axis:  'language',
+  }], ctx);
+  const chip = findFirstByClass(wrap, 'browse-pivot');
+  const href = chip.getAttribute('href');
+  assert.match(href, /filter=g26%2Cl170/, `cumulative stack: ${href}`);
 });
 
 test('renderPivotChips dedupes when the chip filter is already in current parts — #106', () => {
   // Defence: a chip pointing at a filter that's already active should
   // not appear twice in the URL.
-  _setCurrentPartsForTest({ id: 'r101821', filters: ['g26', 'l170'] });
-  try {
-    const wrap = renderPivotChips([{
-      url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=g26',
-      label: 'Country',
-      axis:  'genre',
-    }]);
-    const chip = findFirstByClass(wrap, 'browse-pivot');
-    const href = chip.getAttribute('href');
-    // The chip's g26 collapses into the existing g26; the URL keeps
-    // both filters but doesn't double up.
-    assert.match(href, /filter=g26%2Cl170/);
-    assert.doesNotMatch(href, /g26%2Cl170%2Cg26/);
-  } finally {
-    _setCurrentPartsForTest(null);
-  }
+  const ctx = { childCrumbs: [], currentParts: { id: 'r101821', filters: ['g26', 'l170'] } };
+  const wrap = renderPivotChips([{
+    url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=g26',
+    label: 'Country',
+    axis:  'genre',
+  }], ctx);
+  const chip = findFirstByClass(wrap, 'browse-pivot');
+  const href = chip.getAttribute('href');
+  // The chip's g26 collapses into the existing g26; the URL keeps
+  // both filters but doesn't double up.
+  assert.match(href, /filter=g26%2Cl170/);
+  assert.doesNotMatch(href, /g26%2Cl170%2Cg26/);
 });
 
 test('drillPartsForUrl surfaces parts.filters: [oneEntry] for single-filter URLs (back-compat) — #106', () => {
@@ -687,19 +645,15 @@ test('primeLabelForChip with parts.filters: [N] keys on the last (new) filter �
   tc.cache.invalidate('tunein.label.l170');
 });
 
-test('setCurrentParts is the production setter for current parts — #106', () => {
-  // Equivalent to _setCurrentPartsForTest; verify both wire the same
-  // module-level value.
-  setCurrentParts({ id: 'r101821', filters: ['g26'] });
-  try {
-    const wrap = renderPivotChips([{
-      url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
-      label: 'Hungarian',
-      axis:  'language',
-    }]);
-    const chip = findFirstByClass(wrap, 'browse-pivot');
-    assert.match(chip.getAttribute('href'), /filter=g26%2Cl170/);
-  } finally {
-    setCurrentParts(null);
-  }
+test('renderPivotChips reads currentParts directly from the supplied ctx — #106', () => {
+  // The ctx object passed at call time is the production drive — no
+  // module-level state lurks underneath it.
+  const ctx = { childCrumbs: [], currentParts: { id: 'r101821', filters: ['g26'] } };
+  const wrap = renderPivotChips([{
+    url:   'http://opml.radiotime.com/Browse.ashx?id=r101821&filter=l170',
+    label: 'Hungarian',
+    axis:  'language',
+  }], ctx);
+  const chip = findFirstByClass(wrap, 'browse-pivot');
+  assert.match(chip.getAttribute('href'), /filter=g26%2Cl170/);
 });

--- a/admin/test/test_components.js
+++ b/admin/test/test_components.js
@@ -25,6 +25,7 @@ const {
   throttleLeadingTrailing,
   stationRow,
   stationCard,
+  pillInput,
 } = await import('../app/components.js');
 
 // --- pill ------------------------------------------------------------
@@ -421,4 +422,112 @@ test('stationCard href: p-prefix sid routes to c=pbrowse show landing', () => {
 test('stationCard href: unknown prefix collapses to "#"', () => {
   const c = stationCard({ sid: 'g42', name: 'Genre card' });
   assert.equal(c.getAttribute('href'), '#');
+});
+
+// --- pillInput -------------------------------------------------------
+
+test('pillInput: builds the .pill-input-wrap shell with leading icon + input', () => {
+  const { wrap, input } = pillInput({
+    placeholder: 'Type…',
+    ariaLabel:   'Search things',
+  });
+  assert.ok(classOf(wrap).includes('pill-input-wrap'));
+  assert.ok(findFirstByClass(wrap, 'pill-input-icon'), 'leading icon slot present');
+  assert.equal(input.tagName, 'input');
+  assert.equal(input.getAttribute('class'), 'pill-input');
+  assert.equal(input.getAttribute('aria-label'), 'Search things');
+  assert.equal(input.getAttribute('placeholder'), 'Type…');
+});
+
+test('pillInput: initialValue pre-fills the input and shows the clear button', () => {
+  const { wrap, input } = pillInput({ initialValue: 'jazz' });
+  assert.equal(input.getAttribute('value'), 'jazz');
+  const clearBtn = findFirstByClass(wrap, 'pill-input-clear');
+  assert.ok(clearBtn, 'clear-X present by default');
+  assert.equal(clearBtn.hidden, false, 'clear-X visible when initial value is non-empty');
+});
+
+test('pillInput: clear-X is hidden when initialValue is empty', () => {
+  const { wrap } = pillInput({ initialValue: '' });
+  const clearBtn = findFirstByClass(wrap, 'pill-input-clear');
+  assert.equal(clearBtn.hidden, true);
+});
+
+test('pillInput: showClear=false omits the clear button entirely', () => {
+  const { wrap } = pillInput({ showClear: false });
+  assert.equal(findFirstByClass(wrap, 'pill-input-clear'), null);
+});
+
+test('pillInput: input event fires onInput with the live value (no debounce)', () => {
+  const calls = [];
+  const { input } = pillInput({
+    onInput: (v) => calls.push(v),
+  });
+  input.setAttribute('value', 'kexp');
+  input.dispatchEvent(ev('input', { target: input }));
+  assert.deepEqual(calls, ['kexp']);
+});
+
+test('pillInput: debounceMs > 0 trailing-debounces onInput', async () => {
+  const calls = [];
+  const { input } = pillInput({
+    debounceMs: 30,
+    onInput: (v) => calls.push(v),
+  });
+  input.setAttribute('value', 'a');
+  input.dispatchEvent(ev('input', { target: input }));
+  input.setAttribute('value', 'ab');
+  input.dispatchEvent(ev('input', { target: input }));
+  input.setAttribute('value', 'abc');
+  input.dispatchEvent(ev('input', { target: input }));
+  assert.deepEqual(calls, [], 'no synchronous fire while debouncing');
+  await new Promise((r) => setTimeout(r, 60));
+  assert.deepEqual(calls, ['abc'], 'only the trailing value fires');
+});
+
+test('pillInput: clear-X click empties input, fires onInput(""), refocuses', () => {
+  const calls = [];
+  const { wrap, input } = pillInput({
+    initialValue: 'folk',
+    onInput: (v) => calls.push(v),
+  });
+  input.setAttribute('value', 'folk');
+  const clearBtn = findFirstByClass(wrap, 'pill-input-clear');
+  globalThis.__focus_target__ = null;
+  clearBtn.dispatchEvent(ev('click'));
+  assert.equal(input.getAttribute('value'), '');
+  assert.equal(clearBtn.hidden, true, 'clear-X hides itself after clearing');
+  assert.deepEqual(calls, ['']);
+  assert.equal(globalThis.__focus_target__, input, 'focus returns to the input');
+});
+
+test('pillInput: setValue() updates the input and fires onInput when changed', () => {
+  const calls = [];
+  const { input, setValue } = pillInput({
+    initialValue: 'one',
+    onInput: (v) => calls.push(v),
+  });
+  setValue('two');
+  assert.equal(input.getAttribute('value'), 'two');
+  assert.deepEqual(calls, ['two']);
+});
+
+test('pillInput: setValue() with the same value is a no-op', () => {
+  const calls = [];
+  const { setValue } = pillInput({
+    initialValue: 'same',
+    onInput: (v) => calls.push(v),
+  });
+  setValue('same');
+  assert.deepEqual(calls, [], 'same value does not re-fire onInput');
+});
+
+test('pillInput: setValue() shows / hides clear-X to match the new value', () => {
+  const { wrap, setValue } = pillInput({ initialValue: '' });
+  const clearBtn = findFirstByClass(wrap, 'pill-input-clear');
+  assert.equal(clearBtn.hidden, true);
+  setValue('something');
+  assert.equal(clearBtn.hidden, false);
+  setValue('');
+  assert.equal(clearBtn.hidden, true);
 });

--- a/admin/test/test_components.js
+++ b/admin/test/test_components.js
@@ -247,7 +247,7 @@ test('equalizer: wraps the .eq icon (3 bars)', () => {
 // --- stationArt ------------------------------------------------------
 
 test('stationArt: with url, the <img> src is set to that url', () => {
-  const a = stationArt({ url: 'http://example/a.png', name: 'Foo', size: 32 });
+  const a = stationArt({ url: 'http://example/a.png', name: 'Foo' });
   const img = a.firstChild;
   assert.equal(img.tagName, 'img');
   assert.equal(img.src, 'http://example/a.png');
@@ -277,13 +277,6 @@ test('stationArt: update({ url }) swaps src in place', () => {
   const img = a.firstChild;
   a.update({ url: 'http://example/new.png' });
   assert.equal(img.src, 'http://example/new.png');
-});
-
-test('stationArt: size prop sets the wrapper width/height', () => {
-  const a = stationArt({ name: 'X', size: 72 });
-  // xmldom keeps style as a string attribute; just probe substrings.
-  const style = a.getAttribute('style') || '';
-  assert.ok(style.includes('72px'), `expected 72px in style, got "${style}"`);
 });
 
 // --- stationRow ------------------------------------------------------

--- a/admin/test/test_crumb_renderer.js
+++ b/admin/test/test_crumb_renderer.js
@@ -30,7 +30,6 @@ const {
 
 const {
   renderEntry,
-  _setChildCrumbsForTest,
 } = await import('../app/views/browse.js');
 
 const { cache, TTL_LABEL } = await import('../app/tunein-cache.js');
@@ -256,27 +255,21 @@ test('renderPillBar trail composes Browse › <Tab> › <Ancestor> › <Current>
 test('renderEntry: child row href embeds the parent crumb stack as from=', () => {
   // Simulate the user being on `?c=music&from=lang` — the next click
   // should produce `from=lang,music` (parent stack + current node).
-  _setChildCrumbsForTest(['lang', 'music']);
-  try {
-    const row = renderEntry({
-      text: 'Folk',
-      URL:  'http://opml.radiotime.com/Browse.ashx?id=g79',
-    });
-    const href = row.getAttribute('href');
-    assert.match(href, /^#\/browse\?/);
-    assert.match(href, /id=g79/);
-    assert.match(href, /from=lang%2Cmusic/, `expected from=lang,music in ${href}`);
-  } finally {
-    _setChildCrumbsForTest([]);
-  }
+  const row = renderEntry({
+    text: 'Folk',
+    URL:  'http://opml.radiotime.com/Browse.ashx?id=g79',
+  }, { childCrumbs: ['lang', 'music'], currentParts: null });
+  const href = row.getAttribute('href');
+  assert.match(href, /^#\/browse\?/);
+  assert.match(href, /id=g79/);
+  assert.match(href, /from=lang%2Cmusic/, `expected from=lang,music in ${href}`);
 });
 
 test('renderEntry: with empty child crumb stack, href has no from= param', () => {
-  _setChildCrumbsForTest([]);
   const row = renderEntry({
     text: 'Genre',
     URL:  'http://opml.radiotime.com/Browse.ashx?id=g22',
-  });
+  }, { childCrumbs: [], currentParts: null });
   const href = row.getAttribute('href');
   assert.equal(href, '#/browse?id=g22', `no from= for root-level child: ${href}`);
 });

--- a/admin/test/test_favorites.js
+++ b/admin/test/test_favorites.js
@@ -27,6 +27,7 @@ const {
   withFavoriteRemoved,
   toggleFavorite,
   favoriteHeart,
+  filterFavorites,
 } = await import('../app/favorites.js');
 
 const { store } = await import('../app/state.js');
@@ -86,6 +87,66 @@ test('withFavoriteRemoved: drops the first match; no-op when missing', () => {
 
   const same = withFavoriteRemoved(base, 'sNope');
   assert.equal(same, base, 'miss returns the original reference');
+});
+
+// --- filterFavorites pure list transform ---------------------------
+
+test('filterFavorites: empty / whitespace query returns the original reference', () => {
+  const list = [{ id: 's1', name: 'A', note: '', art: '' }];
+  assert.equal(filterFavorites(list, ''), list, 'empty string is identity');
+  assert.equal(filterFavorites(list, '   '), list, 'whitespace-only is identity');
+  assert.equal(filterFavorites(list, null), list, 'non-string treated as empty');
+});
+
+test('filterFavorites: substring match against name', () => {
+  const list = [
+    { id: 's1', name: 'KEXP Seattle',  note: '', art: '' },
+    { id: 's2', name: 'BBC Radio 6',   note: '', art: '' },
+    { id: 's3', name: 'Radio Paradise', note: '', art: '' },
+  ];
+  const out = filterFavorites(list, 'radio');
+  assert.equal(out.length, 2);
+  assert.deepEqual(out.map((e) => e.id), ['s2', 's3'], 'order preserved');
+});
+
+test('filterFavorites: case-insensitive', () => {
+  const list = [{ id: 's1', name: 'KEXP', note: '', art: '' }];
+  assert.equal(filterFavorites(list, 'kexp').length, 1);
+  assert.equal(filterFavorites(list, 'KEXP').length, 1);
+  assert.equal(filterFavorites(list, 'KeXp').length, 1);
+});
+
+test('filterFavorites: diacritic-insensitive on both sides', () => {
+  const list = [
+    { id: 's1', name: 'Café del Mar', note: '', art: '' },
+    { id: 's2', name: 'Über Radio',   note: '', art: '' },
+  ];
+  // Plain ASCII needle matches the accented haystack.
+  assert.equal(filterFavorites(list, 'cafe')[0].id, 's1');
+  assert.equal(filterFavorites(list, 'uber')[0].id, 's2');
+  // Accented needle still matches the same row.
+  assert.equal(filterFavorites(list, 'CAFÉ')[0].id, 's1');
+});
+
+test('filterFavorites: matches against note and id, not just name', () => {
+  const list = [
+    { id: 's12345', name: 'Mystery', note: '',         art: '' },
+    { id: 'p99',    name: 'Show',    note: 'live mix', art: '' },
+  ];
+  assert.equal(filterFavorites(list, '12345')[0].id, 's12345', 'id substring matches');
+  assert.equal(filterFavorites(list, 'live')[0].id, 'p99',     'note substring matches');
+});
+
+test('filterFavorites: zero matches → empty array, not the original', () => {
+  const list = [{ id: 's1', name: 'A', note: '', art: '' }];
+  const out = filterFavorites(list, 'zzznope');
+  assert.notEqual(out, list);
+  assert.equal(out.length, 0);
+});
+
+test('filterFavorites: null / non-array list collapses to []', () => {
+  assert.deepEqual(filterFavorites(null, 'x'), []);
+  assert.deepEqual(filterFavorites(undefined, 'x'), []);
 });
 
 // --- toggleFavorite optimistic round-trip ---------------------------

--- a/admin/test/test_favorites.js
+++ b/admin/test/test_favorites.js
@@ -335,7 +335,7 @@ test('favourites view: ?focus=<id> flashes the matching row on mount', async () 
   const root = makeRoot();
   const destroy = favoritesView.init(root, store, { query: { focus: 's2' } });
   try {
-    const rows = root.querySelectorAll('.favorites-row');
+    const rows = root.querySelectorAll('.station-row--crud');
     assert.equal(rows.length, 3, 'three rows rendered');
     const target = rows.find((r) => r.dataset.favId === 's2');
     assert.ok(target, 'row for s2 present');
@@ -359,7 +359,7 @@ test('favourites view: ?focus with no match → nothing flashes, no throw', () =
   const root = makeRoot();
   const destroy = favoritesView.init(root, store, { query: { focus: 'sNope' } });
   try {
-    const rows = root.querySelectorAll('.favorites-row');
+    const rows = root.querySelectorAll('.station-row--crud');
     for (const r of rows) {
       assert.equal(r.classList.contains('is-focused'), false,
         'no row should flash when ?focus does not match');
@@ -376,7 +376,7 @@ test('favourites view: mount without ?focus → no row flashes', () => {
   const root = makeRoot();
   const destroy = favoritesView.init(root, store, {});
   try {
-    const rows = root.querySelectorAll('.favorites-row');
+    const rows = root.querySelectorAll('.station-row--crud');
     for (const r of rows) {
       assert.equal(r.classList.contains('is-focused'), false,
         'mount without focus must leave rows untouched');
@@ -392,7 +392,7 @@ test('favourites view: ?focus on unfetched list applies after the list lands', (
   const root = makeRoot();
   const destroy = favoritesView.init(root, store, { query: { focus: 's42' } });
   try {
-    assert.equal(root.querySelectorAll('.favorites-row').length, 0,
+    assert.equal(root.querySelectorAll('.station-row--crud').length, 0,
       'empty state — no rows to flash yet');
     // Now the reconcile lands.
     store.update('speaker', (s) => {
@@ -401,7 +401,7 @@ test('favourites view: ?focus on unfetched list applies after the list lands', (
         { id: 's42', name: 'Magic',   art: '', note: '' },
       ];
     });
-    const rows = root.querySelectorAll('.favorites-row');
+    const rows = root.querySelectorAll('.station-row--crud');
     assert.equal(rows.length, 2, 'rows rendered after the update');
     const target = rows.find((r) => r.dataset.favId === 's42');
     assert.ok(target, 'row for s42 present');
@@ -419,7 +419,7 @@ test('favourites view: ?focus applies once — re-render after flash does not re
   const root = makeRoot();
   const destroy = favoritesView.init(root, store, { query: { focus: 's1' } });
   try {
-    const initialRow = root.querySelector('.favorites-row');
+    const initialRow = root.querySelector('.station-row--crud');
     assert.equal(initialRow.classList.contains('is-focused'), true,
       'first paint flashes the target row');
     // Manually drop the flash class to simulate the post-timeout state,
@@ -431,7 +431,7 @@ test('favourites view: ?focus applies once — re-render after flash does not re
         { id: 's2', name: 'Two',   art: '', note: '' },
       ];
     });
-    const rows = root.querySelectorAll('.favorites-row');
+    const rows = root.querySelectorAll('.station-row--crud');
     for (const r of rows) {
       assert.equal(r.classList.contains('is-focused'), false,
         `subsequent renders must not re-apply the flash (${r.dataset.favId})`);

--- a/admin/test/test_favorites_drag.js
+++ b/admin/test/test_favorites_drag.js
@@ -93,8 +93,8 @@ function stubRowRects(rows) {
   }
 }
 
-function findRows(root) { return root.querySelectorAll('.favorites-row'); }
-function findDragHandle(row) { return row.querySelector('.favorites-row__drag'); }
+function findRows(root) { return root.querySelectorAll('.station-row--crud'); }
+function findDragHandle(row) { return row.querySelector('.station-row__drag'); }
 
 function dispatch(el, type, init) {
   const evt = Object.assign({

--- a/admin/test/test_favorites_inline_hearts.js
+++ b/admin/test/test_favorites_inline_hearts.js
@@ -355,7 +355,7 @@ function mountNowPlaying() {
 test('Now-Playing card: heart visible when source=TUNEIN and item.location carries an s-id', () => {
   setNowPlaying({
     source: 'TUNEIN',
-    item: { itemName: 'KEXP', location: '/v1/playback/station/s12345' },
+    item: { name: 'KEXP', location: '/v1/playback/station/s12345' },
     playStatus: 'PLAY_STATE',
     art: 'http://example/kexp.png',
   });
@@ -383,7 +383,7 @@ test('Now-Playing card: heart visible when source=TUNEIN and item.location carri
 test('Now-Playing card: heart visible on p-id (show drill) under TUNEIN', () => {
   setNowPlaying({
     source: 'TUNEIN',
-    item: { itemName: 'Fresh Air', location: '/v1/playback/station/p17' },
+    item: { name: 'Fresh Air', location: '/v1/playback/station/p17' },
     playStatus: 'PLAY_STATE',
     art: 'http://example/show.png',
   });
@@ -412,7 +412,7 @@ test('Now-Playing card: heart hidden on STANDBY', () => {
 test('Now-Playing card: heart hidden on AUX', () => {
   setNowPlaying({
     source: 'AUX',
-    item: { itemName: 'AUX IN', location: '' },
+    item: { name: 'AUX IN', location: '' },
     playStatus: 'PLAY_STATE',
   });
   const { root, destroy } = mountNowPlaying();
@@ -427,7 +427,7 @@ test('Now-Playing card: heart hidden on AUX', () => {
 test('Now-Playing card: heart hidden on BLUETOOTH', () => {
   setNowPlaying({
     source: 'BLUETOOTH',
-    item: { itemName: 'iPhone', location: '' },
+    item: { name: 'iPhone', location: '' },
     playStatus: 'PLAY_STATE',
   });
   const { root, destroy } = mountNowPlaying();
@@ -442,7 +442,7 @@ test('Now-Playing card: heart hidden on BLUETOOTH', () => {
 test('Now-Playing card: heart hidden on TUNEIN with topic (t-prefix not favouritable)', () => {
   setNowPlaying({
     source: 'TUNEIN',
-    item: { itemName: 'Episode 1', location: '/v1/playback/station/t12345' },
+    item: { name: 'Episode 1', location: '/v1/playback/station/t12345' },
     playStatus: 'PLAY_STATE',
   });
   const { root, destroy } = mountNowPlaying();
@@ -454,11 +454,11 @@ test('Now-Playing card: heart hidden on TUNEIN with topic (t-prefix not favourit
   }
 });
 
-test('Now-Playing card: heart toggle captures {id, name, art, note: ""} from item.location + itemName + np.art', async () => {
+test('Now-Playing card: heart toggle captures {id, name, art, note: ""} from item.location + item.name + np.art', async () => {
   store.state.speaker.favorites = [];
   setNowPlaying({
     source: 'TUNEIN',
-    item: { itemName: 'KEXP', location: '/v1/playback/station/s12345' },
+    item: { name: 'KEXP', location: '/v1/playback/station/s12345' },
     playStatus: 'PLAY_STATE',
     art: 'http://example/kexp.png',
   });
@@ -485,6 +485,51 @@ test('Now-Playing card: heart toggle captures {id, name, art, note: ""} from ite
     assert.deepEqual(body[0], {
       id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '',
     });
+    destroy();
+  } finally {
+    restore();
+  }
+});
+
+// Regression for #131: item.name is empty in transient firmware states
+// (TUNEIN streams where the station label rides on <track> rather than
+// <itemName>, mid-resolve, source switches). The heart's getEntry must
+// fall through to np.track via renderNowPlayingTitle, otherwise
+// toggleFavorite's empty-name fallback persists the sid as the label.
+test('Now-Playing card: heart capture falls through to np.track when item.name is empty (#131)', async () => {
+  store.state.speaker.favorites = [];
+  setNowPlaying({
+    source: 'TUNEIN',
+    item: { name: '', location: '/v1/playback/station/s123456' },
+    track: 'Example Radio',
+    playStatus: 'PLAY_STATE',
+    art: 'http://example/example.png',
+  });
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    if (/\/favorites$/.test(String(url))) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ ok: true, data: [{ id: 's123456', name: 'Example Radio', art: 'http://example/example.png', note: '' }] }),
+      };
+    }
+    return new Promise(() => {});
+  });
+  try {
+    const { root, destroy } = mountNowPlaying();
+    const heart = findFirstByClass(root, 'fav-heart');
+    assert.ok(heart, 'heart present');
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.equal(body[0].id, 's123456');
+    assert.equal(body[0].name, 'Example Radio',
+      'name comes from np.track, not the sid');
+    assert.notEqual(body[0].name, 's123456',
+      'sid must not be persisted as the favourite name');
     destroy();
   } finally {
     restore();

--- a/admin/test/test_favorites_view.js
+++ b/admin/test/test_favorites_view.js
@@ -38,13 +38,15 @@ function mountFavorites(root) {
 
 // Helpers — find row + its inline controls.
 
-function findRows(root) { return root.querySelectorAll('.favorites-row'); }
+function findRows(root) { return root.querySelectorAll('.station-row--crud'); }
 function findRow(root, idx) { return findRows(root)[idx] || null; }
-function findEditBtn(row)   { return row.querySelector('.favorites-row__edit-btn'); }
-function findDeleteBtn(row) { return row.querySelector('.favorites-row__delete-btn'); }
-function findDragHandle(row){ return row.querySelector('.favorites-row__drag'); }
-function findBody(row)      { return row.querySelector('.favorites-row__body'); }
-function findEditForm(row)  { return row.querySelector('.favorites-row__edit'); }
+function findEditBtn(row)   { return row.querySelector('.station-row__crud-edit'); }
+function findDeleteBtn(row) { return row.querySelector('.station-row__crud-delete'); }
+function findDragHandle(row){ return row.querySelector('.station-row__drag'); }
+// The row root itself is the play button (#134); the body is a layout
+// span. Tests click the row to fire play.
+function findBody(row)      { return row; }
+function findEditForm(row)  { return row.querySelector('.station-row__edit'); }
 function findToastAction()  { return doc.querySelector('.toast--action .toast__action'); }
 function findToastText()    { return doc.querySelector('.toast--action .toast__text'); }
 
@@ -84,11 +86,11 @@ test('favorites tab: each row renders drag-handle | body | pencil | trash', asyn
       assert.ok(findDeleteBtn(row),  'trash present');
     }
     // Body text reflects the entry.
-    const firstName = rows[0].querySelector('.favorites-row__name');
+    const firstName = rows[0].querySelector('.station-row__name');
     assert.equal(firstName && firstName.textContent, 'Radio One');
-    // Notes surface in the body.
-    const secondNote = rows[1].querySelector('.favorites-row__note');
-    assert.equal(secondNote && secondNote.textContent, 'live mix');
+    // Notes surface on the meta line — the shared station-row contract.
+    const secondMeta = rows[1].querySelector('.station-row__meta');
+    assert.equal(secondMeta && secondMeta.textContent, 'live mix');
   } finally {
     destroy();
   }
@@ -120,13 +122,13 @@ test('favorites tab: pencil expands row; Save commits + POSTs + collapses', asyn
     assert.ok(form, 'edit form appears after pencil click');
     assert.equal(row.classList.contains('is-expanded'), true, 'row marked as expanded');
 
-    const inputs = form.querySelectorAll('.favorites-edit__input');
+    const inputs = form.querySelectorAll('.station-row__edit-input');
     assert.equal(inputs.length, 3, 'three inputs (name, art, note)');
     setInputValue(inputs[0], 'New Name');
     setInputValue(inputs[1], 'http://art');
     setInputValue(inputs[2], 'edited note');
 
-    const saveBtn = form.querySelector('.favorites-edit__btn--save');
+    const saveBtn = form.querySelector('.station-row__edit-btn--save');
     click(saveBtn);
 
     // Optimistic mutation lands synchronously.
@@ -166,9 +168,9 @@ test('favorites tab: pencil → Cancel collapses without writing', async () => {
     click(findEditBtn(row));
     const form = findEditForm(row);
     assert.ok(form);
-    const inputs = form.querySelectorAll('.favorites-edit__input');
+    const inputs = form.querySelectorAll('.station-row__edit-input');
     setInputValue(inputs[0], 'Mutated');
-    const cancelBtn = form.querySelector('.favorites-edit__btn--cancel');
+    const cancelBtn = form.querySelector('.station-row__edit-btn--cancel');
     click(cancelBtn);
     assert.equal(findEditForm(findRow(root, 0)), null, 'form collapsed after Cancel');
     assert.equal(store.state.speaker.favorites[0].name, 'Radio One', 'state untouched');
@@ -313,9 +315,9 @@ test('favorites tab: edit Save + POST failure → state reverts, toast surfaces'
   try {
     click(findEditBtn(findRow(root, 0)));
     const form = findEditForm(findRow(root, 0));
-    const inputs = form.querySelectorAll('.favorites-edit__input');
+    const inputs = form.querySelectorAll('.station-row__edit-input');
     setInputValue(inputs[0], 'Mutated');
-    click(form.querySelector('.favorites-edit__btn--save'));
+    click(form.querySelector('.station-row__edit-btn--save'));
     // Optimistic edit lands first.
     assert.equal(store.state.speaker.favorites[0].name, 'Mutated');
     await new Promise((r) => setTimeout(r, 10));

--- a/admin/test/test_favorites_view.js
+++ b/admin/test/test_favorites_view.js
@@ -364,6 +364,216 @@ test('favorites tab: any other user action dismisses the Undo toast early', asyn
   }
 });
 
+// --- filter input (#135) -------------------------------------------
+
+function findFilterInput(root) {
+  const inp = root.querySelector('.favorites-filter .pill-input');
+  return inp;
+}
+
+function fireInput(input, value) {
+  input.value = value;
+  input.dispatchEvent({
+    type: 'input',
+    target: input,
+    defaultPrevented: false,
+    preventDefault() {},
+    stopPropagation() {},
+  });
+}
+
+test('favorites filter: pill input renders inside .page-title-bar beside the heading', () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP', note: '', art: '' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const titleBar = root.querySelector('.page-title-bar');
+    assert.ok(titleBar, 'page-title-bar present');
+    const heading = titleBar.querySelector('.page-title');
+    const filter  = titleBar.querySelector('.favorites-filter');
+    assert.ok(heading, 'heading is a child of the title bar');
+    assert.ok(filter,  'filter input is a child of the title bar');
+    const input = filter.querySelector('.pill-input');
+    assert.ok(input, 'pill-input nested inside the favorites-filter wrap');
+    assert.equal(input.getAttribute('placeholder'), 'Filter favourites');
+  } finally {
+    destroy();
+  }
+});
+
+test('favorites filter: typing narrows the visible rows after the debounce', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP Seattle',   note: '', art: '' },
+    { id: 's2', name: 'BBC Radio 6',    note: '', art: '' },
+    { id: 's3', name: 'Radio Paradise', note: '', art: '' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    assert.equal(findRows(root).length, 3, 'all three rows visible initially');
+    fireInput(findFilterInput(root), 'radio');
+    // Debounce is 150 ms — wait it out.
+    await new Promise((r) => setTimeout(r, 200));
+    const rows = findRows(root);
+    assert.equal(rows.length, 2, 'two rows survive the substring filter');
+    const ids = Array.from(rows).map((r) => r.dataset.favId);
+    assert.deepEqual(ids, ['s2', 's3']);
+  } finally {
+    destroy();
+  }
+});
+
+test('favorites filter: drag handles get aria-disabled when the filter is active', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP Seattle',   note: '', art: '' },
+    { id: 's2', name: 'Radio Paradise', note: '', art: '' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    // Unfiltered — handles are interactive.
+    for (const row of findRows(root)) {
+      const h = findDragHandle(row);
+      assert.equal(h.getAttribute('aria-disabled'), null, 'no aria-disabled when filter empty');
+    }
+    fireInput(findFilterInput(root), 'radio');
+    await new Promise((r) => setTimeout(r, 200));
+    for (const row of findRows(root)) {
+      const h = findDragHandle(row);
+      assert.equal(h.getAttribute('aria-disabled'), 'true', 'handle marked disabled while filter active');
+    }
+    // Clearing the filter restores drag.
+    fireInput(findFilterInput(root), '');
+    await new Promise((r) => setTimeout(r, 200));
+    for (const row of findRows(root)) {
+      const h = findDragHandle(row);
+      assert.equal(h.getAttribute('aria-disabled'), null, 'handle is interactive again after filter clear');
+    }
+  } finally {
+    destroy();
+  }
+});
+
+test('favorites filter: aria-disabled handle is a no-op for installFavoriteDrag', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP Seattle',   note: '', art: '' },
+    { id: 's2', name: 'BBC Radio 6',    note: '', art: '' },
+    { id: 's3', name: 'Radio Paradise', note: '', art: '' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    fireInput(findFilterInput(root), 'radio');
+    await new Promise((r) => setTimeout(r, 200));
+    const row = findRow(root, 0);
+    const handle = findDragHandle(row);
+    handle.dispatchEvent({
+      type: 'pointerdown', button: 0, pointerId: 1,
+      clientX: 0, clientY: 0,
+      defaultPrevented: false,
+      preventDefault() { this.defaultPrevented = true; },
+      stopPropagation() {},
+    });
+    // No ghost / indicator gets mounted because the handler bails early.
+    assert.equal(doc.querySelector('.favorites-drag-ghost'), null,
+      'no drag ghost while filter is active');
+    assert.equal(root.querySelector('.favorites-drag-indicator'), null,
+      'no drop indicator while filter is active');
+    assert.equal(row.classList.contains('is-dragging'), false,
+      'row not marked is-dragging');
+  } finally {
+    destroy();
+  }
+});
+
+test('favorites filter: pencil / trash / body-tap stay active under filter', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP Seattle',   note: '', art: '' },
+    { id: 's2', name: 'Radio Paradise', note: '', art: '' },
+  ];
+  const calls = [];
+  const restore = installFetchStub(async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    if (/\/play$/.test(String(url))) {
+      return { ok: true, status: 200, json: async () => ({ ok: true, url: 'http://stream' }) };
+    }
+    if (/\/favorites$/.test(String(url)) && opts && opts.method === 'POST') {
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: [] }) };
+    }
+    return new Promise(() => {});
+  });
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    fireInput(findFilterInput(root), 'paradise');
+    await new Promise((r) => setTimeout(r, 200));
+    const rows = findRows(root);
+    assert.equal(rows.length, 1);
+    const row = rows[0];
+    // Pencil opens the inline edit form.
+    click(findEditBtn(row));
+    assert.ok(findEditForm(row), 'pencil still opens the edit form under filter');
+    // Trash fires a delete POST.
+    click(findDeleteBtn(row));
+    await new Promise((r) => setTimeout(r, 10));
+    assert.ok(calls.some((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST'),
+      'trash issues the delete POST under filter');
+    // Body tap fires /play.
+    click(row);
+    await new Promise((r) => setTimeout(r, 10));
+    assert.ok(calls.some((c) => /\/play$/.test(c.url) && c.opts.method === 'POST'),
+      'body tap fires /play under filter');
+  } finally {
+    destroy();
+    restore();
+  }
+});
+
+test('favorites filter: zero matches renders the no-match empty state with Clear filter', async () => {
+  store.state.speaker.favorites = [
+    { id: 's1', name: 'KEXP Seattle', note: '', art: '' },
+  ];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    fireInput(findFilterInput(root), 'nothingmatchesthis');
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(findRows(root).length, 0, 'no rows rendered for a no-match filter');
+    const empty = root.querySelector('.favorites-empty');
+    assert.ok(empty, 'no-match empty state present');
+    const code = empty.querySelector('code');
+    assert.ok(code && code.textContent === 'nothingmatchesthis',
+      'query echoed back inside <code>');
+    const clearBtn = empty.querySelector('.favorites-empty__clear');
+    assert.ok(clearBtn, 'Clear filter link present');
+    // Tapping Clear filter restores the row + clears the input.
+    click(clearBtn);
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(findRows(root).length, 1, 'rows restored after Clear filter');
+    const input = findFilterInput(root);
+    assert.equal(input.getAttribute('value'), '', 'filter input cleared');
+  } finally {
+    destroy();
+  }
+});
+
+test('favorites filter: zero-favourites empty state uses the broadened wording', () => {
+  store.state.speaker.favorites = [];
+  const root = makeRoot();
+  const destroy = mountFavorites(root);
+  try {
+    const empty = root.querySelector('.favorites-empty');
+    assert.ok(empty, 'empty state visible');
+    const para = empty.querySelector('p');
+    assert.ok(para && /station or show/.test(para.textContent),
+      'wording mentions station OR show, not just station');
+  } finally {
+    destroy();
+  }
+});
+
 // --- body tap plays -------------------------------------------------
 
 test('favorites tab: body tap fires /play with the entry id', async () => {

--- a/admin/test/test_row_internals.js
+++ b/admin/test/test_row_internals.js
@@ -1,0 +1,157 @@
+// Tests for app/row-internals.js — the shared row helpers hoisted out
+// of components.js + show-hero.js (issue #137). Coverage focuses on
+// buildFavoriteHeart's eligibility gate and the default-getEntry
+// fallback shape; the cosmetic helpers (separator dot, genre chip,
+// browseUrlToHash) are exercised end-to-end by the existing browse +
+// favourites suites that consume them through stationRow / showHero.
+//
+// Run: node --test admin/test
+
+import { test, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import './fixtures/dom-shim.js';
+
+const { store } = await import('../app/state.js');
+const { buildFavoriteHeart } = await import('../app/row-internals.js');
+
+beforeEach(() => {
+  store.state.speaker.favorites = [];
+});
+
+test('buildFavoriteHeart: returns null when sid fails isFavoriteId', () => {
+  // t-prefix (topic) is not in the `^[sp]\d+$` favouritable grammar.
+  assert.equal(
+    buildFavoriteHeart({ sid: 't12345', name: 'Topic', favorite: { store } }),
+    null,
+    't-prefix is not favouritable',
+  );
+  // m-prefix (artist) — also out of grammar.
+  assert.equal(
+    buildFavoriteHeart({ sid: 'm99', favorite: { store } }),
+    null,
+    'm-prefix is not favouritable',
+  );
+  // Non-string sid.
+  assert.equal(
+    buildFavoriteHeart({ sid: undefined, favorite: { store } }),
+    null,
+    'undefined sid is not favouritable',
+  );
+});
+
+test('buildFavoriteHeart: returns null when no favorite handle is wired', () => {
+  assert.equal(
+    buildFavoriteHeart({ sid: 's12345', name: 'KEXP' }),
+    null,
+    'eligible sid + no favorite handle → null (caller falls back to chevron)',
+  );
+  assert.equal(
+    buildFavoriteHeart({ sid: 's12345', name: 'KEXP', favorite: {} }),
+    null,
+    'favorite handle without store → null',
+  );
+});
+
+test('buildFavoriteHeart: returns a heart node when sid + store are eligible', () => {
+  const heart = buildFavoriteHeart({
+    sid: 's12345', name: 'KEXP', art: 'http://example/kexp.png',
+    favorite: { store },
+  });
+  assert.ok(heart, 'heart node returned');
+  assert.equal((heart.getAttribute('class') || '').includes('fav-heart'), true,
+    'heart has the fav-heart class');
+  assert.equal(heart.hidden, false, 'heart visible on a favouritable id');
+});
+
+test('buildFavoriteHeart: default getEntry yields {id, name||sid, art||"", note:""}', async () => {
+  // Stub fetch so the heart's click handler can complete its toggle
+  // and we can read back the entry shape that was POSTed.
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '' }] }),
+    };
+  };
+  try {
+    const heart = buildFavoriteHeart({
+      sid: 's12345', name: 'KEXP', art: 'http://example/kexp.png',
+      favorite: { store },
+    });
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.deepEqual(body[0], {
+      id: 's12345', name: 'KEXP', art: 'http://example/kexp.png', note: '',
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('buildFavoriteHeart: default getEntry falls back to sid when name is missing', async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's999', name: 's999', art: '', note: '' }] }),
+    };
+  };
+  try {
+    // No name, no art — defaults should fill in.
+    const heart = buildFavoriteHeart({ sid: 's999', favorite: { store } });
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.deepEqual(body[0], {
+      id: 's999', name: 's999', art: '', note: '',
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('buildFavoriteHeart: explicit getEntry override wins over the defaults', async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url: String(url), opts });
+    return {
+      ok: true, status: 200,
+      json: async () => ({ ok: true, data: [{ id: 's12345', name: 'Live Title', art: 'http://example/live.png', note: 'live note' }] }),
+    };
+  };
+  try {
+    const heart = buildFavoriteHeart({
+      sid: 's12345', name: 'Static Name', art: 'http://example/static.png',
+      favorite: {
+        store,
+        getEntry: () => ({
+          id: 's12345',
+          name: 'Live Title',
+          art: 'http://example/live.png',
+          note: 'live note',
+        }),
+      },
+    });
+    heart.dispatchEvent({ type: 'click', defaultPrevented: false, preventDefault() {}, stopPropagation() {} });
+    await new Promise((r) => setTimeout(r, 5));
+    const post = calls.find((c) => /\/favorites$/.test(c.url) && c.opts.method === 'POST');
+    assert.ok(post, 'POST /favorites issued');
+    const body = JSON.parse(post.opts.body);
+    assert.deepEqual(body[0], {
+      id: 's12345', name: 'Live Title', art: 'http://example/live.png', note: 'live note',
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/admin/test/test_search.js
+++ b/admin/test/test_search.js
@@ -271,22 +271,23 @@ test('search: placeholder hints at TuneIn + 3 example queries', () => {
   assert.match(SEARCH_PLACEHOLDER, /ffh/);
 });
 
-// --- search input wrap: pill-shape + leading icon (CSS contract) ---
+// --- pill input wrap: pill-shape + leading icon (CSS contract) -----
 //
-// The polish pass moved the search input into a bordered wrapper so the
-// magnifier glyph sits inside the field. The contract is the visible
-// .search-input-wrap class with a 38px pill-style row.
-test('search css: .search-input-wrap exists and the input is borderless', async () => {
+// The pill-shaped input shell is shared between search and other
+// callers (favourites filter, future browse-text-filter). Contract:
+// the visible .pill-input-wrap class with a 38px pill-style row,
+// borderless inner input.
+test('pill css: .pill-input-wrap exists and the input is borderless', async () => {
   const fs = await import('node:fs');
   const path = await import('node:path');
   const css = fs.readFileSync(path.resolve('admin/style.css'), 'utf8');
-  const wrapRule = css.match(/^\.search-input-wrap\s*\{([^}]+)\}/m);
-  assert.ok(wrapRule, 'found .search-input-wrap rule');
+  const wrapRule = css.match(/^\.pill-input-wrap\s*\{([^}]+)\}/m);
+  assert.ok(wrapRule, 'found .pill-input-wrap rule');
   assert.match(wrapRule[1], /\bheight:\s*38px\b/);
   assert.match(wrapRule[1], /\bborder:\s*1px solid\b/);
 
-  const inputRule = css.match(/^\.search-input\s*\{([^}]+)\}/m);
-  assert.ok(inputRule, 'found .search-input rule');
+  const inputRule = css.match(/^\.pill-input\s*\{([^}]+)\}/m);
+  assert.ok(inputRule, 'found .pill-input rule');
   assert.match(inputRule[1], /\bborder:\s*0\b/);
 });
 

--- a/admin/test/test_tunein_drill_integration.js
+++ b/admin/test/test_tunein_drill_integration.js
@@ -29,7 +29,7 @@
 // READ-ONLY against production code. This test must not import any
 // helper that mutates tunein-* — it composes the public surfaces.
 
-import { test, before, beforeEach } from 'node:test';
+import { test, beforeEach } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -54,10 +54,13 @@ const { canonicaliseBrowseUrl } = await import('../app/tunein-url.js');
 const {
   renderOutline,
   renderEntry,
-  _setChildCrumbsForTest,
-  _setCurrentPartsForTest,
 } = await import('../app/views/browse/outline-render.js');
 const { cache } = await import('../app/tunein-cache.js');
+
+// Default render context for the drill simulation. The fixture's
+// drill is the top-level entry point — empty childCrumbs, no
+// currentParts.
+const RENDER_CTX = { childCrumbs: [], currentParts: null };
 
 // --- helpers -------------------------------------------------------------
 
@@ -119,13 +122,6 @@ const PAGE1_NEW_GUIDE_IDS = ['s10003', 's10004'];  // s10001 re-emits and dedupe
 
 // --- reset between tests -------------------------------------------------
 
-before(() => {
-  // The renderer reads two module-locals (childCrumbs, currentParts). The
-  // drill simulates the top-level entry point so both are empty.
-  _setChildCrumbsForTest([]);
-  _setCurrentPartsForTest(null);
-});
-
 beforeEach(() => {
   ssStore.clear();
 });
@@ -172,7 +168,7 @@ test('TuneIn drill: cache miss → fetch page 0 → paginate → classify → re
   // three sections (stations, shows, related) so we expect three
   // [data-section] cards.
   const body = doc.createElement('div');
-  const visibleCount = renderOutline(body, json0);
+  const visibleCount = renderOutline(body, json0, RENDER_CTX);
 
   // Two stations + one show row count as "visible" rows in the drill UI.
   // The pivots / cursor are meta and don't increment the count.
@@ -266,7 +262,7 @@ test('TuneIn drill: cache miss → fetch page 0 → paginate → classify → re
   for (const row of pager.rows) {
     assert.equal(classifyOutline(row), 'station',
       `page-1 row ${row.guide_id} classifies as station`);
-    const node = renderEntry(row);
+    const node = renderEntry(row, RENDER_CTX);
     assert.ok(hasClass(node, 'station-row'),
       `page-1 row ${row.guide_id} renders into .station-row`);
     stationCard.appendChild(node);

--- a/docs/adr/0003-favourites-stay-fetch-only.md
+++ b/docs/adr/0003-favourites-stay-fetch-only.md
@@ -1,0 +1,90 @@
+# Favourites stay a fetch-only Field
+
+- **Status**: accepted
+- **Date**: 2026-05-15
+- **Supersedes**: —
+- **Related**: `admin/app/speaker-state.js`, `admin/app/favorites.js`,
+  `admin/cgi-bin/api/v1/favorites`, `CONTEXT.md` § Favourite / Field
+
+## Context
+
+The **Favourite** list is an admin-owned record persisted at
+`/mnt/nv/resolver/admin-data/favorites.json`. It is disjoint from the
+firmware-owned **Preset** slots: the speaker firmware never reads, writes,
+or emits events about favourites. The list is modelled as a **Field** in
+the `FIELDS` registry in `admin/app/speaker-state.js`, the same way every
+other speaker-state row is modelled.
+
+A Field carries a `fetcher`, optional `path` / `tag` / `parseEl` for the
+REST decode path, and an optional `eventTag` that hooks the row into the
+firmware's WebSocket dispatch. **Presets** declare `eventTag:
+'presetsUpdated'` and get cross-tab convergence for free — when one client
+mutates, every other client sees a hint event and refetches. **Favourites**
+declare no `eventTag`, because the firmware has no event to emit: it does
+not know the list exists.
+
+Reconcile for favourites runs on two triggers today:
+
+1. Boot, via `reconcile(store)` at SPA start.
+2. `visibilitychange → 'visible'`, via a listener mounted by the
+   favourites view (mirrored on the now-playing card so the
+   3×3 preview also refreshes when the tab regains focus).
+
+This means two simultaneously open SPA clients converge on the next
+visibility transition — typically the next tab switch — rather than in
+real time.
+
+Every architecture review of the favourites slice surfaces the same
+question: should favourites get a push channel from the resolver back to
+the SPA, so multi-tab clients see each other's edits without waiting for a
+visibility transition?
+
+## Decision
+
+**Favourites remain a fetch-only Field. No resolver-to-SPA push channel.**
+
+The reconcile contract for favourites is:
+
+- Initial load via `fetcher` on boot.
+- Refetch via `fetcher` on `visibilitychange → 'visible'`.
+- After every local mutation, the SPA owns the optimistic state directly;
+  no server round-trip is needed to learn what the local client just
+  wrote.
+
+## Consequences
+
+- The **FIELDS registry** stays a single seam. Every speaker-state row
+  reconciles through the same `fetcher` (+ optional WS hint) shape.
+  Inventing a second transport just for favourites would fracture that
+  invariant: future maintainers would have to ask, per field, "is this
+  one push, pull, or both?" instead of reading one registry row.
+
+- The reconcile delay for a second tab is bounded by user tab-switch
+  latency, which on a single-user single-speaker home appliance is the
+  same order of magnitude as any push-driven UI we could build. No bug
+  has been filed that requires sub-second multi-tab convergence; the
+  cost of building a push channel for hypothetical demand would
+  outweigh the leverage.
+
+- A resolver-pushed event channel would have to be invented from
+  scratch. The firmware's gabbo subprotocol is not extensible from the
+  resolver side — it is owned by the speaker's WebSocket server. A
+  second transport (a second WS endpoint on the resolver, SSE from the
+  CGI, or long-poll) would serve exactly one field today, with no
+  other Field currently asking for the same machinery. The module
+  would be shallow by construction: a large transport implementation
+  behind an interface used by one caller.
+
+- The decision is reversible. If a future Field also needs
+  resolver-originated push — for example, a cross-device pairing flow
+  that the firmware does not surface as a gabbo event — then push
+  becomes a generally useful transport rather than a favourites-only
+  workaround, and this ADR should be re-opened to define the seam
+  before two callers diverge on transport details.
+
+- Future architecture reviews should not re-propose a favourites push
+  channel without identifying at least one additional Field that would
+  share the transport, or a concrete user-visible bug that the
+  visibility-driven reconcile cannot solve. The `// see also` comment
+  on the favourites Field row in `speaker-state.js` points here so the
+  judgement stays local rather than tribal.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,8 +2,8 @@
 
 The speaker firmware exposes 102 endpoints on **TCP 8090**, plain HTTP,
 LAN-local. They don't depend on any cloud service — they're served by
-the firmware itself. Useful for automation, scripting, and the admin UI
-this project plans to ship.
+the firmware itself. Useful for automation, scripting, and the admin
+SPA this project ships under `admin/`.
 
 There's also a **WebSocket on TCP 8080** for real-time events (button
 presses, track changes, volume, source changes, play state). Connect

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,16 @@ Architecture in three layers:
 1. **Static SPA** — `index.html` + `style.css` + an ES-module tree
    under `/app/`. No build step (vanilla CSS, native ES modules,
    tagged-template DOM). Cache-busted via `?v=<git-describe>` query
-   strings rewritten at deploy time.
+   strings rewritten at deploy time. Every primary view wraps its
+   body in a shared `.page` outer chrome with a `.page-title-bar`
+   pill (Browse, Search, Favourites, Settings); shared row primitives
+   live in `components.js` (`stationRow`, `pillInput`, `stationArt`,
+   etc.) with rendering helpers hoisted into `row-internals.js` so
+   the Now-Playing show-hero and the browse station-row share the
+   same meta-separator, genre-chip, and favourite-heart code paths.
+   The browse outline-render pipeline threads an explicit render
+   context (`ctx = {childCrumbs, currentParts}`) through every
+   render entry-point — no module-level slots.
 2. **Shell CGIs under `/cgi-bin/api/v1/`** — `tunein` (forwarder for
    browse / search / probe), `presets` (atomic file-write +
    `/storePreset`), `favorites` (atomic JSON write for the admin-owned
@@ -226,7 +235,7 @@ Mono) live under `/mnt/nv/resolver/fonts/` and are referenced by
 relative URL — the LAN can be cut off from the public internet and
 the admin still loads. No CDN, no Google Fonts, no `unpkg`.
 
-User-facing surface as of 0.7:
+User-facing surface as of 0.7.1:
 
 - Now-playing — transport, volume, source picker, preset row,
   long-press to assign, 3×3 favourites preview grid below the preset
@@ -239,9 +248,13 @@ User-facing surface as of 0.7:
 - Station detail — metadata, probe state, 3×2 preset grid, test-play,
   inline heart next to the station name.
 - Favourites — dedicated tab with full CRUD (drag reorder,
-  expand-in-place edit, toast-undo delete). Persists in a JSON file
-  at `/mnt/nv/resolver/admin-data/favorites.json`. Disjoint from the
-  six firmware-owned hardware presets — a station can be both.
+  expand-in-place edit, toast-undo delete) and a pill filter input
+  above the list (drag is disabled while a filter is active).
+  Persists in a JSON file at
+  `/mnt/nv/resolver/admin-data/favorites.json`. Disjoint from the
+  six firmware-owned hardware presets — a station can be both. See
+  [adr/0003-favourites-stay-fetch-only.md](adr/0003-favourites-stay-fetch-only.md)
+  for why the favourites field is fetch-only with no push channel.
 - Settings — Appearance (theme), Speaker (name / power / sleep),
   Audio (bass / balance / mono-stereo), Bluetooth (own MAC + active
   device), Multi-room (placeholder), Network (signal bars),

--- a/docs/customizing-presets.md
+++ b/docs/customizing-presets.md
@@ -107,11 +107,15 @@ via Bluetooth from your phone, or from another preset that already
 points at it), hold the desired preset button (1–6) for a few seconds.
 This is how Bose meant it to work.
 
-But because we don't have an in-app browse UI yet (planned in
-[../admin/PLAN.md](../admin/PLAN.md)), the more practical route is
-Option B.
+### Option B — Via the browser admin
 
-### Option B — Via the speaker's local API
+Open `http://<speaker-ip>:8181/`, search or browse to the station,
+open it, and tap one of the six preset slots in the assignment grid.
+The admin handles the `/storePreset` POST and atomically rewrites the
+matching `/v1/playback/station/<id>` resolver entry. This is the
+day-to-day path once the admin is deployed.
+
+### Option C — Via the speaker's local API
 
 There's a wrapper script:
 
@@ -183,7 +187,9 @@ need to:
 1. Hand-edit a Bose-shaped JSON file with your direct stream URL.
 2. Push it to `/mnt/nv/resolver/bmx/tunein/v1/playback/station/<some-id>`
    (give it any unique `s`-prefixed ID).
-3. Assign as a preset via Option B above.
+3. Assign as a preset via Option C above (the browser admin won't help
+   for a non-TuneIn id — its assignment grid POSTs through the
+   resolver's TuneIn-shaped path).
 
 That works but isn't supported by `build.py`. Patches welcome (see
 [../CONTRIBUTING.md](../CONTRIBUTING.md)).

--- a/docs/history.md
+++ b/docs/history.md
@@ -143,13 +143,16 @@ Acknowledged trade-offs:
 
 ## Where it's going
 
-A small browser-based admin UI is planned (see
-[../admin/PLAN.md](../admin/PLAN.md)). The aim is to replace the
-`build.py` + scp + curl-storePreset workflow with point-and-click,
-hosted entirely on the speaker via static SPA + thin shell CGI.
+The browser admin landed in 0.4 and has grown through 0.7.1 — it now
+covers transport, presets, full TuneIn browse + search, station
+detail, an admin-owned favourites list, and a settings page. The
+`build.py` + scp + curl-storePreset workflow is no longer the
+day-to-day path; the admin's `refresh-all` CGI does the on-speaker
+equivalent of `python3 resolver/build.py` from the browser. See
+[CHANGELOG.md](../CHANGELOG.md) for the per-release detail.
 
 Long-term, an awk-based dynamic resolver could eliminate the
-periodic-refresh chore. Wanted but not needed yet.
+periodic-refresh chore entirely. Wanted but not needed yet.
 
 ## Acknowledgements
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,8 +120,10 @@ Causes:
 - The speaker booted while it couldn't reach any cloud endpoint and
   decided things were inconsistent.
 
-Re-store each preset using the API call from
-[customizing-presets.md](customizing-presets.md) § "Option B".
+Re-store each preset — easiest route is the browser admin
+([customizing-presets.md](customizing-presets.md) § "Option B"); the
+raw API call lives in § "Option C" if you'd rather drive it from a
+terminal.
 
 ## SSH refused after a reboot
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bose-soundtouch-resurrect",
   "private": true,
   "type": "module",
+  "version": "0.7.1",
   "scripts": {
     "test": "node --test admin/test/*.js"
   },


### PR DESCRIPTION
## Summary

The 0.7.1 milestone bundles 9 ready-for-agent issues plus a polish pass on the SPA chrome, mobile overflow, and the documentation surface.

### User-facing
- **Favourites filter** — pill-input above the list, substring match on name + id, drag disabled while a filter is active.
- **NP heart fix** — favouriting from the now-playing card now captures the station label, not the sid.
- **Folded favourites row** — Favourites rows now share the `.station-row` skin used by Search and Browse via a new `.station-row--crud` modifier; the old `.favorites-row*` namespace is gone.
- **Shared page chrome** — `.page` wrapper, `.page-title` in a pill box matching the filter input, Favourites list rendered as a continuous rounded card with hairline-divided rows.
- **Mobile overflow** fixes — search header URL, settings theme picker, and the mini-player title all now ellipsis-clamp on narrow viewports; no horizontal scroll on iPhone SE / 12 / Pixel 5 / 13 Pro Max.

### Internal
- **`pillInput({...})`** primitive (`admin/app/components.js`); `.search-input*` CSS renamed to `.pill-input*`.
- **`row-internals.js`** hoists `appendMetaSeparator`, `genreChipEl`, `browseUrlToHash`, and `buildFavoriteHeart` out of `components.js` + `show-hero.js`.
- **`outline-render` ctx threading** — `_childCrumbs` / `_currentParts` module slots replaced with a `ctx = {childCrumbs, currentParts}` object threaded through the render pipeline; `drillHashFor(parts, crumbs)` makes `crumbs` required.
- **`joinFilters`** moved to `crumb-parts.js` alongside `filtersOf`.
- **`toggleFavorite`** collapsed into a thin wrapper over `replaceFavorites`.
- **Inline CSS removed** from JS-emitted DOM (modal chrome, station-art sizing); duplicate / dead rules consolidated.
- **ADR 0003** documents why favourites stay a fetch-only Field.

### Verification
- 1057 unit tests pass.
- Playwright e2e suite green against Bo (33 specs).
- Visual smoke confirmed on iPhone SE / 12 / Pixel 5 / 13 Pro Max viewports.

## Test plan

- [ ] `cd admin && npm test` returns 0 failures.
- [ ] Deploy to a speaker via `admin/deploy.sh <ip>` and verify:
  - [ ] Favourites tab shows the filter input; typing narrows rows.
  - [ ] Drag handles fade + no-op while filter is active.
  - [ ] Now-playing card heart captures the visible station label, not the sid.
  - [ ] Settings + Favourites page-titles render in matching pill boxes.
  - [ ] Mini-player title + subtitle ellipsis-clamp when long.
  - [ ] No horizontal scroll on a phone-width viewport across all views.
- [ ] `cd admin/e2e && BOSE_HOST=<ip> npm test` passes.

Closes #131
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #138
Closes #139