### PR TITLE
0.8.2 — TUNEIN token synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scripts/deploy.sh` synthesises a TUNEIN token block in `Sources.xml` when one is missing.** Bose's cloud was the only thing that ever issued the anonymous-account TuneIn token persisted at `/mnt/nv/BoseApp-Persistence/1/Sources.xml`; since the 2026-05-06 shutdown a factory reset wipes that token and nothing re-issues it. Without the block, BoseApp omits TUNEIN from `/sources` and `/select source="TUNEIN"` returns HTTP 500 `UNKNOWN_SOURCE_ERROR` — which the admin surfaces as 502 `SELECT_REJECTED` on every preview ("Speaker rejected the stream"). Deploy now generates a fresh UUID on the laptop, base64-wraps it in `{"serial": "…"}`, and splices the resulting `<source>` block into the Speaker's `Sources.xml` immediately before `</sources>` using a busybox-safe read-loop. Idempotent: re-running on a Speaker that already carries a TUNEIN block (synthesised or original) is a strict no-op — byte-for-byte unchanged file, unchanged mtime. Other `<source>` blocks (AMAZON, SPOTIFY, AUX, INTERNET_RADIO, LOCAL_INTERNET_RADIO, RADIOPLAYER) survive byte-for-byte. BoseApp does not validate the token against anything external. Closes #157, completes the fix for #156.
+
+### Added
+
+- **`scripts/verify.sh` /select probe.** New check posts a TUNEIN `ContentItem` to `localhost:8090/select` and asserts HTTP 200 — the BoseApp → registry → source-resolution path that the missing-token bug breaks, which the existing wget-reachability probes never exercised. Snapshots `/now_playing` first and skips with `[SKIP]` when the Speaker is currently streaming anything other than `STANDBY`, so the probe never interrupts active playback.
+- **`scripts/synthesize-tunein-token.sh`** — busybox-safe POSIX-`sh` splice helper called by deploy. Factored out so the four idempotency / splice / fresh-file / no-op branches are unit-tested on the laptop side against fixture `Sources.xml` files in `scripts/test/fixtures/`. Run the tests with `sh scripts/test/test_synthesize_tunein_token.sh`.
+
+### Documentation
+
+- **`docs/troubleshooting.md`** documents the "Speaker rejected the stream / every preview 502s" failure mode at the top, with the one-line `Sources.xml` grep readers can run to self-diagnose and a pointer to the deploy step that fixes it. Closes #157.
+
 ## [v0.8.1] - 2026-05-16
 
 Recovery resilience release. Closes three gaps that surfaced once v0.8 went out: users whose speakers were already in the v0.8-fixed brick state still had no easy way out, the install guide didn't tell new users how to deploy the browser admin, and there was no documented path for a speaker that won't boot at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.2] - 2026-05-17
+
+External-feedback release. Closes a class of bug where speakers that were factory-reset after the 2026-05-06 cloud shutdown can't play TuneIn at all — every preview toasts "Speaker rejected the stream" because the anonymous-account TuneIn token Bose's cloud used to issue at original onboarding has been wiped along with the rest of `/mnt/nv`, and nothing re-issues it now that the cloud is dark. Reproduced end-to-end on the maintainer's test speaker after stripping its pre-shutdown token; reported in the wild by [@dimmu311](https://github.com/dimmu311) in [#156](https://github.com/skarl/bose-soundtouch-resurrect/issues/156) and independently confirmed by [@qaroq](https://github.com/qaroq) in a comment on the same issue. The maintainer's speaker still carries its original pre-shutdown token, which is why this was never reproduced in-house until now.
+
 ### Fixed
 
 - **`scripts/deploy.sh` synthesises a TUNEIN token block in `Sources.xml` when one is missing.** Bose's cloud was the only thing that ever issued the anonymous-account TuneIn token persisted at `/mnt/nv/BoseApp-Persistence/1/Sources.xml`; since the 2026-05-06 shutdown a factory reset wipes that token and nothing re-issues it. Without the block, BoseApp omits TUNEIN from `/sources` and `/select source="TUNEIN"` returns HTTP 500 `UNKNOWN_SOURCE_ERROR` — which the admin surfaces as 502 `SELECT_REJECTED` on every preview ("Speaker rejected the stream"). Deploy now generates a fresh UUID on the laptop, base64-wraps it in `{"serial": "…"}`, and splices the resulting `<source>` block into the Speaker's `Sources.xml` immediately before `</sources>` using a busybox-safe read-loop. Idempotent: re-running on a Speaker that already carries a TUNEIN block (synthesised or original) is a strict no-op — byte-for-byte unchanged file, unchanged mtime. Other `<source>` blocks (AMAZON, SPOTIFY, AUX, INTERNET_RADIO, LOCAL_INTERNET_RADIO, RADIOPLAYER) survive byte-for-byte. BoseApp does not validate the token against anything external. Closes #157, completes the fix for #156.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,6 +60,40 @@ matrix. If you recover an ST 20, ST 30, or other model with a
 different combination, please open an issue so the next person can
 find it.
 
+## "Speaker rejected the stream" / every preview 502s
+
+Symptoms: tapping any station in the admin SPA toasts "Speaker rejected
+the stream"; the admin's `/preview` CGI returns 502 `SELECT_REJECTED`;
+`/sources` on the Speaker omits `TUNEIN` entirely;
+`/select source="TUNEIN"` returns
+`HTTP 500 <error value="1005" name="UNKNOWN_SOURCE_ERROR">`.
+
+Root cause: BoseApp persists per-source authentication tokens in
+`/mnt/nv/BoseApp-Persistence/1/Sources.xml`, and Bose's cloud was the
+only thing that ever issued the anonymous-account TuneIn token. Since
+the 2026-05-06 shutdown a factory reset wipes the token and nothing
+re-issues it. Without a TUNEIN `<source>` block in that file, BoseApp
+refuses to register TUNEIN as a known source at boot — every downstream
+selection then fails closed.
+
+**Self-diagnose** in one line:
+
+```bash
+ssh root@$SPEAKER_IP 'grep -c "<sourceKey type=\"TUNEIN\"" /mnt/nv/BoseApp-Persistence/1/Sources.xml'
+```
+
+Expect `1`. `0` (or `grep: No such file`) confirms this failure mode.
+
+**Fix:** re-run `scripts/deploy.sh`. As of v0.8.2 the deploy synthesises
+a TUNEIN token block on the Speaker iff one is missing — idempotent, so
+running it against a Speaker that still carries a real pre-shutdown
+token is a strict no-op. BoseApp does not validate the token against
+anything external; a synthetic UUID is accepted on the next boot.
+
+Only TUNEIN is synthesised. RADIOPLAYER's upstream is dead at the
+network layer and `LOCAL_INTERNET_RADIO` has no admin surface — re-
+issuing those would be ceremony with no user-visible value.
+
 ## Nothing plays after pressing a preset
 
 Symptoms: pressing a preset, `/now_playing` shows source `STANDBY` or

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bose-soundtouch-resurrect",
   "private": true,
   "type": "module",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "scripts": {
     "test": "node --test admin/test/*.js"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -140,6 +140,47 @@ say "Pushing shepherd-resolver.xml (auto-start at boot)"
 $SCP "$ROOT/resolver/shepherd-resolver.xml" \
      root@"$SPEAKER":/mnt/nv/shepherd/Shepherd-resolver.xml
 
+say "Ensuring a TUNEIN token block in Sources.xml"
+# Bose's cloud was the only thing that ever issued the anonymous-account
+# TuneIn token persisted at /mnt/nv/BoseApp-Persistence/1/Sources.xml.
+# Without that block, BoseApp refuses to register TUNEIN as a known
+# source: /sources omits it entirely and /select source="TUNEIN" returns
+# HTTP 500 UNKNOWN_SOURCE_ERROR, which the admin surfaces as
+# 502 SELECT_REJECTED on every preview. Since the 2026-05-06 shutdown a
+# factory reset wipes the token and nothing re-issues it.
+#
+# Idempotent: re-running deploy on a Speaker that already has a TUNEIN
+# block (synthesised or original) is a strict no-op — byte-for-byte
+# identical Sources.xml, unchanged mtime. The synthesis script enforces
+# that contract; see scripts/synthesize-tunein-token.sh + the unit
+# tests in scripts/test/. Issue #157.
+#
+# BoseApp does not validate this token against anything external — a
+# fresh UUID base64-wrapped in {"serial":"…"} is accepted on next boot.
+TUNEIN_UUID=$(uuidgen | tr 'A-Z' 'a-z')
+case "$TUNEIN_UUID" in
+    [0-9a-f]*-*-*-*-*) ;;
+    *) fail "uuidgen produced unexpected output: $TUNEIN_UUID" ;;
+esac
+# base64-encode {"serial": "<uuid>"} on the laptop side. macOS and Linux
+# both ship `base64`; behaviour for short inputs is identical, no line
+# wrapping concerns at this length. Mirrors the wire shape Bose emitted
+# pre-shutdown (verified on the maintainer's pre-shutdown test Speaker).
+TUNEIN_SECRET=$(printf '{"serial": "%s"}' "$TUNEIN_UUID" | base64 | tr -d '\n')
+$SSH root@"$SPEAKER" "cat > /tmp/tunein-block.xml" <<EOF
+    <source secret="$TUNEIN_SECRET" secretType="token">
+        <sourceKey type="TUNEIN" account="" />
+    </source>
+EOF
+$SCP "$ROOT/scripts/synthesize-tunein-token.sh" \
+     root@"$SPEAKER":/tmp/synthesize-tunein-token.sh
+$SSH root@"$SPEAKER" '
+  sh /tmp/synthesize-tunein-token.sh \
+     /mnt/nv/BoseApp-Persistence/1/Sources.xml \
+     /tmp/tunein-block.xml \
+  && rm -f /tmp/synthesize-tunein-token.sh /tmp/tunein-block.xml
+' || fail "TUNEIN-token synthesis failed; see speaker output above."
+
 say "Writing OverrideSdkPrivateCfg.xml (point speaker at itself)"
 $SSH root@"$SPEAKER" "cat > /mnt/nv/OverrideSdkPrivateCfg.xml" <<'EOF'
 <?xml version="1.0" encoding="utf-8"?>

--- a/scripts/synthesize-tunein-token.sh
+++ b/scripts/synthesize-tunein-token.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# synthesize-tunein-token — idempotently ensure a TUNEIN <source> block
+# exists in a SoundTouch Speaker's BoseApp Sources.xml.
+#
+# Background:
+#   Bose's cloud was the only thing that ever issued the anonymous-account
+#   TuneIn token persisted at /mnt/nv/BoseApp-Persistence/1/Sources.xml.
+#   Without that token block, BoseApp refuses to register TUNEIN as a known
+#   source and /select source="TUNEIN" returns HTTP 500 UNKNOWN_SOURCE_ERROR.
+#   Since the 2026-05-06 shutdown a factory reset wipes the token and
+#   nothing re-issues it; we synthesise one. BoseApp does not validate it
+#   against anything external. See issue #157 / context #156.
+#
+# Usage:
+#   synthesize-tunein-token.sh <sources-xml-path> <block-file>
+#
+# Behaviour:
+#   - If <sources-xml-path> already contains a `<sourceKey type="TUNEIN"`
+#     line, exits 0 with no changes. mtime is preserved.
+#   - If the file exists but lacks the TUNEIN block, splices the contents
+#     of <block-file> in immediately before the closing </sources> tag,
+#     atomically (tmp file + mv). All other <source> blocks survive
+#     byte-for-byte.
+#   - If the file does not exist, writes a minimal valid Sources.xml
+#     containing the XML declaration, <sources> wrapper, and the block.
+#     Parent directories are created.
+#
+# Speaker-side constraints (also tested on the laptop, so the constraints
+# bind here too): busybox sh — no bashisms, no GNU sed -i, no awk -v, no
+# python3. Only sh / sed / grep / cat / mv / mkdir / printf / dirname.
+
+set -eu
+
+SRC="${1:?usage: $0 <sources-xml-path> <block-file>}"
+BLOCK_FILE="${2:?usage: $0 <sources-xml-path> <block-file>}"
+
+[ -f "$BLOCK_FILE" ] || { printf 'error: block file missing: %s\n' "$BLOCK_FILE" >&2; exit 1; }
+
+# Case 1: file already has a TUNEIN block — leave it strictly alone.
+# Detection mirrors the issue spec exactly so the no-op branch is
+# byte-for-byte conservative.
+if [ -f "$SRC" ] && grep -q '<sourceKey type="TUNEIN"' "$SRC"; then
+    exit 0
+fi
+
+# Case 2: file is absent — write a minimal Sources.xml containing just
+# the TUNEIN block. Parent dirs are created on demand because the
+# Speaker may have a fresh /mnt/nv with no BoseApp-Persistence tree yet.
+if [ ! -f "$SRC" ]; then
+    mkdir -p "$(dirname "$SRC")"
+    TMP="$SRC.new"
+    {
+        printf '<?xml version="1.0" encoding="UTF-8" ?>\n'
+        printf '<sources>\n'
+        cat "$BLOCK_FILE"
+        printf '</sources>\n'
+    } > "$TMP"
+    mv "$TMP" "$SRC"
+    exit 0
+fi
+
+# Case 3: file exists but lacks TUNEIN — splice the block in immediately
+# before the closing </sources> tag, leaving every other <source> block
+# byte-for-byte intact. Read-loop idiom is busybox-safe and obviously
+# correct on inspection; busybox sed insert semantics for multi-line
+# blocks are easy to get subtly wrong.
+TMP="$SRC.new"
+: > "$TMP"
+spliced=0
+while IFS= read -r line; do
+    case "$line" in
+        *"</sources>"*)
+            if [ "$spliced" -eq 0 ]; then
+                cat "$BLOCK_FILE" >> "$TMP"
+                spliced=1
+            fi
+            ;;
+    esac
+    printf '%s\n' "$line" >> "$TMP"
+done < "$SRC"
+
+# Defensive: if the input had no </sources> tag at all, append the block
+# plus a closing tag so we produce something BoseApp can parse rather
+# than silently corrupting the file. (Real Sources.xml always has the
+# closing tag; this guards the pathological case.)
+if [ "$spliced" -eq 0 ]; then
+    cat "$BLOCK_FILE" >> "$TMP"
+    printf '</sources>\n' >> "$TMP"
+fi
+
+mv "$TMP" "$SRC"

--- a/scripts/test/fixtures/sources-minimal-stub.xml
+++ b/scripts/test/fixtures/sources-minimal-stub.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sources>
+</sources>

--- a/scripts/test/fixtures/sources-with-existing-tunein.xml
+++ b/scripts/test/fixtures/sources-with-existing-tunein.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sources>
+    <source displayName="AUX IN" secret="" secretType="">
+        <sourceKey type="AUX" account="AUX" />
+    </source>
+    <source secret="eyJzZXJpYWwiOiAiYTIwMzNmY2ItMmJkYy00NmZlLTllOTAtNTJiYmRmNmI5NWVlIn0=" secretType="token">
+        <sourceKey type="TUNEIN" account="" />
+    </source>
+</sources>

--- a/scripts/test/fixtures/sources-with-user-tokens-no-tunein.xml
+++ b/scripts/test/fixtures/sources-with-user-tokens-no-tunein.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sources>
+    <source secret='{&quot;AmazonSecret&quot;:{&quot;refresh_token&quot;:&quot;FAKE_AMAZON_TOKEN_FOR_TEST_FIXTURE_DO_NOT_USE&quot;,&quot;site_id&quot;:&quot;0000000000&quot;}}' secretType="token">
+        <sourceKey type="AMAZON" account="test@example.invalid" />
+    </source>
+    <source displayName="AUX IN" secret="" secretType="">
+        <sourceKey type="AUX" account="AUX" />
+    </source>
+    <source secret="" secretType="token">
+        <sourceKey type="INTERNET_RADIO" account="" />
+    </source>
+    <source secret="eyJzZXJpYWwiOiAiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIn0=" secretType="token">
+        <sourceKey type="LOCAL_INTERNET_RADIO" account="" />
+    </source>
+    <source secret="00000000-0000-0000-0000-000000000000" secretType="token">
+        <sourceKey type="RADIOPLAYER" account="" />
+    </source>
+    <source displayName="test@example.invalid" secret="FAKE_SPOTIFY_TOKEN_FOR_TEST_FIXTURE" secretType="token_version_3">
+        <sourceKey type="SPOTIFY" account="testaccount" />
+    </source>
+</sources>

--- a/scripts/test/test_synthesize_tunein_token.sh
+++ b/scripts/test/test_synthesize_tunein_token.sh
@@ -1,0 +1,220 @@
+#!/bin/sh
+#
+# test_synthesize_tunein_token — unit tests for
+# scripts/synthesize-tunein-token.sh.
+#
+# Exercises the four fixture cases the issue spec calls out:
+#   1. Sources.xml has AMAZON + SPOTIFY blocks but no TUNEIN → splice;
+#      pre-existing blocks must survive byte-for-byte.
+#   2. Sources.xml is the minimal stub (declaration + empty <sources>) →
+#      splice; the result must contain the new TUNEIN block.
+#   3. Sources.xml does not exist at all → write a fresh minimal file
+#      with just the TUNEIN block.
+#   4. Sources.xml already has a TUNEIN row → no-op, byte-identical
+#      output and unchanged mtime.
+#
+# Run with: sh scripts/test/test_synthesize_tunein_token.sh
+# Exits non-zero on any failure.
+
+set -u
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$THIS_DIR/../.." && pwd)
+SCRIPT="$REPO/scripts/synthesize-tunein-token.sh"
+FIXTURES="$THIS_DIR/fixtures"
+
+[ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+WORK=$(mktemp -d 2>/dev/null || echo "/tmp/test_synth_tunein.$$")
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+ok=0
+fail=0
+
+note_ok()   { printf '  [ OK ] %s\n' "$1"; ok=$((ok + 1)); }
+note_fail() { printf '  [FAIL] %s\n' "$1"; fail=$((fail + 1)); }
+
+# A representative TUNEIN block, identical in shape to what deploy.sh
+# builds at runtime. The UUID is a frozen test value — anything that
+# parses as a serial is fine for BoseApp; we just need to assert the
+# script splices what we hand it.
+BLOCK="$WORK/tunein-block.xml"
+cat > "$BLOCK" <<'EOF'
+    <source secret="eyJzZXJpYWwiOiAiZGVhZGJlZWYtYmVlZi1iZWVmLWJlZWYtZGVhZGJlZWZkZWFkIn0=" secretType="token">
+        <sourceKey type="TUNEIN" account="" />
+    </source>
+EOF
+
+# ---------------------------------------------------------------------
+# Case 1: existing AMAZON / SPOTIFY survive; TUNEIN block is spliced in.
+# ---------------------------------------------------------------------
+printf '\n--- Case 1: existing user-account tokens + no TUNEIN ---\n'
+
+CASE1="$WORK/case1-sources.xml"
+cp "$FIXTURES/sources-with-user-tokens-no-tunein.xml" "$CASE1"
+
+if sh "$SCRIPT" "$CASE1" "$BLOCK"; then
+    note_ok "synthesis returns 0"
+else
+    note_fail "synthesis returned non-zero"
+fi
+
+if grep -q '<sourceKey type="TUNEIN"' "$CASE1"; then
+    note_ok "TUNEIN block present after splice"
+else
+    note_fail "TUNEIN block missing after splice"
+fi
+
+if grep -q '<sourceKey type="AMAZON"' "$CASE1" \
+   && grep -q '<sourceKey type="SPOTIFY"' "$CASE1" \
+   && grep -q '<sourceKey type="AUX"' "$CASE1" \
+   && grep -q '<sourceKey type="INTERNET_RADIO"' "$CASE1" \
+   && grep -q '<sourceKey type="LOCAL_INTERNET_RADIO"' "$CASE1" \
+   && grep -q '<sourceKey type="RADIOPLAYER"' "$CASE1"; then
+    note_ok "all pre-existing sourceKey blocks survive"
+else
+    note_fail "a pre-existing sourceKey block was lost"
+fi
+
+# Stronger: every line of the original fixture must still be present in
+# the same order. Compare via grep -F line-by-line; the splice only adds
+# lines, never removes or reorders them.
+case1_loss=0
+while IFS= read -r line; do
+    case "$line" in
+        ''|'</sources>'*) continue ;;
+    esac
+    if ! grep -qF -- "$line" "$CASE1"; then
+        printf '    missing original line: %s\n' "$line"
+        case1_loss=1
+    fi
+done < "$FIXTURES/sources-with-user-tokens-no-tunein.xml"
+if [ "$case1_loss" -eq 0 ]; then
+    note_ok "every original line of the fixture is still present"
+else
+    note_fail "at least one original line was lost"
+fi
+
+# The TUNEIN block must land before the closing </sources> tag, not
+# after — otherwise BoseApp won't parse it as a child of <sources>.
+if grep -n '<sourceKey type="TUNEIN"\|</sources>' "$CASE1" \
+   | sort -n \
+   | head -1 \
+   | grep -q TUNEIN; then
+    note_ok "TUNEIN block is spliced before </sources>"
+else
+    note_fail "TUNEIN block landed after </sources>"
+fi
+
+# ---------------------------------------------------------------------
+# Case 2: minimal stub (declaration + empty <sources>) → splice.
+# ---------------------------------------------------------------------
+printf '\n--- Case 2: minimal stub Sources.xml ---\n'
+
+CASE2="$WORK/case2-sources.xml"
+cp "$FIXTURES/sources-minimal-stub.xml" "$CASE2"
+
+if sh "$SCRIPT" "$CASE2" "$BLOCK"; then
+    note_ok "synthesis returns 0"
+else
+    note_fail "synthesis returned non-zero"
+fi
+
+if grep -q '<sourceKey type="TUNEIN"' "$CASE2"; then
+    note_ok "TUNEIN block present in stub after splice"
+else
+    note_fail "TUNEIN block missing in stub after splice"
+fi
+
+if grep -q '^<?xml ' "$CASE2" && grep -q '^<sources>' "$CASE2" && grep -q '^</sources>' "$CASE2"; then
+    note_ok "XML declaration + <sources> wrapper preserved"
+else
+    note_fail "XML declaration or <sources> wrapper missing"
+fi
+
+# ---------------------------------------------------------------------
+# Case 3: file does not exist at all → fresh minimal file is created.
+# ---------------------------------------------------------------------
+printf '\n--- Case 3: Sources.xml does not exist ---\n'
+
+CASE3_DIR="$WORK/case3-fresh-tree/BoseApp-Persistence/1"
+CASE3="$CASE3_DIR/Sources.xml"
+# Intentionally do NOT mkdir -p — the synthesis script is responsible
+# for creating parent directories when the speaker has a fresh NV.
+
+if sh "$SCRIPT" "$CASE3" "$BLOCK"; then
+    note_ok "synthesis returns 0"
+else
+    note_fail "synthesis returned non-zero"
+fi
+
+if [ -f "$CASE3" ]; then
+    note_ok "fresh Sources.xml was created"
+else
+    note_fail "Sources.xml was not created"
+fi
+
+if [ -f "$CASE3" ] && grep -q '<sourceKey type="TUNEIN"' "$CASE3"; then
+    note_ok "fresh file contains the TUNEIN block"
+else
+    note_fail "fresh file does not contain the TUNEIN block"
+fi
+
+if [ -f "$CASE3" ] \
+    && grep -q '<?xml ' "$CASE3" \
+    && grep -q '<sources>' "$CASE3" \
+    && grep -q '</sources>' "$CASE3"; then
+    note_ok "fresh file is well-formed (declaration + wrapper)"
+else
+    note_fail "fresh file is malformed"
+fi
+
+# ---------------------------------------------------------------------
+# Case 4: file already has TUNEIN → no-op, byte-identical, mtime stable.
+# ---------------------------------------------------------------------
+printf '\n--- Case 4: Sources.xml already has TUNEIN (idempotency) ---\n'
+
+CASE4="$WORK/case4-sources.xml"
+cp "$FIXTURES/sources-with-existing-tunein.xml" "$CASE4"
+
+# Capture pre-state: byte content + mtime. Backdate the mtime so we
+# can prove the script doesn't touch it even if our timer's resolution
+# is coarse. `touch -t` is POSIX.
+touch -t 202001011200.00 "$CASE4"
+BEFORE_SHA=$(shasum "$CASE4" 2>/dev/null | awk '{print $1}')
+BEFORE_MTIME=$(ls -la "$CASE4" | awk '{print $6, $7, $8}')
+
+if sh "$SCRIPT" "$CASE4" "$BLOCK"; then
+    note_ok "synthesis returns 0"
+else
+    note_fail "synthesis returned non-zero"
+fi
+
+AFTER_SHA=$(shasum "$CASE4" 2>/dev/null | awk '{print $1}')
+AFTER_MTIME=$(ls -la "$CASE4" | awk '{print $6, $7, $8}')
+
+if [ "$BEFORE_SHA" = "$AFTER_SHA" ]; then
+    note_ok "byte-identical content after idempotent re-run"
+else
+    note_fail "content changed (before=$BEFORE_SHA after=$AFTER_SHA)"
+fi
+
+if [ "$BEFORE_MTIME" = "$AFTER_MTIME" ]; then
+    note_ok "mtime unchanged after idempotent re-run"
+else
+    note_fail "mtime changed (before=$BEFORE_MTIME after=$AFTER_MTIME)"
+fi
+
+# Sanity check: there's still only ONE TUNEIN block — we didn't append
+# a duplicate even though the splice path was a no-op.
+n_tunein=$(grep -c '<sourceKey type="TUNEIN"' "$CASE4" || true)
+if [ "$n_tunein" = "1" ]; then
+    note_ok "exactly one TUNEIN block after re-run"
+else
+    note_fail "expected 1 TUNEIN block, found $n_tunein"
+fi
+
+# ---------------------------------------------------------------------
+printf '\n--- Summary: %d ok, %d failed ---\n' "$ok" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -78,6 +78,36 @@ check "port 8090 /info returns XML" \
 check "port 8090 /now_playing returns XML" \
     $SSH root@"$SPEAKER" 'curl -s http://localhost:8090/now_playing | grep -q "<nowPlaying"'
 
+printf '\n=== TUNEIN source registered (exercises Sources.xml token) ===\n'
+# When BoseApp lacks a TUNEIN token block in
+# /mnt/nv/BoseApp-Persistence/1/Sources.xml, /sources omits TUNEIN
+# entirely and /select source="TUNEIN" returns HTTP 500
+# UNKNOWN_SOURCE_ERROR — the failure mode the deploy step's synthesis
+# now defends against. See issue #157 / docs/troubleshooting.md.
+#
+# We POST a no-op TUNEIN ContentItem (the canonical "TuneIn" root, the
+# same shape the admin shell sends on a cold open). A healthy Speaker
+# returns HTTP 200; an unregistered TUNEIN source returns HTTP 500
+# with <error value="1005" name="UNKNOWN_SOURCE_ERROR">.
+#
+# Never interrupt active playback: snapshot /now_playing first and skip
+# if the Speaker is streaming anything other than STANDBY. The probe is
+# diagnostic, not part of the happy-path install gate.
+np_xml=$($SSH root@"$SPEAKER" 'curl -s --max-time 5 http://localhost:8090/now_playing' 2>/dev/null || true)
+np_source=$(printf '%s' "$np_xml" | sed -n 's|.*<nowPlaying[^>]*source="\([^"]*\)".*|\1|p' | head -1)
+if [ -n "$np_source" ] && [ "$np_source" != "STANDBY" ]; then
+    printf '  [SKIP] Speaker is currently streaming (source=%s); not interrupting playback\n' "$np_source"
+else
+    check "POST /select with TUNEIN ContentItem returns HTTP 200" \
+        sh -c 'code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/xml" \
+            --max-time 10 \
+            -d "<ContentItem source=\"TUNEIN\" type=\"rdir\" location=\"/\" sourceAccount=\"\" isPresetable=\"true\"><itemName>TuneIn</itemName></ContentItem>" \
+            "http://'"$SPEAKER"':8090/select"); \
+            [ "$code" = "200" ]'
+fi
+
 printf '\n=== Admin SPA (skipped if not deployed) ===\n'
 # Probe via the speaker (matches the existing wget/curl-through-ssh
 # pattern). The admin is optional: skip cleanly if index.html isn't


### PR DESCRIPTION
## Summary

- `scripts/deploy.sh` synthesises a TUNEIN token block in `/mnt/nv/BoseApp-Persistence/1/Sources.xml` when one is missing. Idempotent — re-running on a Speaker with an existing block (synthesised or original) is a strict no-op (byte-for-byte unchanged file, unchanged mtime). Closes the failure mode where factory-resetting after the 2026-05-06 cloud shutdown leaves a Speaker unable to play TuneIn ("Speaker rejected the stream" toast / 502 `SELECT_REJECTED` on every preview).
- `scripts/verify.sh` gains a `/select` probe that exercises the BoseApp → registry → source-resolution path this bug breaks (the existing wget-reachability probes never did). Skips with `[SKIP]` if the Speaker is currently streaming, so it never interrupts active playback.
- New busybox-safe splice helper `scripts/synthesize-tunein-token.sh` plus laptop-side fixture-driven shell unit tests at `scripts/test/test_synthesize_tunein_token.sh` (16 ok, 0 failed across all four spec cases).
- `docs/troubleshooting.md` documents the failure mode + a one-line self-diagnose grep.

Reported in #156 by @dimmu311, independently confirmed by @qaroq in a comment on the same issue. #156 stays open until reporters confirm the fix in-the-wild.

Closes #157

## Test plan

- [x] Shell unit tests: 16 ok, 0 failed (all four cases: existing user-account tokens + no TUNEIN / minimal stub / file absent / idempotent re-run)
- [x] `npm test`: 1057 / 1057 pass, no regressions
- [x] `shellcheck --severity=warning` clean on all touched scripts
- [x] End-to-end integration on the maintainer's test Speaker: stripped its TUNEIN block to mimic the post-reset broken state, ran new `scripts/deploy.sh`, all 31 verify probes green including the new `/select TUNEIN` probe — fresh synthesised UUID in Sources.xml, BoseApp accepts it, `/select source="TUNEIN"` returns HTTP 200
- [x] Idempotency confirmed: second deploy run produced byte-identical Sources.xml (same sha1, same mtime); no collateral damage to AMAZON / SPOTIFY / other user-account `<source>` blocks
- [x] Speaker restored to its original pre-shutdown token after testing