### PR TITLE
0.8.1 — recovery resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.1] - 2026-05-16
+
+Recovery resilience release. Closes three gaps that surfaced once v0.8 went out: users whose speakers were already in the v0.8-fixed brick state still had no easy way out, the install guide didn't tell new users how to deploy the browser admin, and there was no documented path for a speaker that won't boot at all.
+
+### Fixed
+
+- **`scripts/deploy.sh` recovers brick-class speakers in one shot.** The MAC lookup at the top of the deploy used to query port 8090 — which is exactly the port that's dead when `shepherdd` isn't supervising `BoseApp`, the failure mode v0.8 closes for fresh installs. Users whose speakers were already in that state from the pre-0.8 deploy couldn't run `deploy.sh` to recover. The lookup now falls back to `/proc/device-tree/ocp/macaddr/mac-address` over the same SSH connection — u-boot populates that node from the SCM module's OTP at boot, independent of any userspace daemon. A running speaker takes the unchanged `/info` path; the fallback only fires when `/info` returns nothing. Format is identical (12 uppercase hex characters, no separators) so the resolver heartbeat sink path key still matches. Closes #152.
+
+### Documentation
+
+- **Install guide covers both layers explicitly.** `docs/installation.md` now leads with the two-layer model — mandatory **Resolver** plus the recommended **Browser admin SPA** — and a new "Step 1b" documents `admin/deploy.sh` alongside `scripts/deploy.sh`. The "Verify" section notes that `scripts/verify.sh` auto-skips admin probes when the SPA isn't deployed, so a resolver-only install is a valid passing state. README Quick-start updated to match (no longer implies the admin appears automatically). Closes #154.
+- **Troubleshooting guide for the "won't boot at all" failure mode.** New top-of-file section in `docs/troubleshooting.md` for SoundTouch 10 speakers that don't respond to SSH, WiFi, or LAN and don't accept the standard Bose factory reset. Documents the two-stage button-press sequence (`Preset 1` + `Vol −` held during power-on, release on the orange/blue/white/orange LED sweep, hold again for ~15s once the second LED goes blue) that [@dimmu311](https://github.com/dimmu311) found in [#143](https://github.com/skarl/bose-soundtouch-resurrect/issues/143). Reaches the bootloader-level reset handler when userland-dependent recovery paths can't. Closes #153.
+
 ## [v0.8] - 2026-05-16
 
 Onboarding hardening release. Closes a class of bug where the documented install path was non-reproducible because it required invisible manual sysadmin state on the maintainer's NV flash to work — every fresh user (especially on a different SoundTouch model) was walking off a cliff. Discovered when external contributor David reported a boot hang at ~90% on his ST 20 (discussion #121) that we couldn't reproduce on the maintainer's ST 10. Validated end-to-end on the test speaker after a clean shepherd-state reset: `scripts/verify.sh` reported 30 OK / 0 failed across resolver, admin SPA, CGIs, WebSocket, and speaker-proxy probes.

--- a/README.md
+++ b/README.md
@@ -111,18 +111,20 @@ Five steps. Each one links to the full doc.
 2. **Open up your speaker** (one-time, enables SSH) —
    [docs/opening-up-your-speaker.md](docs/opening-up-your-speaker.md).
    Format USB stick FAT32, drop a marker file, plug in, boot.
-3. **Install the resolver** —
-   [docs/installation.md](docs/installation.md). Pushes static files
-   to `/mnt/nv/resolver/`, drops a daemon config that binds
-   `0.0.0.0:8181` (loopback for the SDK; LAN-reachable for the admin
-   SPA), points the speaker at `127.0.0.1:8181`, reboots.
+3. **Install the resolver and the browser admin** —
+   [docs/installation.md](docs/installation.md). Two layers, both
+   served by the speaker's busybox httpd: `scripts/deploy.sh` pushes
+   the resolver tree and reboots; `admin/deploy.sh` then layers the
+   browser admin on top. The admin SPA is optional — skip it if you
+   only want hardware preset playback.
 4. **Customise your presets** —
    [docs/customizing-presets.md](docs/customizing-presets.md). Either
-   copy `resolver/stations.example.json` to `resolver/stations.json`,
-   edit it, and run `build.py`, or use the browser admin: search →
-   assign to slot.
-5. **Verify** with `scripts/verify.sh <speaker-ip>` and press a
-   preset button on the speaker.
+   open the browser admin (search → assign to slot), or copy
+   `resolver/stations.example.json` to `resolver/stations.json`, edit
+   it, and run `build.py`.
+5. **Verify** with `scripts/verify.sh <speaker-ip>` (covers both
+   layers; admin probes auto-skip if you didn't install it) and press
+   a preset button on the speaker.
 
 ## The recurring chore
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,19 @@
 # Installation
 
-Deploy the on-speaker resolver. Once installed, the speaker is fully
-self-sufficient — preset buttons resolve their stations through a tiny
-HTTP server running on the speaker itself.
+The install has two layers, both served by the speaker's own busybox
+httpd:
+
+1. **Resolver** (mandatory) — the tiny static-file responder that
+   replaces the four Bose-hosted services the speaker expects to talk
+   to. Without it the preset buttons stay silent.
+2. **Browser admin SPA** (recommended) — the everyday post-cloud-shutdown
+   interface for search, browse, favourites, and assigning stations to
+   preset slots. Reachable at `http://<speaker-ip>:8181/` from any LAN
+   browser. Skip this layer if you only want hardware preset playback
+   and you're happy editing `resolver/stations.json` by hand.
+
+The resolver goes on first (it provides the httpd the admin SPA is
+served from); the admin SPA layers on top.
 
 **Prerequisite:** SSH must be enabled on the speaker. If you haven't
 done that, follow [opening-up-your-speaker.md](opening-up-your-speaker.md)
@@ -50,10 +61,35 @@ the daemon config, and writing the override XML.
 ./scripts/deploy.sh "$SPEAKER_IP"
 ```
 
-This is the path of least resistance. Skip to Step 4 to verify.
+This is the path of least resistance for the resolver. To also install
+the browser admin, continue with Step 1b. To verify a resolver-only
+install, skip to Step 4.
 
-If you'd rather do it by hand (to understand each step, or if `deploy.sh`
-fails partway), continue with Step 2.
+If you'd rather do the resolver by hand (to understand each step, or if
+`deploy.sh` fails partway), continue with Step 2.
+
+## Step 1b — Deploy the browser admin (recommended)
+
+With the resolver in place, the speaker's busybox httpd is now serving
+`http://<speaker-ip>:8181/`. Layer the admin SPA on top:
+
+```bash
+./admin/deploy.sh "$SPEAKER_IP"
+```
+
+The script sanity-checks SSH access and resolver presence, pushes the
+admin shell (`index.html`, `style.css`, the `app/` ES modules, the
+self-hosted Geist fonts), pushes the `cgi-bin/api/v1/` shell CGIs,
+substitutes the build version into the HTML, and verifies the response.
+It does **not** reboot the speaker and does **not** touch the resolver
+files.
+
+Once it's done, open `http://<speaker-ip>:8181/` in any browser on the
+same LAN. See [README.md § The browser admin](../README.md#the-browser-admin)
+for what's in the UI.
+
+To remove the admin later without touching the resolver, run
+`./admin/uninstall.sh "$SPEAKER_IP"`.
 
 ## Step 2 — Build the per-station resolver files
 
@@ -130,7 +166,7 @@ Wait ~75 seconds for the speaker to come back.
 
 ## Step 4 — Verify
 
-The repo includes a verifier:
+The repo includes a verifier that covers both layers:
 
 ```bash
 ./scripts/verify.sh "$SPEAKER_IP"
@@ -138,7 +174,9 @@ The repo includes a verifier:
 
 It checks: SSH works, the resolver httpd is listening, all expected
 files are in `/mnt/nv/resolver/`, the override XML is in place, and
-`/now_playing` reports a sane state.
+`/now_playing` reports a sane state. If the admin SPA is deployed it
+additionally probes the admin shell and CGIs; if it isn't, those probes
+auto-skip cleanly — a resolver-only install is a valid passing state.
 
 To test playback by hand, press preset 1:
 
@@ -189,7 +227,12 @@ $SSH root@$SPEAKER_IP '
 This puts the speaker back to its factory configuration, where it
 attempts to reach the (offline) Bose cloud and effectively becomes
 silent for preset playback. AUX, Bluetooth, and Spotify Connect will
-still work; preset buttons won't.
+still work; preset buttons won't. The `rm -rf /mnt/nv/resolver`
+removes the admin SPA too, since it lives under the same tree — no
+separate admin uninstall is needed when rolling all the way back.
+
+To drop only the admin layer and keep the resolver, use
+`./admin/uninstall.sh "$SPEAKER_IP"` instead.
 
 To also disable SSH, see [opening-up-your-speaker.md](opening-up-your-speaker.md)
 § "Reverting".

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,23 +20,23 @@ SSH connects refuse or time out, and the standard Bose factory reset
 (hold `Preset 1` + `Vol −` until the speaker beeps) does nothing —
 userland isn't running far enough to register the button event.
 
-The most common cause of this state in this project is a speaker that
-got the pre-0.8 `deploy.sh` (#144): it dropped only our resolver
-config into `/mnt/nv/shepherd/` without the stock variant files
-alongside, which made `shepherdd` stop supervising BoseApp, WebServer,
-NetManager, and everything else that brings the speaker up at boot.
-v0.8 fixed that path; this section is here for anyone whose speaker
-is already in the broken state.
+The most common cause is a speaker that ran the pre-0.8 `deploy.sh`
+(see #144): it created `/mnt/nv/shepherd/` with only the resolver
+config inside and no stock variant files alongside, which made
+`shepherdd` stop supervising `BoseApp`, `WebServer`, `NetManager`,
+and the other daemons that bring the speaker up at boot. The deploy
+path was fixed in v0.8; this section is for anyone whose speaker is
+still stuck in that state.
 
-USB-stick `Update.stu` re-flash doesn't help (the bug is in
-`/mnt/nv/`, not the firmware image), and the USB-cable-to-laptop SSH
-trick doesn't help either (userland is too broken to expose the
-USB-network gadget).
+USB-stick `Update.stu` re-flash does not help (the bug lives in
+`/mnt/nv/`, not in the firmware image), and the USB-cable-to-laptop
+SSH path does not help either (userland is too degraded to expose
+the USB-network gadget).
 
-External contributor [@dimmu311](https://github.com/dimmu311) found a
-two-stage button-press sequence in [#143](https://github.com/skarl/bose-soundtouch-resurrect/issues/143)
-that hits the bootloader / early-boot button handler at the right
-moment to trigger a deeper reset than the userland one. Verbatim:
+[@dimmu311](https://github.com/dimmu311) documented a two-stage
+button-press sequence in [#143](https://github.com/skarl/bose-soundtouch-resurrect/issues/143)
+that reaches the bootloader / early-boot button handler at the
+right moment to trigger a deeper reset than the userland one:
 
 1. AC unplug.
 2. Press and hold `1` + `Vol −`.
@@ -50,15 +50,15 @@ moment to trigger a deeper reset than the userland one. Verbatim:
    are off. Release.
 
 The speaker's setup-mode hotspot is now active — re-onboard via the
-SoundTouch app as you would with a new speaker.
+SoundTouch mobile app as you would with a new speaker.
 
-This procedure is documented for the **SoundTouch 10** specifically.
-Other models in the line very likely have a working bootloader-level
-reset combo too, but the exact buttons and LED-state cues may
-differ; see [compatibility.md](compatibility.md) for the
-model-supported matrix and current evidence per model. If you
-recover an ST 20 / ST 30 / other model with a different combo,
-please file a report so the next person can find it.
+This procedure is verified on the **SoundTouch 10**. Other models in
+the family very likely have an equivalent bootloader-level reset
+combo, but the exact buttons and LED cues may differ — see
+[compatibility.md](compatibility.md) for the per-model evidence
+matrix. If you recover an ST 20, ST 30, or other model with a
+different combination, please open an issue so the next person can
+find it.
 
 ## Nothing plays after pressing a preset
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,6 +13,53 @@ shepherdd pids, `/mnt/nv/` listing, mount info, Shepherd-config mtimes,
 dmesg tail, and `/var/log/messages` tail into a timestamped folder.
 Scrub LAN IPs / MACs / fritz.box hostnames before pasting.
 
+## If the speaker won't boot at all (no SSH, no WiFi, no LAN)
+
+Symptoms: the speaker no longer joins WiFi, isn't reachable over LAN,
+SSH connects refuse or time out, and the standard Bose factory reset
+(hold `Preset 1` + `Vol −` until the speaker beeps) does nothing —
+userland isn't running far enough to register the button event.
+
+The most common cause of this state in this project is a speaker that
+got the pre-0.8 `deploy.sh` (#144): it dropped only our resolver
+config into `/mnt/nv/shepherd/` without the stock variant files
+alongside, which made `shepherdd` stop supervising BoseApp, WebServer,
+NetManager, and everything else that brings the speaker up at boot.
+v0.8 fixed that path; this section is here for anyone whose speaker
+is already in the broken state.
+
+USB-stick `Update.stu` re-flash doesn't help (the bug is in
+`/mnt/nv/`, not the firmware image), and the USB-cable-to-laptop SSH
+trick doesn't help either (userland is too broken to expose the
+USB-network gadget).
+
+External contributor [@dimmu311](https://github.com/dimmu311) found a
+two-stage button-press sequence in [#143](https://github.com/skarl/bose-soundtouch-resurrect/issues/143)
+that hits the bootloader / early-boot button handler at the right
+moment to trigger a deeper reset than the userland one. Verbatim:
+
+1. AC unplug.
+2. Press and hold `1` + `Vol −`.
+3. AC plug back in.
+4. After a few seconds the LEDs sweep left to right:
+   **orange, blue, white, orange**.
+5. Release the buttons. Be careful at this moment — timing matters.
+6. The LEDs briefly all go off.
+7. The second LED comes up blue. Press and hold `1` + `Vol −` again.
+8. After about 15 seconds the first LED lights blue and all others
+   are off. Release.
+
+The speaker's setup-mode hotspot is now active — re-onboard via the
+SoundTouch app as you would with a new speaker.
+
+This procedure is documented for the **SoundTouch 10** specifically.
+Other models in the line very likely have a working bootloader-level
+reset combo too, but the exact buttons and LED-state cues may
+differ; see [compatibility.md](compatibility.md) for the
+model-supported matrix and current evidence per model. If you
+recover an ST 20 / ST 30 / other model with a different combo,
+please file a report so the next person can find it.
+
 ## Nothing plays after pressing a preset
 
 Symptoms: pressing a preset, `/now_playing` shows source `STANDBY` or

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bose-soundtouch-resurrect",
   "private": true,
   "type": "module",
-  "version": "0.8",
+  "version": "0.8.1",
   "scripts": {
     "test": "node --test admin/test/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bose-soundtouch-resurrect",
   "private": true,
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.8",
   "scripts": {
     "test": "node --test admin/test/*.js"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -67,9 +67,37 @@ say "Looking up speaker MAC for the heartbeat sink"
 # <networkInfo type="SMSC"> blocks each with their own <macAddress>; we use
 # deviceID because it's the one the resolver heartbeat sink path is keyed
 # under.
-MAC=$($SSH root@"$SPEAKER" 'curl -s http://localhost:8090/info' \
+#
+# Brick-class fallback: port 8090 is served by BoseApp, which is exactly the
+# stock daemon that doesn't come up on a speaker whose Shepherd override
+# directory is missing its stock-config symlinks (the failure mode this
+# release recovers from — see docs/adr/0004-shepherd-override-replaces-not-merges.md).
+# On such a speaker SSH still works, so we can recover the same MAC kernel-side
+# from the device tree, which u-boot populates from the SCM module's OTP at
+# boot independent of any userspace daemon.
+#
+# Verified on the maintainer's ST 10 (variant rhino): /proc/device-tree/ocp/
+# macaddr/mac-address is the SCM MAC (matches deviceID), populated by u-boot
+# regardless of BoseApp state. /sys/class/net/*/address on ST 10 only exposes
+# the SMSC + USB MACs (different from deviceID), so the device-tree path is
+# the only kernel-side source that yields the deviceID-matching value.
+MAC=$($SSH root@"$SPEAKER" 'curl -s --max-time 3 http://localhost:8090/info 2>/dev/null' \
       | sed -n 's|.*<info deviceID="\([0-9A-Fa-f]\{12\}\)".*|\1|p')
-[ -n "$MAC" ] || fail "couldn't read speaker MAC from /info (deviceID attribute)"
+if [ -z "$MAC" ]; then
+  echo "  port 8090 returned nothing (likely brick-class state) — falling back to kernel-side MAC lookup"
+  # od outputs " 34 15 13 9a bd 77\n"; strip whitespace and uppercase to
+  # match the deviceID format (12 uppercase hex chars, no separators) so
+  # the heartbeat sink path key below still matches.
+  MAC=$($SSH root@"$SPEAKER" 'od -An -tx1 /proc/device-tree/ocp/macaddr/mac-address 2>/dev/null' \
+        | tr -d ' \n' | tr 'a-f' 'A-F')
+  # Sanity-check the kernel-side value: must be exactly 12 hex chars.
+  case "$MAC" in
+    [0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F]) ;;
+    *) MAC= ;;
+  esac
+fi
+[ -n "$MAC" ] || fail "couldn't read speaker MAC: port 8090 dead AND /proc/device-tree/ocp/macaddr/mac-address unreadable.
+       Try: ssh root@$SPEAKER 'od -An -tx1 /proc/device-tree/ocp/macaddr/mac-address'"
 echo "Speaker MAC: $MAC"
 
 say "Creating directories on the speaker"


### PR DESCRIPTION
## Summary

Three gap-closers that surfaced once v0.8 went out:

1. Users whose speakers were already in the brick state v0.8 fixes still couldn't run the new deploy to recover — it bailed at the port-8090 MAC lookup, which is exactly the port the brick takes out
2. The install guide never documented `admin/deploy.sh`, so new users following it end-to-end got preset playback but no browser UI
3. There was no documented path for the deepest brick state (no SSH, no WiFi, no LAN, standard factory reset won't register)

Closes #152
Closes #153
Closes #154

## What changed

- **`scripts/deploy.sh`** falls back to a kernel-side MAC lookup (`/proc/device-tree/ocp/macaddr/mac-address`) when port 8090 returns nothing. Verified on the maintainer's ST 10: `/sys/class/net/*/address` only exposes the SMSC + USB MACs, not the SCM MAC the firmware uses as `deviceID`. The device-tree path is the only kernel-side source that produces the deviceID-matching value.
- **`docs/installation.md`** leads with the two-layer install model (mandatory resolver + recommended admin SPA), adds Step 1b for `admin/deploy.sh`, updates the Verify and Uninstall sections.
- **`README.md`** Quick-start no longer implies the admin appears automatically.
- **`docs/troubleshooting.md`** has a new top section for speakers that won't boot at all, with [@dimmu311](https://github.com/dimmu311)'s two-stage button-press recovery from #143.

## Test plan

- [x] Cherry-picked from three parallel agent worktrees with disjoint file scopes (no merge conflicts)
- [x] `scripts/deploy.sh` syntax-checked under `sh -n` and `dash -n`; MAC fallback verified against the test speaker (healthy `/info` path: matches `deviceID`; simulated brick by pointing curl at a dead port: kernel-side path yields the same MAC)
- [x] Existing tests still pass (`resolver/test_build.py` + `admin/test/*.js`)
- [x] CHANGELOG entry under `[v0.8.1] - 2026-05-16` covering all three closes
- [x] No private info leaks in the diff (no LAN IPs, MACs, fritz.box hostnames, speaker nicknames)