### PR TITLE
0.7.2 — deploy/refresh glob fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.7.2] - 2026-05-15
+
+### Fixed
+
+- **`deploy.sh` no longer wipes `resolver/stations.json`.** The
+  cleanup step before `build.py` used `rm -f s*`, which matched
+  `stations.json`, `stations.example.json`, and `shepherd-resolver.xml`
+  alongside the intended per-station output files. Narrowed both the
+  cleanup and the matching SCP upload globs in
+  `scripts/deploy.sh` and `scripts/refresh-streams.sh` to `s[0-9]*` —
+  the same pattern `deploy.sh:59` already uses to count the produced
+  station files, and `verify.sh:50` uses to detect them on the
+  speaker. Also narrowed the same glob in the docs' manual SCP / `ls`
+  examples (`resolver/build.py` docstring, `docs/installation.md`,
+  `docs/customizing-presets.md`) and corrected `README.md` Quick-start
+  step 4 to say copy-then-edit `stations.example.json` instead of
+  editing it in place. Reported externally against the 0.5.0 tag
+  (#141).
+
 ## [v0.7.1] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ Five steps. Each one links to the full doc.
    SPA), points the speaker at `127.0.0.1:8181`, reboots.
 4. **Customise your presets** —
    [docs/customizing-presets.md](docs/customizing-presets.md). Either
-   edit `resolver/stations.example.json` and run `build.py`, or use
-   the browser admin: search → assign to slot.
+   copy `resolver/stations.example.json` to `resolver/stations.json`,
+   edit it, and run `build.py`, or use the browser admin: search →
+   assign to slot.
 5. **Verify** with `scripts/verify.sh <speaker-ip>` and press a
    preset button on the speaker.
 

--- a/docs/customizing-presets.md
+++ b/docs/customizing-presets.md
@@ -95,7 +95,7 @@ for that station. Skip it or use a different station.
 ```bash
 SPEAKER_IP=<your-speaker-ip>
 SCP="scp -O -oHostKeyAlgorithms=+ssh-rsa -oUserKnownHostsFile=/dev/null -oStrictHostKeyChecking=no -oConnectTimeout=10"
-$SCP s* root@$SPEAKER_IP:/mnt/nv/resolver/bmx/tunein/v1/playback/station/
+$SCP s[0-9]* root@$SPEAKER_IP:/mnt/nv/resolver/bmx/tunein/v1/playback/station/
 ```
 
 Then assign one of your stations to a preset slot. Two ways:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ cd resolver/
 cp stations.example.json stations.json
 # Edit stations.json — see customizing-presets.md for how to find IDs.
 python3 build.py
-ls s*    # one file per station ID, e.g. s12345, s23456, ...
+ls s[0-9]*    # one file per station ID, e.g. s12345, s23456, ...
 cd ..
 ```
 
@@ -102,7 +102,7 @@ $SSH root@$SPEAKER_IP '
 '
 
 # Per-station resolver files
-$SCP resolver/s* root@$SPEAKER_IP:/mnt/nv/resolver/bmx/tunein/v1/playback/station/
+$SCP resolver/s[0-9]* root@$SPEAKER_IP:/mnt/nv/resolver/bmx/tunein/v1/playback/station/
 
 # Daemon config so busybox httpd auto-starts at boot
 $SCP resolver/shepherd-resolver.xml \

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bose-soundtouch-resurrect",
   "private": true,
   "type": "module",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "scripts": {
     "test": "node --test admin/test/*.js"
   },

--- a/resolver/build.py
+++ b/resolver/build.py
@@ -12,7 +12,7 @@ The script writes one file per station ID into the current directory.
 The filename matches the TuneIn ID exactly (e.g. ./s12345). After this,
 scp the files to your speaker:
 
-    scp -O -oHostKeyAlgorithms=+ssh-rsa s* \\
+    scp -O -oHostKeyAlgorithms=+ssh-rsa s[0-9]* \\
         root@<speaker-ip>:/mnt/nv/resolver/bmx/tunein/v1/playback/station/
 
 See ../docs/customizing-presets.md for how to find a station's ID.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,7 +54,7 @@ $SSH root@"$SPEAKER" 'true' \
        See docs/opening-up-your-speaker.md."
 
 say "Building station files (TuneIn → Bose JSON)"
-( cd "$ROOT/resolver" && rm -f s* 2>/dev/null; python3 build.py )
+( cd "$ROOT/resolver" && rm -f s[0-9]* 2>/dev/null; python3 build.py )
 
 STATION_COUNT=$(find "$ROOT/resolver" -maxdepth 1 -type f -name 's[0-9]*' 2>/dev/null | wc -l | tr -d ' ')
 [ "$STATION_COUNT" -gt 0 ] \
@@ -93,7 +93,7 @@ $SSH root@"$SPEAKER" "
 "
 
 say "Pushing per-station JSON files"
-$SCP "$ROOT"/resolver/s* \
+$SCP "$ROOT"/resolver/s[0-9]* \
      root@"$SPEAKER":/mnt/nv/resolver/bmx/tunein/v1/playback/station/
 
 say "Pushing shepherd-resolver.xml (auto-start at boot)"

--- a/scripts/refresh-streams.sh
+++ b/scripts/refresh-streams.sh
@@ -23,11 +23,11 @@ SCP="scp -O -oHostKeyAlgorithms=+ssh-rsa -oUserKnownHostsFile=/dev/null -oStrict
   || { echo "error: resolver/stations.json missing." >&2; exit 1; }
 
 echo "=== Building station files ==="
-( cd "$ROOT/resolver" && rm -f s* 2>/dev/null; python3 build.py )
+( cd "$ROOT/resolver" && rm -f s[0-9]* 2>/dev/null; python3 build.py )
 
 echo
 echo "=== Pushing to speaker ==="
-$SCP "$ROOT"/resolver/s* \
+$SCP "$ROOT"/resolver/s[0-9]* \
      root@"$SPEAKER":/mnt/nv/resolver/bmx/tunein/v1/playback/station/
 
 echo


### PR DESCRIPTION
## Summary

Patch release. The cleanup step before `build.py` in `scripts/deploy.sh` and `scripts/refresh-streams.sh` used `rm -f s*`, which matched not only the per-station output files (e.g. `s12345`) but also `stations.json`, `stations.example.json`, and `shepherd-resolver.xml` — silently wiping the user's preset list before `build.py` ran, and producing the confusing `error: stations.json doesn't exist` from build.py that followed.

- Narrow the cleanup and matching SCP upload globs to `s[0-9]*` in both scripts — same pattern `deploy.sh:59` already uses to count produced files and `verify.sh:50` uses to detect them on the speaker.
- Narrow the same glob in the doc examples (`resolver/build.py` docstring, `docs/installation.md`, `docs/customizing-presets.md`) so manual copy-paste paths don't propagate the footgun.
- Fix `README.md` Quick-start step 4: it said "edit `resolver/stations.example.json`" — should be copy-then-edit, matching the rest of the docs.
- CHANGELOG entry under `[v0.7.2] - 2026-05-15`.
- Bump `package.json` to 0.7.2.

Closes #141.

## Test plan

- [x] Side-by-side sandbox simulation: `rm -f s*` (old) wiped `stations.json`/`stations.example.json`/`shepherd-resolver.xml`; `rm -f s[0-9]*` (new) leaves them alone and still evicts stale `s12345/s67890/s99999`.
- [x] SCP glob expansion verified — only `s[0-9]*` matches would upload.
- [x] Fresh-checkout edge case: zero matches is a safe no-op, `STATION_COUNT` guard on `deploy.sh:59` still catches a failed build.
- [x] POSIX `sh` portability check via `dash` (Linux Mint's `/bin/sh`).
- [x] `set -eu` interaction: empty cleanup doesn't abort the script.
- [x] `bash -n` on both scripts; `ast.parse` on `build.py`.
- [x] Final sweep: no literal `s*` glob remains in `.sh`/`.py`/`.md` outside the CHANGELOG entry that intentionally quotes the old pattern.